### PR TITLE
perf(v2): Alpha 42.3 C 原生卸载残留扫描预览

### DIFF
--- a/.github/workflows/v2-alpha42-3-native-corpse-scanner.yml
+++ b/.github/workflows/v2-alpha42-3-native-corpse-scanner.yml
@@ -1,0 +1,109 @@
+name: BaiZe v2 Alpha 42.3 Native Corpse Scanner
+
+on:
+  push:
+    branches: [v2-alpha42-3-native-corpse-scanner]
+    paths:
+      - 'v2/**'
+      - '.github/workflows/v2-alpha42-3-native-corpse-scanner.yml'
+  pull_request:
+    branches: [v2-alpha42-2-compose-aux-ui]
+    paths:
+      - 'v2/**'
+      - '.github/workflows/v2-alpha42-3-native-corpse-scanner.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v2-alpha42-3-native-corpse-scanner
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Validate shell and native source
+        run: |
+          sh -n cleaner.sh notify.sh service.sh
+          sh -n v2/module/action.sh v2/module/customize.sh v2/module/service.sh v2/module/uninstall.sh
+          sh -n v2/module/cleaner.sh v2/scripts/build-native.sh v2/scripts/package-module.sh
+          python3 v2/scripts/validate-rules.py
+          grep -q 'version=v2.0.0-alpha42.3' v2/module/module.prop
+          grep -q 'versionCode=22230' v2/module/module.prop
+          grep -q 'scan-corpses' v2/native/baize_engine.c
+          grep -q 'cleaner.sh.compat' v2/scripts/package-module.sh
+
+      - name: Test native corpse scanner fixture
+        run: |
+          cc -std=c11 -O2 -Wall -Wextra -Werror -Wformat=2 -Wshadow -Wconversion \
+            v2/native/baize_engine.c -o /tmp/baize_engine_host
+          TEST=/tmp/baize-native-test
+          rm -rf "$TEST"
+          mkdir -p "$TEST/media/0/Android/data/com.example.installed/cache"
+          mkdir -p "$TEST/media/0/Android/data/com.old.app/cache/deep"
+          mkdir -p "$TEST/media/0/Android/obb/com.empty.game"
+          mkdir -p "$TEST/media/0/Android/media/com.protected.app/files"
+          mkdir -p "$TEST/state" "$TEST/installed"
+          printf 'abc' > "$TEST/media/0/Android/data/com.old.app/cache/a.bin"
+          printf '12345' > "$TEST/media/0/Android/data/com.old.app/cache/deep/b.bin"
+          printf 'secret' > "$TEST/media/0/Android/media/com.protected.app/files/x"
+          printf 'com.example.installed\n' > "$TEST/installed/0.txt"
+          cp config/default.conf "$TEST/state/config.conf"
+          printf '%s\n' "$TEST/media/0/Android/media/com.protected.app" > "$TEST/state/whitelist.conf"
+          BAIZE_NATIVE_TEST=1 \
+          BAIZE_STATE_DIR="$TEST/state" \
+          BAIZE_MEDIA_ROOT="$TEST/media" \
+          BAIZE_INSTALLED_ROOT="$TEST/installed" \
+          BAIZE_NATIVE_ENGINE=/tmp/baize_engine_host \
+            sh v2/module/cleaner.sh corpse-scan ci
+          grep -q '^engine=native-c-arm64$' "$TEST/state/latest.env"
+          grep -q '^files=3$' "$TEST/state/latest.env"
+          grep -q '/com.old.app$' "$TEST/state/corpse_scan.targets"
+          grep -q '/com.empty.game$' "$TEST/state/corpse_scan.targets"
+          ! grep -q '/com.example.installed$' "$TEST/state/corpse_scan.targets"
+          ! grep -q '/com.protected.app$' "$TEST/state/corpse_scan.targets"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build arm64 native engine
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build native App
+        working-directory: v2
+        run: gradle --no-daemon :app:assembleDebug
+
+      - name: Package and verify module
+        working-directory: v2
+        run: |
+          sh scripts/package-module.sh
+          ZIP=dist/BaiZe-v2-Alpha42.3-Native-Corpse-Scanner-Module.zip
+          unzip -tq "$ZIP"
+          unzip -p "$ZIP" module.prop | grep -q 'version=v2.0.0-alpha42.3'
+          unzip -l "$ZIP" | grep -q 'app/baize.apk'
+          unzip -l "$ZIP" | grep -q 'cleaner.sh.compat'
+          unzip -l "$ZIP" | grep -q 'bin/arm64-v8a/baize_engine'
+          unzip -p "$ZIP" bin/arm64-v8a/baize_engine > /tmp/baize_engine_android
+          file /tmp/baize_engine_android | grep -q 'ARM aarch64'
+          sha256sum "$ZIP"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2-Alpha42.3-Native-Corpse-Scanner
+          path: v2/dist/BaiZe-v2-Alpha42.3-Native-Corpse-Scanner-Module.zip

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22220
-        versionName = "2.0.0-alpha42.2"
+        versionCode = 22230
+        versionName = "2.0.0-alpha42.3"
     }
 
     buildFeatures {

--- a/v2/module/cleaner.sh
+++ b/v2/module/cleaner.sh
@@ -1,0 +1,250 @@
+#!/system/bin/sh
+
+MODDIR=${0%/*}
+COMPAT_ENGINE="$MODDIR/cleaner.sh.compat"
+REQUEST_MODE=${1:-scan}
+TRIGGER=${2:-manual}
+STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
+MEDIA_ROOT=${BAIZE_MEDIA_ROOT:-/data/media}
+CONFIG="$STATE_DIR/config.conf"
+WHITELIST="$STATE_DIR/whitelist.conf"
+REPORT_DIR="$STATE_DIR/reports"
+LOG_DIR="$STATE_DIR/logs"
+LOCK_DIR="$STATE_DIR/run.lock"
+RUNNING_FILE="$STATE_DIR/running.env"
+STOP_FILE="$STATE_DIR/stop"
+CORPSE_SCAN_STATE="$STATE_DIR/corpse_scan.env"
+CORPSE_SCAN_TARGETS="$STATE_DIR/corpse_scan.targets"
+HISTORY_FILE="$STATE_DIR/history.tsv"
+NATIVE_ENGINE=${BAIZE_NATIVE_ENGINE:-$MODDIR/bin/arm64-v8a/baize_engine}
+
+fallback() {
+  [ -f "$COMPAT_ENGINE" ] || { echo "兼容清理引擎缺失" >&2; exit 5; }
+  exec /system/bin/sh "$COMPAT_ENGINE" "$@"
+}
+
+[ "$REQUEST_MODE" = "corpse-scan" ] || fallback "$@"
+[ -x "$NATIVE_ENGINE" ] || fallback "$@"
+case "$(uname -m 2>/dev/null)" in
+  aarch64|arm64) ;;
+  x86_64) [ -n "${BAIZE_NATIVE_TEST:-}" ] || fallback "$@" ;;
+  *) fallback "$@" ;;
+esac
+
+mkdir -p "$STATE_DIR" "$REPORT_DIR" "$LOG_DIR"
+[ -f "$CONFIG" ] || cp -f "$MODDIR/config/default.conf" "$CONFIG"
+[ -f "$WHITELIST" ] || cp -f "$MODDIR/config/whitelist.conf" "$WHITELIST"
+
+native_enabled=$(sed -n 's/^native_scanner_enabled=//p' "$CONFIG" 2>/dev/null | tail -n 1)
+[ "$native_enabled" = "0" ] && fallback "$@"
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  old_pid=$(sed -n '1p' "$LOCK_DIR/pid" 2>/dev/null)
+  case "$old_pid" in ''|*[!0-9]*) old_pid=0 ;; esac
+  if [ "$old_pid" -gt 1 ] && kill -0 "$old_pid" 2>/dev/null; then
+    echo "已有扫描或清理任务正在运行"
+    exit 3
+  fi
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+  mkdir "$LOCK_DIR" 2>/dev/null || { echo "无法恢复任务锁"; exit 4; }
+fi
+printf '%s\n' "$$" >"$LOCK_DIR/pid"
+TMP_DIR="$LOCK_DIR/tmp"
+mkdir -p "$TMP_DIR"
+
+cleanup_lock() {
+  rm -f "$RUNNING_FILE" 2>/dev/null
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+}
+trap cleanup_lock EXIT INT TERM
+rm -f "$STOP_FILE"
+
+START_EPOCH=$(date +%s)
+STAMP=$(date '+%Y-%m-%d_%H-%M-%S')
+REPORT_FILE="$REPORT_DIR/$STAMP-corpse-scan.tsv"
+TARGETS_TMP="$TMP_DIR/corpse-scan.targets"
+SUMMARY_FILE="$TMP_DIR/native-summary.env"
+LOG_FILE="$LOG_DIR/$STAMP-corpse-scan.log"
+INSTALLED_ROOT=${BAIZE_INSTALLED_ROOT:-$TMP_DIR/installed}
+mkdir -p "$INSTALLED_ROOT"
+printf 'package\tcategory\tfiles\tbytes\n' >"$REPORT_DIR/apps-latest.tsv"
+printf 'package\tcategory\tfiles\tbytes\terrors\tsample_path\n' >"$REPORT_DIR/app-items-latest.tsv"
+
+set_phase() {
+  phase=$1
+  current=${2:-0}
+  total=${3:-0}
+  path=${4:-}
+  tmp="$RUNNING_FILE.tmp.$$"
+  {
+    echo "mode=corpse-scan"
+    echo "phase=$phase"
+    echo "started=$START_EPOCH"
+    echo "progress_current=$current"
+    echo "progress_total=$total"
+    printf 'current_path=%s\n' "$path" | tr '\r\n' '  '
+    echo "engine=native-c-arm64"
+  } >"$tmp"
+  mv -f "$tmp" "$RUNNING_FILE"
+}
+
+set_phase "原生引擎读取已安装应用"
+
+if [ -z "${BAIZE_INSTALLED_ROOT:-}" ]; then
+  found_users=0
+  for userdir in "$MEDIA_ROOT"/[0-9]*; do
+    [ -d "$userdir" ] || continue
+    user=${userdir##*/}
+    case "$user" in ''|*[!0-9]*) continue ;; esac
+    packages="$INSTALLED_ROOT/$user.txt"
+    : >"$packages"
+    if command -v cmd >/dev/null 2>&1; then
+      cmd package list packages --user "$user" 2>/dev/null | sed 's/^package://' | sort -u >"$packages"
+    fi
+    if [ ! -s "$packages" ] && command -v pm >/dev/null 2>&1; then
+      pm list packages --user "$user" 2>/dev/null | sed 's/^package://' | sort -u >"$packages"
+    fi
+    if [ ! -s "$packages" ]; then
+      echo "[原生回退] 无法读取用户 $user 的已安装包列表" >>"$LOG_FILE"
+      cleanup_lock
+      trap - EXIT INT TERM
+      fallback "$@"
+    fi
+    found_users=$((found_users + 1))
+  done
+  if [ "$found_users" -eq 0 ]; then
+    echo "[原生回退] 未发现可扫描的 Android 用户" >>"$LOG_FILE"
+    cleanup_lock
+    trap - EXIT INT TERM
+    fallback "$@"
+  fi
+fi
+
+max_mb=$(sed -n 's/^max_file_mb=//p' "$CONFIG" 2>/dev/null | tail -n 1)
+case "$max_mb" in ''|*[!0-9]*) max_mb=256 ;; esac
+[ "$max_mb" -lt 1 ] && max_mb=1
+[ "$max_mb" -gt 4096 ] && max_mb=4096
+MAX_FILE_BYTES=$((max_mb * 1024 * 1024))
+
+set_phase "启动 C 原生卸载残留扫描"
+"$NATIVE_ENGINE" scan-corpses \
+  --media-root "$MEDIA_ROOT" \
+  --installed-root "$INSTALLED_ROOT" \
+  --whitelist "$WHITELIST" \
+  --max-file-bytes "$MAX_FILE_BYTES" \
+  --report "$REPORT_FILE" \
+  --targets "$TARGETS_TMP" \
+  --summary "$SUMMARY_FILE" \
+  --progress "$RUNNING_FILE" \
+  --stop "$STOP_FILE" >>"$LOG_FILE" 2>&1
+code=$?
+
+value() {
+  sed -n "s/^$1=//p" "$SUMMARY_FILE" 2>/dev/null | tail -n 1
+}
+number() {
+  result=$(value "$1")
+  case "$result" in ''|*[!0-9]*) result=0 ;; esac
+  echo "$result"
+}
+human_bytes() {
+  awk -v b="$1" 'BEGIN {
+    if (b >= 1073741824) printf "%.2f GB", b/1073741824;
+    else if (b >= 1048576) printf "%.2f MB", b/1048576;
+    else if (b >= 1024) printf "%.2f KB", b/1024;
+    else printf "%.0f B", b;
+  }'
+}
+
+if [ "$code" -ne 0 ] && [ "$code" -ne 9 ]; then
+  echo "[原生回退] C 扫描器失败，代码 $code，切换兼容引擎" >>"$LOG_FILE"
+  rm -f "$REPORT_FILE" "$TARGETS_TMP" "$SUMMARY_FILE"
+  cleanup_lock
+  trap - EXIT INT TERM
+  fallback "$@"
+fi
+
+FILES=$(number files)
+EMPTY_DIRS=$(number empty_dirs)
+BYTES=$(number bytes)
+SKIPPED=$(number skipped)
+ERRORS=$(number errors)
+PROTECTED_ITEMS=$(number protected_items)
+PROTECTED_BYTES=$(number protected_bytes)
+TARGETS=$(number targets)
+CANDIDATES=$(number candidates)
+TOTAL_FILES=$((FILES + EMPTY_DIRS))
+END_EPOCH=$(date +%s)
+ELAPSED=$((END_EPOCH - START_EPOCH))
+SPACE=$(human_bytes "$BYTES")
+
+if [ "$code" -eq 9 ]; then
+  RESULT="卸载残留扫描已停止"
+  rm -f "$TARGETS_TMP"
+else
+  RESULT="卸载残留原生扫描完成，可清理 $SPACE"
+  chmod 0600 "$TARGETS_TMP" 2>/dev/null
+  mv -f "$TARGETS_TMP" "$CORPSE_SCAN_TARGETS"
+  {
+    echo "epoch=$(date +%s)"
+    echo "bytes=$BYTES"
+    echo "items=$TOTAL_FILES"
+    echo "engine=native-c-arm64"
+    echo "targets=$CANDIDATES"
+  } >"$CORPSE_SCAN_STATE"
+fi
+
+{
+  echo "mode=corpse-scan"
+  echo "time=$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "files=$TOTAL_FILES"
+  echo "regular_files=$FILES"
+  echo "empty_files=0"
+  echo "empty_dirs=$EMPTY_DIRS"
+  echo "hidden_items=0"
+  echo "fragment_files=0"
+  echo "bytes=$BYTES"
+  echo "skipped=$SKIPPED"
+  echo "errors=$ERRORS"
+  echo "protected_items=$PROTECTED_ITEMS"
+  echo "protected_bytes=$PROTECTED_BYTES"
+  echo "risk_low=0"
+  echo "risk_medium=0"
+  echo "risk_high=$TARGETS"
+  echo "risk_critical=0"
+  echo "deep_slow_items=0"
+  echo "deep_mount_items=0"
+  echo "deep_truncated=0"
+  echo "cache_slow_dirs=0"
+  echo "cache_truncated=0"
+  echo "deep_progress_current=$TARGETS"
+  echo "deep_progress_total=$TARGETS"
+  echo "elapsed=$ELAPSED"
+  echo "engine=native-c-arm64"
+  echo "result=$RESULT"
+} >"$STATE_DIR/latest.env"
+
+[ -f "$REPORT_FILE" ] && cp -f "$REPORT_FILE" "$REPORT_DIR/latest.tsv"
+{
+  echo "----------------------------------------"
+  echo "$RESULT"
+  echo "原生引擎: C arm64 预览版"
+  echo "候选目录: $CANDIDATES | 文件: $FILES | 空目录: $EMPTY_DIRS | 受保护: $PROTECTED_ITEMS | 跳过: $SKIPPED | 错误: $ERRORS | 耗时: ${ELAPSED}s"
+} >>"$LOG_FILE"
+cp -f "$LOG_FILE" "$LOG_DIR/latest.log"
+
+history_category="卸载残留|$BYTES|$TOTAL_FILES"
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$(date '+%Y-%m-%d %H:%M:%S')" "corpse-scan" "$BYTES" "$TOTAL_FILES" "$EMPTY_DIRS" "$ERRORS" \
+  "$RESULT" "$TRIGGER" "$history_category" "" >>"$HISTORY_FILE"
+tail -n 100 "$HISTORY_FILE" >"$HISTORY_FILE.tmp.$$" 2>/dev/null && mv -f "$HISTORY_FILE.tmp.$$" "$HISTORY_FILE"
+
+ls -1t "$LOG_DIR"/*.log 2>/dev/null | awk 'NR>11' | while IFS= read -r old; do rm -f "$old"; done
+ls -1t "$REPORT_DIR"/*.tsv 2>/dev/null | grep -v '/latest.tsv$' | awk 'NR>20' | while IFS= read -r old; do rm -f "$old"; done
+
+echo "$RESULT"
+echo "原生引擎: C arm64 | 候选目录: $CANDIDATES | 文件: $FILES | 空目录: $EMPTY_DIRS | 受保护: $PROTECTED_ITEMS | 耗时: ${ELAPSED}s"
+cleanup_lock
+trap - EXIT INT TERM
+[ "$code" -eq 9 ] && exit 9
+exit 0

--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -7,17 +7,20 @@ OLD_UPDATE="/data/adb/modules_update/safesweep"
 OLD_STATE="/data/adb/safesweep"
 APK="$MODPATH/app/baize.apk"
 HASH_FILE="$MODPATH/app/baize.apk.sha256"
+NATIVE_ENGINE="$MODPATH/bin/arm64-v8a/baize_engine"
 
-ui_print "- 安装白泽 v2 Alpha 42.2 辅助清理页面双皮肤版"
-ui_print "- 清理中心与深度清理页面已跟随 Material / Miuix 外观"
-ui_print "- 内置原生 App、完整清理引擎、真实调度器与规则库"
+ui_print "- 安装白泽 v2 Alpha 42.3 C 原生扫描预览版"
+ui_print "- 卸载残留扫描优先使用 arm64 C 引擎，异常时自动回退 Shell"
+ui_print "- 删除、授权快照、高风险保护与其他清理功能继续沿用稳定引擎"
 ui_print "- 旧版 v1 将在迁移配置后彻底移除，不再保留双模块"
 
 mkdir -p "$STATE_DIR"
 chmod 0700 "$STATE_DIR"
 
 [ -f "$APK" ] || abort "! 模块包中缺少 app/baize.apk"
-[ -f "$MODPATH/cleaner.sh" ] || abort "! 模块包中缺少一键清理引擎"
+[ -f "$MODPATH/cleaner.sh" ] || abort "! 模块包中缺少清理入口"
+[ -f "$MODPATH/cleaner.sh.compat" ] || abort "! 模块包中缺少兼容清理引擎"
+[ -f "$NATIVE_ENGINE" ] || abort "! 模块包中缺少 arm64 原生扫描器"
 [ -f "$MODPATH/scheduler.sh" ] || abort "! 模块包中缺少自动调度器"
 [ -f "$MODPATH/config/deep.rules" ] || abort "! 模块包中缺少完整深度规则库"
 
@@ -49,7 +52,7 @@ fi
 
 chmod 0600 "$STATE_DIR/config.conf" "$STATE_DIR/whitelist.conf" "$STATE_DIR/custom.rules" 2>/dev/null
 chmod 0644 "$APK" "$HASH_FILE" 2>/dev/null
-chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" 2>/dev/null
+chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/cleaner.sh.compat" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" "$NATIVE_ENGINE" 2>/dev/null
 
 install_app() {
   pm install -r -d --user 0 "$APK" >/dev/null 2>&1 && return 0

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.0.0-alpha42.2
-versionCode=22220
+version=v2.0.0-alpha42.3
+versionCode=22230
 author=惜故里丶
-description=智能清理缓存、日志、空项目与存储垃圾。
+description=智能清理缓存、日志、空项目与存储垃圾；卸载残留支持 C 原生高速扫描。

--- a/v2/native/baize_engine.c
+++ b/v2/native/baize_engine.c
@@ -1,0 +1,510 @@
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define ENGINE_VERSION "42.3-preview1"
+
+typedef struct {
+    char **items;
+    size_t count;
+    size_t capacity;
+} StringList;
+
+typedef struct {
+    char *path;
+} Target;
+
+typedef struct {
+    Target *items;
+    size_t count;
+    size_t capacity;
+} TargetList;
+
+typedef struct {
+    uint64_t files;
+    uint64_t bytes;
+    uint64_t errors;
+    bool oversized;
+} DirStats;
+
+typedef struct {
+    const char *media_root;
+    const char *installed_root;
+    const char *whitelist_path;
+    const char *report_path;
+    const char *targets_path;
+    const char *summary_path;
+    const char *progress_path;
+    const char *stop_path;
+    uint64_t max_file_bytes;
+} Options;
+
+typedef struct {
+    uint64_t candidates;
+    uint64_t files;
+    uint64_t empty_dirs;
+    uint64_t bytes;
+    uint64_t protected_items;
+    uint64_t protected_bytes;
+    uint64_t skipped;
+    uint64_t errors;
+    uint64_t users;
+    uint64_t targets;
+    bool cancelled;
+} Summary;
+
+static void die_usage(void) {
+    fprintf(stderr,
+            "用法: baize_engine scan-corpses --media-root PATH --installed-root PATH "
+            "--whitelist FILE --max-file-bytes N --report FILE --targets FILE "
+            "--summary FILE --progress FILE --stop FILE\n");
+    exit(2);
+}
+
+static void *xrealloc(void *ptr, size_t size) {
+    void *next = realloc(ptr, size);
+    if (!next) {
+        fprintf(stderr, "内存不足\n");
+        exit(70);
+    }
+    return next;
+}
+
+static char *xstrdup(const char *value) {
+    char *copy = strdup(value ? value : "");
+    if (!copy) {
+        fprintf(stderr, "内存不足\n");
+        exit(70);
+    }
+    return copy;
+}
+
+static bool is_numeric_name(const char *name) {
+    if (!name || !*name) return false;
+    for (const unsigned char *p = (const unsigned char *) name; *p; ++p) {
+        if (!isdigit(*p)) return false;
+    }
+    return true;
+}
+
+static bool valid_package_name(const char *name) {
+    if (!name || !*name || !strchr(name, '.')) return false;
+    for (const unsigned char *p = (const unsigned char *) name; *p; ++p) {
+        if (!(isalnum(*p) || *p == '.' || *p == '_' || *p == '-')) return false;
+    }
+    return true;
+}
+
+static void string_list_add(StringList *list, const char *value) {
+    if (list->count == list->capacity) {
+        list->capacity = list->capacity ? list->capacity * 2 : 64;
+        list->items = xrealloc(list->items, list->capacity * sizeof(*list->items));
+    }
+    list->items[list->count++] = xstrdup(value);
+}
+
+static int compare_strings(const void *a, const void *b) {
+    const char *const *left = a;
+    const char *const *right = b;
+    return strcmp(*left, *right);
+}
+
+static void string_list_sort_unique(StringList *list) {
+    if (list->count < 2) return;
+    qsort(list->items, list->count, sizeof(*list->items), compare_strings);
+    size_t out = 1;
+    for (size_t i = 1; i < list->count; ++i) {
+        if (strcmp(list->items[i], list->items[out - 1]) == 0) {
+            free(list->items[i]);
+        } else {
+            list->items[out++] = list->items[i];
+        }
+    }
+    list->count = out;
+}
+
+static bool string_list_contains(const StringList *list, const char *value) {
+    if (!list->count) return false;
+    char *key = (char *) value;
+    return bsearch(&key, list->items, list->count, sizeof(*list->items), compare_strings) != NULL;
+}
+
+static void string_list_free(StringList *list) {
+    for (size_t i = 0; i < list->count; ++i) free(list->items[i]);
+    free(list->items);
+    memset(list, 0, sizeof(*list));
+}
+
+static void target_list_add(TargetList *list, const char *path) {
+    if (list->count == list->capacity) {
+        list->capacity = list->capacity ? list->capacity * 2 : 64;
+        list->items = xrealloc(list->items, list->capacity * sizeof(*list->items));
+    }
+    list->items[list->count++].path = xstrdup(path);
+}
+
+static int compare_targets(const void *a, const void *b) {
+    const Target *left = a;
+    const Target *right = b;
+    return strcmp(left->path, right->path);
+}
+
+static void target_list_sort_unique(TargetList *list) {
+    if (list->count < 2) return;
+    qsort(list->items, list->count, sizeof(*list->items), compare_targets);
+    size_t out = 1;
+    for (size_t i = 1; i < list->count; ++i) {
+        if (strcmp(list->items[i].path, list->items[out - 1].path) == 0) {
+            free(list->items[i].path);
+        } else {
+            if (out != i) list->items[out] = list->items[i];
+            out++;
+        }
+    }
+    list->count = out;
+}
+
+static void target_list_free(TargetList *list) {
+    for (size_t i = 0; i < list->count; ++i) free(list->items[i].path);
+    free(list->items);
+    memset(list, 0, sizeof(*list));
+}
+
+static char *trim_line(char *line) {
+    while (*line && isspace((unsigned char) *line)) line++;
+    size_t len = strlen(line);
+    while (len > 0 && isspace((unsigned char) line[len - 1])) line[--len] = '\0';
+    return line;
+}
+
+static bool load_lines(const char *path, StringList *list, bool packages_only) {
+    FILE *file = fopen(path, "re");
+    if (!file) return false;
+    char *line = NULL;
+    size_t capacity = 0;
+    while (getline(&line, &capacity, file) >= 0) {
+        char *value = trim_line(line);
+        if (!*value || *value == '#') continue;
+        if (packages_only && !valid_package_name(value)) continue;
+        string_list_add(list, value);
+    }
+    free(line);
+    fclose(file);
+    string_list_sort_unique(list);
+    return true;
+}
+
+static bool path_has_prefix(const char *path, const char *prefix) {
+    size_t length = strlen(prefix);
+    while (length > 1 && prefix[length - 1] == '/') length--;
+    return strncmp(path, prefix, length) == 0 && (path[length] == '\0' || path[length] == '/');
+}
+
+static bool is_whitelisted(const StringList *whitelist, const char *path) {
+    for (size_t i = 0; i < whitelist->count; ++i) {
+        if (path_has_prefix(path, whitelist->items[i])) return true;
+    }
+    return false;
+}
+
+static bool stop_requested(const char *stop_path) {
+    return stop_path && access(stop_path, F_OK) == 0;
+}
+
+static int scan_dir_fd(int dir_fd, const Options *options, DirStats *stats) {
+    int duplicate = dup(dir_fd);
+    if (duplicate < 0) {
+        stats->errors++;
+        return -1;
+    }
+    DIR *dir = fdopendir(duplicate);
+    if (!dir) {
+        close(duplicate);
+        stats->errors++;
+        return -1;
+    }
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
+        if (stop_requested(options->stop_path)) {
+            closedir(dir);
+            return 9;
+        }
+        struct stat st;
+        if (fstatat(dir_fd, entry->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0) {
+            stats->errors++;
+            continue;
+        }
+        if (S_ISLNK(st.st_mode)) continue;
+        if (S_ISREG(st.st_mode)) {
+            stats->files++;
+            if (st.st_size > 0) stats->bytes += (uint64_t) st.st_size;
+            if ((uint64_t) st.st_size > options->max_file_bytes) stats->oversized = true;
+            continue;
+        }
+        if (S_ISDIR(st.st_mode)) {
+            int child = openat(dir_fd, entry->d_name, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+            if (child < 0) {
+                stats->errors++;
+                continue;
+            }
+            int code = scan_dir_fd(child, options, stats);
+            close(child);
+            if (code == 9) {
+                closedir(dir);
+                return 9;
+            }
+        }
+    }
+    closedir(dir);
+    return 0;
+}
+
+static int scan_target(const char *path, const Options *options, DirStats *stats) {
+    struct stat st;
+    if (lstat(path, &st) != 0) return -1;
+    if (!S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)) return -1;
+    int fd = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC | O_NOFOLLOW);
+    if (fd < 0) return -1;
+    int code = scan_dir_fd(fd, options, stats);
+    close(fd);
+    return code;
+}
+
+static void sanitize_tsv(const char *input, char *output, size_t size) {
+    if (!size) return;
+    size_t out = 0;
+    for (const unsigned char *p = (const unsigned char *) input; *p && out + 1 < size; ++p) {
+        unsigned char c = *p;
+        output[out++] = (c == '\t' || c == '\r' || c == '\n') ? ' ' : (char) c;
+    }
+    output[out] = '\0';
+}
+
+static bool write_atomic_text(const char *path, const char *text) {
+    char temporary[PATH_MAX];
+    if (snprintf(temporary, sizeof(temporary), "%s.tmp.%ld", path, (long) getpid()) >= (int) sizeof(temporary)) return false;
+    FILE *file = fopen(temporary, "we");
+    if (!file) return false;
+    bool ok = fputs(text, file) >= 0 && fflush(file) == 0 && fsync(fileno(file)) == 0;
+    if (fclose(file) != 0) ok = false;
+    if (ok && rename(temporary, path) == 0) return true;
+    unlink(temporary);
+    return false;
+}
+
+static void write_progress(const Options *options, uint64_t current, uint64_t total, const char *path) {
+    char safe_path[PATH_MAX];
+    sanitize_tsv(path ? path : "", safe_path, sizeof(safe_path));
+    char text[PATH_MAX + 256];
+    snprintf(text, sizeof(text),
+             "mode=corpse-scan\nphase=原生引擎扫描卸载残留（%" PRIu64 "/%" PRIu64 "）\n"
+             "progress_current=%" PRIu64 "\nprogress_total=%" PRIu64 "\ncurrent_path=%s\nengine=native-c-arm64\n",
+             current, total, current, total, safe_path);
+    write_atomic_text(options->progress_path, text);
+}
+
+static bool join_path(char *output, size_t size, const char *a, const char *b) {
+    int written = snprintf(output, size, "%s/%s", a, b);
+    return written > 0 && written < (int) size;
+}
+
+static void collect_targets_for_root(const char *root, const StringList *installed, TargetList *targets) {
+    DIR *dir = opendir(root);
+    if (!dir) return;
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL) {
+        if (entry->d_name[0] == '.') continue;
+        if (!valid_package_name(entry->d_name)) continue;
+        if (string_list_contains(installed, entry->d_name)) continue;
+        char path[PATH_MAX];
+        if (!join_path(path, sizeof(path), root, entry->d_name)) continue;
+        struct stat st;
+        if (lstat(path, &st) != 0 || !S_ISDIR(st.st_mode) || S_ISLNK(st.st_mode)) continue;
+        target_list_add(targets, path);
+    }
+    closedir(dir);
+}
+
+static int collect_targets(const Options *options, TargetList *targets, Summary *summary) {
+    DIR *media = opendir(options->media_root);
+    if (!media) return 7;
+    struct dirent *user_entry;
+    while ((user_entry = readdir(media)) != NULL) {
+        if (!is_numeric_name(user_entry->d_name)) continue;
+        char user_root[PATH_MAX];
+        if (!join_path(user_root, sizeof(user_root), options->media_root, user_entry->d_name)) continue;
+        struct stat user_stat;
+        if (lstat(user_root, &user_stat) != 0 || !S_ISDIR(user_stat.st_mode) || S_ISLNK(user_stat.st_mode)) continue;
+
+        char installed_path[PATH_MAX];
+        char installed_name[64];
+        if (snprintf(installed_name, sizeof(installed_name), "%s.txt", user_entry->d_name) >= (int) sizeof(installed_name)) continue;
+        if (!join_path(installed_path, sizeof(installed_path), options->installed_root, installed_name)) continue;
+        StringList installed = {0};
+        if (!load_lines(installed_path, &installed, true)) {
+            string_list_free(&installed);
+            continue;
+        }
+        summary->users++;
+
+        const char *subroots[] = {"Android/data", "Android/obb", "Android/media"};
+        for (size_t i = 0; i < sizeof(subroots) / sizeof(subroots[0]); ++i) {
+            char root[PATH_MAX];
+            if (!join_path(root, sizeof(root), user_root, subroots[i])) continue;
+            collect_targets_for_root(root, &installed, targets);
+        }
+        string_list_free(&installed);
+    }
+    closedir(media);
+    target_list_sort_unique(targets);
+    summary->targets = targets->count;
+    return summary->users ? 0 : 7;
+}
+
+static int scan_corpses(const Options *options) {
+    StringList whitelist = {0};
+    load_lines(options->whitelist_path, &whitelist, false);
+
+    TargetList targets = {0};
+    Summary summary = {0};
+    int collect_code = collect_targets(options, &targets, &summary);
+    if (collect_code != 0) {
+        string_list_free(&whitelist);
+        target_list_free(&targets);
+        return collect_code;
+    }
+
+    FILE *report = fopen(options->report_path, "we");
+    FILE *target_file = fopen(options->targets_path, "we");
+    if (!report || !target_file) {
+        if (report) fclose(report);
+        if (target_file) fclose(target_file);
+        string_list_free(&whitelist);
+        target_list_free(&targets);
+        return 71;
+    }
+    fprintf(report, "action\trisk\tcategory\titems\tbytes\tpath\n");
+
+    write_progress(options, 0, targets.count, "");
+    for (size_t i = 0; i < targets.count; ++i) {
+        const Target *target = &targets.items[i];
+        if (stop_requested(options->stop_path)) {
+            summary.cancelled = true;
+            break;
+        }
+        if (is_whitelisted(&whitelist, target->path)) {
+            summary.skipped++;
+            char safe[PATH_MAX];
+            sanitize_tsv(target->path, safe, sizeof(safe));
+            fprintf(report, "skipped\tprotected\t卸载残留\t0\t0\t%s\n", safe);
+        } else {
+            DirStats stats = {0};
+            int code = scan_target(target->path, options, &stats);
+            if (code == 9) {
+                summary.cancelled = true;
+                break;
+            }
+            char safe[PATH_MAX];
+            sanitize_tsv(target->path, safe, sizeof(safe));
+            if (code != 0) {
+                summary.errors++;
+                fprintf(report, "failed\thigh\t卸载残留\t1\t0\t%s（无法统计）\n", safe);
+            } else if (stats.oversized) {
+                uint64_t report_count = stats.files ? stats.files : 1;
+                summary.protected_items += report_count;
+                summary.protected_bytes += stats.bytes;
+                summary.errors += stats.errors;
+                fprintf(report, "protected\thigh\t卸载残留\t%" PRIu64 "\t%" PRIu64 "\t%s（含超过单文件上限的文件）\n",
+                        report_count, stats.bytes, safe);
+            } else {
+                uint64_t report_count = stats.files ? stats.files : 1;
+                summary.candidates++;
+                summary.files += stats.files;
+                if (stats.files == 0) summary.empty_dirs++;
+                summary.bytes += stats.bytes;
+                summary.errors += stats.errors;
+                fprintf(report, "candidate\thigh\t卸载残留\t%" PRIu64 "\t%" PRIu64 "\t%s\n",
+                        report_count, stats.bytes, safe);
+                fprintf(target_file, "%s\n", target->path);
+            }
+        }
+        if (i == 0 || (i + 1) % 4 == 0 || i + 1 == targets.count) {
+            write_progress(options, i + 1, targets.count, target->path);
+        }
+    }
+
+    fflush(report);
+    fsync(fileno(report));
+    fflush(target_file);
+    fsync(fileno(target_file));
+    fclose(report);
+    fclose(target_file);
+
+    char summary_text[1024];
+    snprintf(summary_text, sizeof(summary_text),
+             "engine=native-c-arm64\nengine_version=%s\nusers=%" PRIu64 "\ntargets=%" PRIu64 "\n"
+             "candidates=%" PRIu64 "\nfiles=%" PRIu64 "\nempty_dirs=%" PRIu64 "\nbytes=%" PRIu64 "\n"
+             "protected_items=%" PRIu64 "\nprotected_bytes=%" PRIu64 "\nskipped=%" PRIu64 "\nerrors=%" PRIu64 "\n"
+             "cancelled=%d\n",
+             ENGINE_VERSION, summary.users, summary.targets, summary.candidates, summary.files,
+             summary.empty_dirs, summary.bytes, summary.protected_items, summary.protected_bytes,
+             summary.skipped, summary.errors, summary.cancelled ? 1 : 0);
+    write_atomic_text(options->summary_path, summary_text);
+
+    string_list_free(&whitelist);
+    target_list_free(&targets);
+    return summary.cancelled ? 9 : 0;
+}
+
+static uint64_t parse_u64(const char *value) {
+    if (!value || !*value) die_usage();
+    errno = 0;
+    char *end = NULL;
+    unsigned long long parsed = strtoull(value, &end, 10);
+    if (errno || !end || *end) die_usage();
+    return (uint64_t) parsed;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2 || strcmp(argv[1], "scan-corpses") != 0) die_usage();
+    Options options = {0};
+    for (int i = 2; i < argc; ++i) {
+        if (i + 1 >= argc) die_usage();
+        const char *key = argv[i++];
+        const char *value = argv[i];
+        if (strcmp(key, "--media-root") == 0) options.media_root = value;
+        else if (strcmp(key, "--installed-root") == 0) options.installed_root = value;
+        else if (strcmp(key, "--whitelist") == 0) options.whitelist_path = value;
+        else if (strcmp(key, "--max-file-bytes") == 0) options.max_file_bytes = parse_u64(value);
+        else if (strcmp(key, "--report") == 0) options.report_path = value;
+        else if (strcmp(key, "--targets") == 0) options.targets_path = value;
+        else if (strcmp(key, "--summary") == 0) options.summary_path = value;
+        else if (strcmp(key, "--progress") == 0) options.progress_path = value;
+        else if (strcmp(key, "--stop") == 0) options.stop_path = value;
+        else die_usage();
+    }
+    if (!options.media_root || !options.installed_root || !options.whitelist_path ||
+        !options.report_path || !options.targets_path || !options.summary_path ||
+        !options.progress_path || !options.stop_path || options.max_file_bytes == 0) {
+        die_usage();
+    }
+    return scan_corpses(&options);
+}

--- a/v2/scripts/build-native.sh
+++ b/v2/scripts/build-native.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+OUT="$ROOT/build/native/arm64-v8a"
+SOURCE="$ROOT/native/baize_engine.c"
+API=${ANDROID_API:-26}
+
+find_ndk() {
+  if [ -n "${ANDROID_NDK_HOME:-}" ] && [ -d "$ANDROID_NDK_HOME" ]; then
+    printf '%s\n' "$ANDROID_NDK_HOME"
+    return 0
+  fi
+  if [ -n "${ANDROID_SDK_ROOT:-}" ] && [ -d "$ANDROID_SDK_ROOT/ndk" ]; then
+    find "$ANDROID_SDK_ROOT/ndk" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1
+    return 0
+  fi
+  return 1
+}
+
+NDK=$(find_ndk) || { echo "未找到 Android NDK" >&2; exit 1; }
+HOST_TAG=linux-x86_64
+[ "$(uname -s)" = "Darwin" ] && HOST_TAG=darwin-x86_64
+TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/$HOST_TAG/bin"
+CC="$TOOLCHAIN/aarch64-linux-android${API}-clang"
+STRIP="$TOOLCHAIN/llvm-strip"
+
+[ -x "$CC" ] || { echo "未找到编译器：$CC" >&2; exit 1; }
+mkdir -p "$OUT"
+"$CC" -std=c11 -O2 -fPIE -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
+  -Wall -Wextra -Werror -Wformat=2 -Wshadow -Wconversion \
+  "$SOURCE" -o "$OUT/baize_engine"
+"$STRIP" --strip-unneeded "$OUT/baize_engine"
+chmod 0755 "$OUT/baize_engine"
+file "$OUT/baize_engine"
+echo "已生成原生扫描器：$OUT/baize_engine"

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -7,23 +7,27 @@ OUT="$ROOT/dist"
 MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/debug/app-debug.apk"
-OUTPUT="$OUT/BaiZe-v2-Alpha42.2-Module.zip"
+NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
+OUTPUT="$OUT/BaiZe-v2-Alpha42.3-Native-Corpse-Scanner-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
+[ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
 
 rm -rf "$STAGE"
-mkdir -p "$OUT" "$STAGE/app"
+mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
 cp -a "$MODULE/." "$STAGE/"
 cp -a "$REPO/config" "$STAGE/config"
 
-# Reuse the mature v1 automatic cleaner and scheduler instead of wrapping the scan UI in a fake
-# timer. The staging copies use an isolated v2 state directory and the v2 module path.
-cp -f "$REPO/cleaner.sh" "$STAGE/cleaner.sh"
+# 保留成熟 Shell 引擎作为所有清理操作与原生扫描失败时的兼容回退。
+cp -f "$REPO/cleaner.sh" "$STAGE/cleaner.sh.compat"
 cp -f "$REPO/notify.sh" "$STAGE/notify.sh"
 cp -f "$REPO/service.sh" "$STAGE/scheduler.sh"
-sed -i 's|STATE_DIR=/data/adb/safesweep|STATE_DIR=/data/adb/baize-v2|g' "$STAGE/cleaner.sh" "$STAGE/scheduler.sh"
-sed -i 's|\*safesweep\*cleaner.sh\*|*baize_v2*cleaner.sh*|g; s|\*safesweep\*job-runner.sh\*|*baize_v2*job-runner.sh*|g; s|\*safesweep\*webctl.sh\*|*baize_v2*webctl.sh*|g' "$STAGE/cleaner.sh"
-chmod 0755 "$STAGE/cleaner.sh" "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh"
+sed -i 's|STATE_DIR=/data/adb/safesweep|STATE_DIR=/data/adb/baize-v2|g' "$STAGE/cleaner.sh.compat" "$STAGE/scheduler.sh"
+sed -i 's|\*safesweep\*cleaner.sh\*|*baize_v2*cleaner.sh*|g; s|\*safesweep\*job-runner.sh\*|*baize_v2*job-runner.sh*|g; s|\*safesweep\*webctl.sh\*|*baize_v2*webctl.sh*|g' "$STAGE/cleaner.sh.compat"
+
+cp -f "$NATIVE" "$STAGE/bin/arm64-v8a/baize_engine"
+chmod 0755 "$STAGE/cleaner.sh" "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine"
+chmod 0755 "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh"
 
 cp -f "$APK" "$STAGE/app/baize.apk"
 chmod 0644 "$STAGE/app/baize.apk"
@@ -39,8 +43,10 @@ rm -f "$OUTPUT"
 unzip -tq "$OUTPUT" >/dev/null
 unzip -l "$OUTPUT" | grep -q 'app/baize.apk'
 unzip -l "$OUTPUT" | grep -q 'cleaner.sh'
+unzip -l "$OUTPUT" | grep -q 'cleaner.sh.compat'
+unzip -l "$OUTPUT" | grep -q 'bin/arm64-v8a/baize_engine'
 unzip -l "$OUTPUT" | grep -q 'scheduler.sh'
 unzip -l "$OUTPUT" | grep -q 'config/deep.rules'
 unzip -p "$OUTPUT" config/deep.rules | sha256sum | grep -q '^73d4c898630a292753adca33298c8aabbf6146debf414b2cabbe6b87d1d5c31c'
 
-echo "已生成 Alpha 42.2 辅助清理页面双皮肤模块：$OUTPUT"
+echo "已生成 Alpha 42.3 C 原生卸载残留扫描预览模块：$OUTPUT"


### PR DESCRIPTION
## 改动

- 新增 `baize_engine` C 原生扫描器，首阶段只负责卸载残留扫描。
- 原生引擎单次遍历同时统计文件数量、大小、空目录与超大文件，避免反复调用 `du`、`find`、`wc`、`awk`。
- 扫描前仍通过 Android 包管理器读取各用户已安装包列表。
- 保持 `corpse_scan.targets`、`corpse_scan.env`、`latest.env`、TSV 报告和历史格式兼容。
- `corpse-clean` 与其他所有扫描/清理操作继续使用现有稳定 Shell 引擎。
- arm64 原生引擎不可用、包列表读取失败或执行异常时自动回退 Shell。
- 新增 Linux 夹具测试、Android NDK arm64 交叉编译和模块产物校验。
- 版本升级为 `v2.0.0-alpha42.3 / 22230`。

## 安全边界

- 不修改成熟删除实现。
- 不放宽白名单、单文件大小保护和卸载残留二次安装状态核对。
- 原生扫描生成的授权快照仍由 Shell 清理器消费并重新确认包安装状态。

## 真机重点

- 对比 Alpha 42.2 与 Alpha 42.3 的卸载残留扫描耗时。
- 检查退出重进后候选授权恢复。
- 检查一键清理仍直接消费扫描快照，不重新扫描。
- 检查日志中显示 `native-c-arm64`；异常设备应自动回退兼容引擎。