### PR TITLE
fix(v2): Alpha 42.5 缓存快照、进度恢复与停止修复

### DIFF
--- a/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
+++ b/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
@@ -1,0 +1,223 @@
+name: BaiZe v2 Alpha 42.5 Cache Snapshot Recovery
+
+on:
+  push:
+    branches: [v2-alpha42-5-cache-snapshot-recovery]
+    paths:
+      - 'v2/**'
+      - '.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml'
+  pull_request:
+    branches: [v2-alpha42-4-native-deep-cache-scanner]
+    paths:
+      - 'v2/**'
+      - '.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v2-alpha42-5-cache-snapshot-recovery
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Validate sources and version
+        run: |
+          sh -n cleaner.sh notify.sh service.sh
+          sh -n v2/module/cleaner.sh v2/module/customize.sh v2/module/service.sh v2/module/action.sh
+          sh -n v2/scripts/build-native.sh v2/scripts/package-module.sh
+          python3 v2/scripts/validate-rules.py
+          grep -q 'version=v2.0.0-alpha42.5' v2/module/module.prop
+          grep -q 'versionCode=22250' v2/module/module.prop
+          grep -q 'cache_scan.env' v2/module/cleaner.sh
+          grep -q '正在清理刚才扫描到的缓存' v2/module/cleaner.sh
+          grep -q 'snapshotReady' v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
+          grep -q '不会重新扫描' v2/app/src/main/java/io/github/xgl34222220/baize/CacheActivity.kt
+
+      - name: Build host native scanner
+        run: |
+          cc -std=c11 -O2 -Wall -Wextra -Wformat=2 -Wshadow -Wconversion \
+            v2/native/baize_engine_42_4.c -o /tmp/baize_engine_host
+
+      - name: Test scan snapshot and no-rescan clean
+        shell: bash
+        run: |
+          set -euo pipefail
+          TEST=/tmp/baize-cache-snapshot
+          rm -rf "$TEST"
+          mkdir -p "$TEST/data/user/0/com.example.cache/cache/sub"
+          mkdir -p "$TEST/media/0/Android/data/com.example.external/cache"
+          mkdir -p "$TEST/state/reports"
+          printf 'old-a' > "$TEST/data/user/0/com.example.cache/cache/a.bin"
+          printf 'old-b' > "$TEST/data/user/0/com.example.cache/cache/sub/b.bin"
+          printf 'old-c' > "$TEST/media/0/Android/data/com.example.external/cache/c.bin"
+          touch -d '10 minutes ago' \
+            "$TEST/data/user/0/com.example.cache/cache/a.bin" \
+            "$TEST/data/user/0/com.example.cache/cache/sub/b.bin" \
+            "$TEST/media/0/Android/data/com.example.external/cache/c.bin"
+          printf 'max_file_mb=256\napp_cache_days=0\nexternal_cache_days=0\n' > "$TEST/state/config.conf"
+          : > "$TEST/state/whitelist.conf"
+          : > "$TEST/state/native-cache-packages.conf"
+
+          BAIZE_NATIVE_TEST=1 \
+          BAIZE_STATE_DIR="$TEST/state" \
+          BAIZE_DATA_ROOT="$TEST/data" \
+          BAIZE_MEDIA_ROOT="$TEST/media" \
+          BAIZE_NATIVE_ENGINE=/tmp/baize_engine_host \
+          BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
+            bash v2/module/cleaner.sh cache-scan ci
+
+          test -s "$TEST/state/cache_scan.env"
+          test -s "$TEST/state/cache_scan.targets"
+          test -s "$TEST/state/cache_scan.items.tsv"
+          grep -q '^snapshot_id=' "$TEST/state/cache_scan.env"
+          grep -q '^mode=cache-scan$' "$TEST/state/latest.env"
+
+          # This file did not exist during the scan and must survive snapshot cleaning.
+          printf 'new-after-scan' > "$TEST/data/user/0/com.example.cache/cache/new.bin"
+
+          BAIZE_NATIVE_TEST=1 \
+          BAIZE_STATE_DIR="$TEST/state" \
+          BAIZE_DATA_ROOT="$TEST/data" \
+          BAIZE_MEDIA_ROOT="$TEST/media" \
+          BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
+            bash v2/module/cleaner.sh cache-clean ci
+
+          test ! -e "$TEST/data/user/0/com.example.cache/cache/a.bin"
+          test ! -e "$TEST/data/user/0/com.example.cache/cache/sub/b.bin"
+          test ! -e "$TEST/media/0/Android/data/com.example.external/cache/c.bin"
+          test -f "$TEST/data/user/0/com.example.cache/cache/new.bin"
+          test -d "$TEST/data/user/0/com.example.cache/cache"
+          test ! -e "$TEST/state/cache_scan.env"
+          test ! -e "$TEST/state/cache_scan.targets"
+          grep -q '^mode=cache-clean$' "$TEST/state/latest.env"
+          grep -q '扫描快照' "$TEST/state/logs/latest.log"
+
+      - name: Test stop request and snapshot retention
+        shell: bash
+        run: |
+          set -euo pipefail
+          TEST=/tmp/baize-cache-stop
+          rm -rf "$TEST"
+          mkdir -p "$TEST/data/user/0/com.example.stop/cache"
+          mkdir -p "$TEST/media/0" "$TEST/state/reports" "$TEST/fakebin"
+          for index in $(seq 1 120); do
+            mkdir -p "$TEST/data/user/0/com.example.stop/cache/d$index"
+            printf 'old-%s' "$index" > "$TEST/data/user/0/com.example.stop/cache/d$index/f$index.bin"
+          done
+          find "$TEST/data/user/0/com.example.stop/cache" -type f -exec touch -d '10 minutes ago' {} +
+          printf 'max_file_mb=256\napp_cache_days=0\nexternal_cache_days=0\n' > "$TEST/state/config.conf"
+          : > "$TEST/state/whitelist.conf"
+          : > "$TEST/state/native-cache-packages.conf"
+
+          BAIZE_NATIVE_TEST=1 \
+          BAIZE_STATE_DIR="$TEST/state" \
+          BAIZE_DATA_ROOT="$TEST/data" \
+          BAIZE_MEDIA_ROOT="$TEST/media" \
+          BAIZE_NATIVE_ENGINE=/tmp/baize_engine_host \
+          BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
+            bash v2/module/cleaner.sh cache-scan ci
+
+          cat > "$TEST/fakebin/find" <<'SCRIPT'
+          #!/usr/bin/env bash
+          sleep 1
+          exec /usr/bin/find "$@"
+          SCRIPT
+          chmod +x "$TEST/fakebin/find"
+
+          set +e
+          PATH="$TEST/fakebin:$PATH" \
+          BAIZE_NATIVE_TEST=1 \
+          BAIZE_STATE_DIR="$TEST/state" \
+          BAIZE_DATA_ROOT="$TEST/data" \
+          BAIZE_MEDIA_ROOT="$TEST/media" \
+          BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
+            bash v2/module/cleaner.sh cache-clean ci > "$TEST/clean.out" 2>&1 &
+          task_pid=$!
+          set -e
+          for _ in $(seq 1 40); do
+            test -f "$TEST/state/running.env" && break
+            sleep 0.1
+          done
+          touch "$TEST/state/stop"
+          set +e
+          wait "$task_pid"
+          code=$?
+          set -e
+          test "$code" -eq 9
+          test -s "$TEST/state/cache_scan.env"
+          grep -q '清理已停止' "$TEST/clean.out"
+          test ! -e "$TEST/state/run.lock"
+          test ! -e "$TEST/state/running.env"
+
+      - name: Test stale lock recovery
+        shell: bash
+        run: |
+          set -euo pipefail
+          TEST=/tmp/baize-stale-lock
+          rm -rf "$TEST"
+          mkdir -p "$TEST/data/user/0/com.example.lock/cache" "$TEST/media/0" "$TEST/state/run.lock" "$TEST/state/reports"
+          printf 'old' > "$TEST/data/user/0/com.example.lock/cache/a"
+          touch -d '10 minutes ago' "$TEST/data/user/0/com.example.lock/cache/a"
+          printf 'max_file_mb=256\napp_cache_days=0\nexternal_cache_days=0\n' > "$TEST/state/config.conf"
+          : > "$TEST/state/whitelist.conf"
+          : > "$TEST/state/native-cache-packages.conf"
+          printf '%s\n' "$$" > "$TEST/state/run.lock/pid"
+          printf 'mode=cache-scan\nphase=stale\n' > "$TEST/state/running.env"
+
+          BAIZE_NATIVE_TEST=1 \
+          BAIZE_STATE_DIR="$TEST/state" \
+          BAIZE_DATA_ROOT="$TEST/data" \
+          BAIZE_MEDIA_ROOT="$TEST/media" \
+          BAIZE_NATIVE_ENGINE=/tmp/baize_engine_host \
+          BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
+            bash v2/module/cleaner.sh cache-scan ci
+          grep -q '^mode=cache-scan$' "$TEST/state/latest.env"
+          test ! -e "$TEST/state/run.lock"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build arm64 native engine
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build Android App
+        working-directory: v2
+        run: gradle --no-daemon :app:assembleDebug
+
+      - name: Package and verify module
+        working-directory: v2
+        run: |
+          sh scripts/package-module.sh
+          ZIP=dist/BaiZe-v2-Alpha42.5-Cache-Snapshot-Recovery-Module.zip
+          unzip -tq "$ZIP"
+          unzip -p "$ZIP" module.prop | grep -q 'version=v2.0.0-alpha42.5'
+          unzip -p "$ZIP" module.prop | grep -q 'versionCode=22250'
+          unzip -l "$ZIP" | grep -q 'app/baize.apk'
+          unzip -l "$ZIP" | grep -q 'cleaner.sh.compat'
+          unzip -l "$ZIP" | grep -q 'bin/arm64-v8a/baize_engine'
+          unzip -p "$ZIP" bin/arm64-v8a/baize_engine > /tmp/baize_engine_android
+          file /tmp/baize_engine_android | grep -q 'ARM aarch64'
+          sha256sum "$ZIP"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2-Alpha42.5-Cache-Snapshot-Recovery
+          path: v2/dist/BaiZe-v2-Alpha42.5-Cache-Snapshot-Recovery-Module.zip

--- a/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
+++ b/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
@@ -47,12 +47,17 @@ jobs:
       - name: Test scan snapshot and no-rescan clean
         shell: bash
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           TEST=/tmp/baize-cache-snapshot
           diagnose() {
             status=$?
             echo "===== snapshot regression failed: $status ====="
-            find "$TEST" -maxdepth 8 -printf '%y %TY-%Tm-%Td %TH:%TM:%TS %p\n' 2>/dev/null || true
+            echo "===== scan trace ====="
+            tail -n 100 "$TEST/scan.trace" 2>/dev/null || true
+            echo "===== clean trace ====="
+            tail -n 160 "$TEST/clean.trace" 2>/dev/null || true
+            echo "===== remaining files ====="
+            find "$TEST" -maxdepth 9 -printf '%y %TY-%Tm-%Td %TH:%TM:%TS %p\n' 2>/dev/null || true
             for file in "$TEST/state/cache_scan.env" "$TEST/state/cache_scan.targets" "$TEST/state/cache_scan.items.tsv" "$TEST/state/latest.env" "$TEST/state/logs/latest.log"; do
               echo "===== $file ====="
               cat "$file" 2>/dev/null || true
@@ -81,7 +86,7 @@ jobs:
           BAIZE_MEDIA_ROOT="$TEST/media" \
           BAIZE_NATIVE_ENGINE=/tmp/baize_engine_host \
           BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
-            bash -x v2/module/cleaner.sh cache-scan ci
+            bash -x v2/module/cleaner.sh cache-scan ci >"$TEST/scan.trace" 2>&1
 
           test -s "$TEST/state/cache_scan.env"
           test -s "$TEST/state/cache_scan.targets"
@@ -97,7 +102,7 @@ jobs:
           BAIZE_DATA_ROOT="$TEST/data" \
           BAIZE_MEDIA_ROOT="$TEST/media" \
           BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
-            bash -x v2/module/cleaner.sh cache-clean ci
+            bash -x v2/module/cleaner.sh cache-clean ci >"$TEST/clean.trace" 2>&1
 
           test ! -e "$TEST/data/user/0/com.example.cache/cache/a.bin"
           test ! -e "$TEST/data/user/0/com.example.cache/cache/sub/b.bin"
@@ -109,6 +114,13 @@ jobs:
           grep -q '^mode=cache-clean$' "$TEST/state/latest.env"
           grep -q '扫描快照' "$TEST/state/logs/latest.log"
           trap - ERR
+
+      - name: Upload cache snapshot failure state
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Alpha42.5-Cache-Snapshot-Failure
+          path: /tmp/baize-cache-snapshot
 
       - name: Test stop request and snapshot retention
         shell: bash

--- a/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
+++ b/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
@@ -47,8 +47,19 @@ jobs:
       - name: Test scan snapshot and no-rescan clean
         shell: bash
         run: |
-          set -euo pipefail
+          set -euxo pipefail
           TEST=/tmp/baize-cache-snapshot
+          diagnose() {
+            status=$?
+            echo "===== snapshot regression failed: $status ====="
+            find "$TEST" -maxdepth 8 -printf '%y %TY-%Tm-%Td %TH:%TM:%TS %p\n' 2>/dev/null || true
+            for file in "$TEST/state/cache_scan.env" "$TEST/state/cache_scan.targets" "$TEST/state/cache_scan.items.tsv" "$TEST/state/latest.env" "$TEST/state/logs/latest.log"; do
+              echo "===== $file ====="
+              cat "$file" 2>/dev/null || true
+            done
+            exit "$status"
+          }
+          trap diagnose ERR
           rm -rf "$TEST"
           mkdir -p "$TEST/data/user/0/com.example.cache/cache/sub"
           mkdir -p "$TEST/media/0/Android/data/com.example.external/cache"
@@ -70,7 +81,7 @@ jobs:
           BAIZE_MEDIA_ROOT="$TEST/media" \
           BAIZE_NATIVE_ENGINE=/tmp/baize_engine_host \
           BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
-            bash v2/module/cleaner.sh cache-scan ci
+            bash -x v2/module/cleaner.sh cache-scan ci
 
           test -s "$TEST/state/cache_scan.env"
           test -s "$TEST/state/cache_scan.targets"
@@ -86,7 +97,7 @@ jobs:
           BAIZE_DATA_ROOT="$TEST/data" \
           BAIZE_MEDIA_ROOT="$TEST/media" \
           BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
-            bash v2/module/cleaner.sh cache-clean ci
+            bash -x v2/module/cleaner.sh cache-clean ci
 
           test ! -e "$TEST/data/user/0/com.example.cache/cache/a.bin"
           test ! -e "$TEST/data/user/0/com.example.cache/cache/sub/b.bin"
@@ -97,6 +108,7 @@ jobs:
           test ! -e "$TEST/state/cache_scan.targets"
           grep -q '^mode=cache-clean$' "$TEST/state/latest.env"
           grep -q '扫描快照' "$TEST/state/logs/latest.log"
+          trap - ERR
 
       - name: Test stop request and snapshot retention
         shell: bash

--- a/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
+++ b/.github/workflows/v2-alpha42-5-cache-snapshot-recovery.yml
@@ -29,13 +29,15 @@ jobs:
       - name: Validate sources and version
         run: |
           sh -n cleaner.sh notify.sh service.sh
-          sh -n v2/module/cleaner.sh v2/module/customize.sh v2/module/service.sh v2/module/action.sh
+          sh -n v2/module/cleaner.sh v2/module/cache-snapshot-clean.sh
+          sh -n v2/module/customize.sh v2/module/service.sh v2/module/action.sh
           sh -n v2/scripts/build-native.sh v2/scripts/package-module.sh
           python3 v2/scripts/validate-rules.py
           grep -q 'version=v2.0.0-alpha42.5' v2/module/module.prop
           grep -q 'versionCode=22250' v2/module/module.prop
           grep -q 'cache_scan.env' v2/module/cleaner.sh
-          grep -q '正在清理刚才扫描到的缓存' v2/module/cleaner.sh
+          grep -q '! -newer "$CACHE_SCAN_STATE"' v2/module/cache-snapshot-clean.sh
+          grep -q 'cache-snapshot-clean.sh' v2/scripts/package-module.sh
           grep -q 'snapshotReady' v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
           grep -q '不会重新扫描' v2/app/src/main/java/io/github/xgl34222220/baize/CacheActivity.kt
 
@@ -55,7 +57,7 @@ jobs:
             echo "===== scan trace ====="
             tail -n 100 "$TEST/scan.trace" 2>/dev/null || true
             echo "===== clean trace ====="
-            tail -n 160 "$TEST/clean.trace" 2>/dev/null || true
+            tail -n 180 "$TEST/clean.trace" 2>/dev/null || true
             echo "===== remaining files ====="
             find "$TEST" -maxdepth 9 -printf '%y %TY-%Tm-%Td %TH:%TM:%TS %p\n' 2>/dev/null || true
             for file in "$TEST/state/cache_scan.env" "$TEST/state/cache_scan.targets" "$TEST/state/cache_scan.items.tsv" "$TEST/state/latest.env" "$TEST/state/logs/latest.log"; do
@@ -95,6 +97,7 @@ jobs:
           grep -q '^mode=cache-scan$' "$TEST/state/latest.env"
 
           # This file did not exist during the scan and must survive snapshot cleaning.
+          sleep 0.1
           printf 'new-after-scan' > "$TEST/data/user/0/com.example.cache/cache/new.bin"
 
           BAIZE_NATIVE_TEST=1 \
@@ -102,7 +105,7 @@ jobs:
           BAIZE_DATA_ROOT="$TEST/data" \
           BAIZE_MEDIA_ROOT="$TEST/media" \
           BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
-            bash -x v2/module/cleaner.sh cache-clean ci >"$TEST/clean.trace" 2>&1
+            bash -x v2/module/cache-snapshot-clean.sh cache-clean ci >"$TEST/clean.trace" 2>&1
 
           test ! -e "$TEST/data/user/0/com.example.cache/cache/a.bin"
           test ! -e "$TEST/data/user/0/com.example.cache/cache/sub/b.bin"
@@ -149,7 +152,7 @@ jobs:
 
           cat > "$TEST/fakebin/find" <<'SCRIPT'
           #!/usr/bin/env bash
-          sleep 1
+          sleep 3
           exec /usr/bin/find "$@"
           SCRIPT
           chmod +x "$TEST/fakebin/find"
@@ -161,7 +164,7 @@ jobs:
           BAIZE_DATA_ROOT="$TEST/data" \
           BAIZE_MEDIA_ROOT="$TEST/media" \
           BAIZE_PACKAGE_WHITELIST="$TEST/state/native-cache-packages.conf" \
-            bash v2/module/cleaner.sh cache-clean ci > "$TEST/clean.out" 2>&1 &
+            bash v2/module/cache-snapshot-clean.sh cache-clean ci > "$TEST/clean.out" 2>&1 &
           task_pid=$!
           set -e
           for _ in $(seq 1 40); do
@@ -235,7 +238,10 @@ jobs:
           unzip -p "$ZIP" module.prop | grep -q 'version=v2.0.0-alpha42.5'
           unzip -p "$ZIP" module.prop | grep -q 'versionCode=22250'
           unzip -l "$ZIP" | grep -q 'app/baize.apk'
+          unzip -l "$ZIP" | grep -q 'cleaner.native.sh'
+          unzip -l "$ZIP" | grep -q 'cache-snapshot-clean.sh'
           unzip -l "$ZIP" | grep -q 'cleaner.sh.compat'
+          unzip -p "$ZIP" cleaner.sh | grep -q 'cache-snapshot-clean.sh'
           unzip -l "$ZIP" | grep -q 'bin/arm64-v8a/baize_engine'
           unzip -p "$ZIP" bin/arm64-v8a/baize_engine > /tmp/baize_engine_android
           file /tmp/baize_engine_android | grep -q 'ARM aarch64'

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22240
-        versionName = "2.0.0-alpha42.4"
+        versionCode = 22250
+        versionName = "2.0.0-alpha42.5"
     }
 
     buildFeatures {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CacheActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CacheActivity.kt
@@ -37,6 +37,7 @@ class CacheActivity : AppCompatActivity() {
     private var cacheBindingRequested = false
     private var moduleBindingRequested = false
     private var running = false
+    private var recovering = false
     private var snapshotId = ""
     private var total = 0
     private var page = 0
@@ -49,13 +50,12 @@ class CacheActivity : AppCompatActivity() {
             cacheBindingRequested = true
             renderConnectionState()
             renderActionState()
+            recoverRemoteOrSnapshot()
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
             cacheService = null
             cacheBindingRequested = false
-            running = false
-            pollJob?.cancel()
             renderConnectionState()
             renderActionState()
         }
@@ -67,13 +67,12 @@ class CacheActivity : AppCompatActivity() {
             moduleBindingRequested = true
             renderConnectionState()
             renderActionState()
+            recoverRemoteOrSnapshot()
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
             moduleService = null
             moduleBindingRequested = false
-            running = false
-            pollJob?.cancel()
             renderConnectionState()
             renderActionState()
         }
@@ -87,7 +86,7 @@ class CacheActivity : AppCompatActivity() {
         binding.titleText.text = "应用缓存"
         binding.subtitleText.text = "内部 cache、code_cache 与 Android/data 外部缓存"
         binding.resultTitleText.text = "缓存明细"
-        binding.safetyText.text = "扫描后会自动纳入全部安全缓存，无需逐项勾选；白名单、标准路径、软链接、挂载点和大文件限制仍会在删除前再次校验。"
+        binding.safetyText.text = "扫描只执行一次并保存 30 分钟快照；一键清理只处理刚才扫描到的缓存，不会再次扫描。退出页面后任务进度与结果仍可恢复。"
 
         adapter = ProfileCandidateAdapter { _, _ -> }
         adapter.setInteractionEnabled(false)
@@ -96,18 +95,15 @@ class CacheActivity : AppCompatActivity() {
 
         binding.backButton.setOnClickListener { finish() }
         binding.scanButton.setOnClickListener { scan() }
-        binding.cancelButton.setOnClickListener {
-            cacheService?.cancelCurrentTask()
-            moduleService?.cancelCurrentTask()
-            binding.summaryText.text = "正在安全停止当前任务…"
-        }
+        binding.cancelButton.setOnClickListener { stopTask() }
         binding.cleanButton.setOnClickListener { confirmQuickClean() }
         binding.previousButton.setOnClickListener { loadPage(page - 1) }
         binding.nextButton.setOnClickListener { loadPage(page + 1) }
 
         binding.scanButton.text = "扫描缓存明细"
         binding.cleanButton.text = "扫描后可一键清理"
-        binding.statusText.text = "正在连接 Root 扫描与自动清理引擎"
+        binding.statusText.text = "正在连接 Root 持久任务引擎"
+        binding.resultSection.visibility = View.GONE
         renderActionState()
         connectServices()
     }
@@ -123,21 +119,21 @@ class CacheActivity : AppCompatActivity() {
             RootService.bind(cacheIntent(), cacheConnection)
             cacheBindingRequested = true
         }.onFailure {
-            binding.statusText.text = it.message ?: "缓存扫描服务启动失败"
+            binding.statusText.text = it.message ?: "缓存任务服务启动失败"
         }
         runCatching {
             RootService.bind(moduleIntent(), moduleConnection)
             moduleBindingRequested = true
         }.onFailure {
-            binding.statusText.text = it.message ?: "自动清理服务启动失败"
+            binding.statusText.text = it.message ?: "模块任务服务启动失败"
         }
     }
 
     private fun renderConnectionState() {
         binding.statusText.text = when {
-            cacheService != null && moduleService != null -> "Root 扫描与一键清理引擎已连接"
-            cacheService != null -> "缓存扫描已连接 · 正在连接一键清理"
-            moduleService != null -> "一键清理已连接 · 正在连接缓存扫描"
+            cacheService != null && moduleService != null -> "Root 持久扫描与快照清理引擎已连接"
+            cacheService != null -> "缓存扫描已连接 · 正在连接快照清理"
+            moduleService != null -> "快照清理已连接 · 正在连接缓存扫描"
             else -> "Root 服务已断开"
         }
     }
@@ -154,7 +150,8 @@ class CacheActivity : AppCompatActivity() {
         adapter.setInteractionEnabled(false)
         binding.resultSection.visibility = View.GONE
         setTaskUi(true)
-        binding.summaryText.text = "正在发现真实且非空的应用缓存目录…"
+        binding.summaryText.text = "正在扫描应用缓存…"
+        startPolling()
 
         lifecycleScope.launch {
             val whitelist = preferences.getStringSet("package_whitelist", emptySet()).orEmpty()
@@ -162,34 +159,52 @@ class CacheActivity : AppCompatActivity() {
                 withContext(Dispatchers.IO) { root.scanCandidates(JSONArray(whitelist.toList()).toString()) }
             }
             running = false
+            pollJob?.cancel()
             setTaskUi(false)
             result.onSuccess { raw ->
                 val json = JSONObject(raw)
+                if (json.optString("error") == "busy") {
+                    binding.summaryText.text = "检测到后台任务，正在恢复真实进度…"
+                    recoverRemoteOrSnapshot()
+                    return@onSuccess
+                }
                 if (json.has("error")) {
                     binding.summaryText.text = json.optString("message", "扫描失败")
                     return@onSuccess
                 }
                 if (json.optBoolean("cancelled")) {
                     binding.summaryText.text = "扫描已停止 · ${json.optLong("elapsedMs")}ms"
+                    restoreSnapshot(showEmptyMessage = false)
                     return@onSuccess
                 }
-                snapshotId = json.optString("snapshotId")
-                total = json.optInt("totalCandidates")
-                quickCleanReady = total > 0
-                binding.summaryText.text = buildString {
-                    append("扫描完成 · ${json.optLong("elapsedMs")}ms\n")
-                    append("发现 $total 项真实非空缓存 · 白名单保护 ${json.optInt("whitelisted")} 项\n")
-                    append("已自动选择全部安全缓存，直接点击一键清理即可。")
-                }
-                binding.cleanButton.text = if (total > 0) "一键清理全部缓存（$total 项）" else "没有可清理缓存"
-                binding.selectionText.text = "全部安全缓存已自动纳入本次清理；列表仅用于查看明细。"
-                binding.resultSection.visibility = if (total > 0) View.VISIBLE else View.GONE
-                if (total > 0) loadPage(0)
-                renderActionState()
+                applyScanResult(json)
             }.onFailure {
                 binding.summaryText.text = "扫描失败：${it.message ?: it.javaClass.simpleName}"
             }
         }
+    }
+
+    private fun applyScanResult(json: JSONObject) {
+        snapshotId = json.optString("snapshotId")
+        total = json.optInt("totalCandidates").coerceAtLeast(0)
+        page = 0
+        quickCleanReady = snapshotId.isNotBlank() && total > 0
+        binding.summaryText.text = buildString {
+            append("扫描完成 · ${json.optLong("elapsedMs")}ms\n")
+            append("发现 $total 项真实非空缓存")
+            val files = json.optLong("totalFiles", 0L)
+            val bytes = json.optLong("totalBytes", 0L)
+            if (files > 0L) append(" · $files 个文件")
+            if (bytes > 0L) append(" · ${Formatter.formatFileSize(this@CacheActivity, bytes)}")
+            val protected = json.optInt("whitelisted", 0)
+            if (protected > 0) append(" · 白名单保护 $protected 项")
+            append("\n已保存扫描快照，清理时不会再次扫描。")
+        }
+        binding.cleanButton.text = if (quickCleanReady) "一键清理刚才扫描的缓存（$total 项）" else "没有可清理缓存"
+        binding.selectionText.text = if (quickCleanReady) "当前快照 30 分钟内有效；列表只用于查看明细。" else "没有发现可清理缓存"
+        binding.resultSection.visibility = if (quickCleanReady) View.VISIBLE else View.GONE
+        if (quickCleanReady) loadPage(0)
+        renderActionState()
     }
 
     private fun loadPage(targetPage: Int) {
@@ -209,6 +224,8 @@ class CacheActivity : AppCompatActivity() {
                 val json = JSONObject(raw)
                 if (json.has("error")) {
                     binding.selectionText.text = json.optString("message", "读取结果失败")
+                    quickCleanReady = false
+                    renderActionState()
                     return@onSuccess
                 }
                 val array = json.optJSONArray("items") ?: JSONArray()
@@ -229,7 +246,7 @@ class CacheActivity : AppCompatActivity() {
                             directories = item.optLong("directories", -1L),
                             measured = item.optBoolean("measured"),
                             complete = item.optBoolean("complete"),
-                            note = "已自动选择",
+                            note = "已纳入扫描快照",
                             selected = true
                         )
                     )
@@ -240,7 +257,7 @@ class CacheActivity : AppCompatActivity() {
                 binding.pageText.text = "${page + 1} / $pages"
                 binding.previousButton.isEnabled = page > 0
                 binding.nextButton.isEnabled = page + 1 < pages
-                binding.selectionText.text = "共 $total 项 · 当前页 ${values.size} 项 · 已自动选择全部安全缓存"
+                binding.selectionText.text = "共 $total 项 · 当前页 ${values.size} 项 · 清理只消费本次快照"
                 renderActionState()
             }.onFailure {
                 binding.selectionText.text = "读取结果失败：${it.message}"
@@ -251,8 +268,8 @@ class CacheActivity : AppCompatActivity() {
     private fun confirmQuickClean() {
         if (!quickCleanReady || moduleService == null || running) return
         AlertDialog.Builder(this)
-            .setTitle("一键清理全部安全缓存")
-            .setMessage("将自动清理本次分类下所有通过二次校验的应用缓存，不需要逐项勾选。缓存根目录会保留，白名单、软链接、挂载点和异常路径会自动跳过。")
+            .setTitle("清理刚才扫描到的缓存")
+            .setMessage("不会再次扫描。只处理当前 30 分钟快照中的安全缓存；扫描后新建或修改的文件、白名单路径、软链接、挂载点和大文件会自动跳过。")
             .setNegativeButton("取消", null)
             .setPositiveButton("立即清理") { _, _ -> quickClean() }
             .show()
@@ -260,10 +277,10 @@ class CacheActivity : AppCompatActivity() {
 
     private fun quickClean() {
         val root = moduleService ?: return
-        if (running) return
+        if (running || snapshotId.isBlank()) return
         running = true
         setTaskUi(true)
-        binding.summaryText.text = "正在自动扫描并清理全部安全缓存…"
+        binding.summaryText.text = "正在清理刚才扫描到的缓存，不会重新扫描…"
         startPolling()
 
         lifecycleScope.launch {
@@ -275,12 +292,17 @@ class CacheActivity : AppCompatActivity() {
             setTaskUi(false)
             result.onSuccess { raw ->
                 val json = JSONObject(raw)
-                val output = json.optString("output").lineSequence().filter { it.isNotBlank() }.takeLast(5).joinToString("\n")
+                if (json.optString("error") == "busy" || json.optInt("exitCode") == 3) {
+                    binding.summaryText.text = "检测到后台任务，正在恢复真实进度…"
+                    recoverRemoteOrSnapshot()
+                    return@onSuccess
+                }
+                val output = json.optString("output").lineSequence().filter { it.isNotBlank() }.takeLast(6).joinToString("\n")
                 val report = buildString {
                     append(
                         when {
                             json.optBoolean("cancelled") -> "缓存清理已停止"
-                            json.optBoolean("success") -> "全部安全缓存清理完成"
+                            json.optBoolean("success") -> "扫描快照清理完成"
                             else -> json.optString("message", "缓存清理失败")
                         }
                     )
@@ -295,14 +317,64 @@ class CacheActivity : AppCompatActivity() {
                     json.optString("message", "缓存任务已结束"),
                     report
                 )
-                quickCleanReady = false
-                snapshotId = ""
-                total = 0
-                adapter.submitPage(emptyList())
-                binding.resultSection.visibility = View.GONE
-                binding.cleanButton.text = "扫描后可一键清理"
+                if (json.optBoolean("success") && !json.optBoolean("cancelled")) clearSnapshotUi()
+                else restoreSnapshot(showEmptyMessage = false)
             }.onFailure {
                 binding.summaryText.text = "清理失败：${it.message ?: it.javaClass.simpleName}"
+            }
+        }
+    }
+
+    private fun stopTask() {
+        if (!running) return
+        cacheService?.cancelCurrentTask()
+        moduleService?.cancelCurrentTask()
+        binding.summaryText.text = "已发送停止请求，正在结束当前目录…"
+        startPolling()
+    }
+
+    private fun recoverRemoteOrSnapshot() {
+        if (recovering || running || (cacheService == null && moduleService == null)) return
+        recovering = true
+        lifecycleScope.launch {
+            val task = runCatching {
+                withContext(Dispatchers.IO) {
+                    val raw = cacheService?.getTaskState().orEmpty().ifBlank { moduleService?.getTaskState().orEmpty() }
+                    if (raw.isBlank()) null else JSONObject(raw)
+                }
+            }.getOrNull()
+            recovering = false
+            if (task?.optBoolean("running") == true) {
+                val mode = task.optString("mode", task.optString("operation"))
+                if (mode.contains("cache", ignoreCase = true)) {
+                    running = true
+                    setTaskUi(true)
+                    renderRemoteTaskState(task)
+                    startRecoveryPolling()
+                } else {
+                    binding.summaryText.text = "其他清理任务正在运行：${task.optString("phase", mode)}"
+                    renderActionState()
+                }
+            } else {
+                restoreSnapshot(showEmptyMessage = true)
+            }
+        }
+    }
+
+    private fun startRecoveryPolling() {
+        pollJob?.cancel()
+        pollJob = lifecycleScope.launch {
+            while (isActive && running) {
+                val task = readRemoteTaskState()
+                if (task?.optBoolean("running") == true) {
+                    renderRemoteTaskState(task)
+                    delay(350L)
+                    continue
+                }
+                running = false
+                setTaskUi(false)
+                restoreSnapshot(showEmptyMessage = false)
+                break
             }
         }
     }
@@ -311,23 +383,73 @@ class CacheActivity : AppCompatActivity() {
         pollJob?.cancel()
         pollJob = lifecycleScope.launch {
             while (isActive && running) {
-                val raw = runCatching { withContext(Dispatchers.IO) { moduleService?.getTaskState().orEmpty() } }.getOrNull()
-                if (!raw.isNullOrBlank()) {
-                    val json = runCatching { JSONObject(raw) }.getOrNull()
-                    if (json != null && json.optBoolean("running")) {
-                        binding.summaryText.text = buildString {
-                            append(json.optString("phase", "正在自动清理缓存"))
-                            val current = json.optInt("progress_current", json.optInt("current"))
-                            val totalState = json.optInt("progress_total", json.optInt("total"))
-                            if (totalState > 0) append(" · $current/$totalState")
-                            val path = json.optString("current_path", json.optString("currentPath"))
-                            if (path.isNotBlank()) append("\n").append(path.takeLast(92))
-                        }
-                    }
-                }
-                delay(400L)
+                val task = readRemoteTaskState()
+                if (task?.optBoolean("running") == true) renderRemoteTaskState(task)
+                delay(300L)
             }
         }
+    }
+
+    private suspend fun readRemoteTaskState(): JSONObject? = runCatching {
+        withContext(Dispatchers.IO) {
+            val raw = cacheService?.getTaskState().orEmpty().ifBlank { moduleService?.getTaskState().orEmpty() }
+            if (raw.isBlank()) null else JSONObject(raw)
+        }
+    }.getOrNull()
+
+    private fun renderRemoteTaskState(json: JSONObject) {
+        binding.summaryText.text = buildString {
+            append(json.optString("phase", "后台缓存任务正在执行"))
+            val current = json.optInt("progress_current", json.optInt("current"))
+            val totalState = json.optInt("progress_total", json.optInt("total"))
+            if (totalState > 0) append(" · $current/$totalState")
+            val path = json.optString("current_path", json.optString("currentPath"))
+            if (path.isNotBlank()) append("\n").append(path.takeLast(92))
+            if (json.optBoolean("cancelRequested")) append("\n正在安全停止…")
+        }
+    }
+
+    private fun restoreSnapshot(showEmptyMessage: Boolean) {
+        val root = cacheService ?: return
+        lifecycleScope.launch {
+            val info = runCatching {
+                withContext(Dispatchers.IO) { JSONObject(root.ping()) }
+            }.getOrNull() ?: return@launch
+            if (!info.optBoolean("snapshotReady")) {
+                clearSnapshotUi()
+                if (showEmptyMessage) binding.summaryText.text = "等待开始缓存扫描"
+                return@launch
+            }
+            snapshotId = info.optString("snapshotId")
+            total = info.optInt("snapshotItems").coerceAtLeast(0)
+            page = 0
+            quickCleanReady = snapshotId.isNotBlank() && total > 0
+            val files = info.optLong("snapshotFiles", 0L)
+            val bytes = info.optLong("snapshotBytes", 0L)
+            binding.summaryText.text = buildString {
+                append("已恢复最近一次缓存扫描快照")
+                if (total > 0) append("\n$total 项 · $files 个文件 · ${Formatter.formatFileSize(this@CacheActivity, bytes)}")
+                else append("\n没有可清理缓存")
+                append("\n可直接一键清理，不会重新扫描。")
+            }
+            binding.cleanButton.text = if (quickCleanReady) "一键清理刚才扫描的缓存（$total 项）" else "没有可清理缓存"
+            binding.selectionText.text = "已从模块状态恢复；快照 30 分钟内有效。"
+            binding.resultSection.visibility = if (quickCleanReady) View.VISIBLE else View.GONE
+            if (quickCleanReady) loadPage(0)
+            renderActionState()
+        }
+    }
+
+    private fun clearSnapshotUi() {
+        quickCleanReady = false
+        snapshotId = ""
+        total = 0
+        page = 0
+        adapter.submitPage(emptyList())
+        binding.resultSection.visibility = View.GONE
+        binding.cleanButton.text = "扫描后可一键清理"
+        binding.selectionText.text = "扫描后保存快照，再一键清理"
+        renderActionState()
     }
 
     private fun setTaskUi(active: Boolean) {
@@ -342,6 +464,7 @@ class CacheActivity : AppCompatActivity() {
 
     private fun renderActionState() {
         binding.scanButton.isEnabled = !running && cacheService != null
+        binding.cancelButton.isEnabled = running
         binding.cleanButton.isEnabled = !running && quickCleanReady && moduleService != null
     }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
@@ -15,7 +15,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Alpha 42.5 cache task bridge.
  *
  * The module owns the persistent task lock, progress file and scan snapshot. The RootService only
- * launches the task and exposes those files to the UI, so leaving the page never loses progress.
+ * launches the task and exposes those files to every UI entry, so leaving a page never loses the
+ * real progress and every clean action consumes the same on-disk snapshot without rediscovery.
  */
 class BaiZeRootService : RootService() {
     private data class CacheItem(
@@ -25,6 +26,13 @@ class BaiZeRootService : RootService() {
         val bytes: Long,
         val directories: Long,
         val path: String
+    )
+
+    private data class CleanReport(
+        val cleanedCandidates: Int,
+        val deletedFiles: Long,
+        val deletedBytes: Long,
+        val failures: Int
     )
 
     private val running = AtomicBoolean(false)
@@ -116,11 +124,42 @@ class BaiZeRootService : RootService() {
                 .toString()
         }
 
-        override fun cleanSelected(snapshotId: String?, selectionJson: String?, whitelistJson: String?): String =
-            JSONObject()
-                .put("error", "module_clean_required")
-                .put("message", "请使用扫描快照一键清理")
-                .toString()
+        override fun cleanSelected(
+            requestedSnapshotId: String?,
+            selectionJson: String?,
+            whitelistJson: String?
+        ): String {
+            if (moduleTaskAlive()) return busy("cache-clean")
+            if (!restoreSnapshotFromDisk() || !snapshotValid(requestedSnapshotId.orEmpty())) {
+                return JSONObject()
+                    .put("error", "snapshot_expired")
+                    .put("message", "缓存扫描快照已失效，不会自动重新扫描")
+                    .toString()
+            }
+            val allSafe = runCatching {
+                JSONObject(selectionJson.orEmpty()).optBoolean("__all_safe__", false)
+            }.getOrDefault(false)
+            if (!allSafe) {
+                return JSONObject()
+                    .put("error", "selection_required")
+                    .put("message", "没有授权清理当前缓存快照")
+                    .toString()
+            }
+            if (!running.compareAndSet(false, true)) return busy("cache-clean")
+            cancelled.set(false)
+            val started = SystemClock.elapsedRealtime()
+            return try {
+                runSnapshotClean(whitelistJson.orEmpty(), started)
+            } catch (error: Throwable) {
+                JSONObject()
+                    .put("error", "cache_snapshot_clean_failed")
+                    .put("message", error.message ?: error.javaClass.simpleName)
+                    .toString()
+            } finally {
+                running.set(false)
+                taskStateJson = idleState()
+            }
+        }
 
         override fun getTaskState(): String {
             val alive = moduleTaskAlive()
@@ -179,16 +218,7 @@ class BaiZeRootService : RootService() {
             .redirectOutput(appLog)
             .start()
 
-        while (!process.waitFor(200, TimeUnit.MILLISECONDS)) {
-            if (cancelled.get()) runCatching { File(stateDir, "stop").writeText("1\n") }
-            val state = readEnv(File(stateDir, "running.env"))
-            taskStateJson = state
-                .put("running", true)
-                .put("operation", "native-cache-scan")
-                .put("elapsedMs", SystemClock.elapsedRealtime() - started)
-                .toString()
-        }
-
+        pollModuleProcess(process, stateDir, started, "native-cache-scan")
         val code = process.exitValue()
         val elapsed = SystemClock.elapsedRealtime() - started
         if (code != 0) {
@@ -224,6 +254,88 @@ class BaiZeRootService : RootService() {
             .put("totalBytes", snapshotBytes)
             .put("engine", "native-c-arm64")
             .toString()
+    }
+
+    private fun runSnapshotClean(whitelistJson: String, started: Long): String {
+        val cleaner = File(MODULE_DIR, "cleaner.sh")
+        if (!cleaner.isFile) {
+            return JSONObject()
+                .put("error", "cleaner_missing")
+                .put("message", "缓存快照清理入口缺失，请重新刷入完整模块")
+                .toString()
+        }
+
+        val stateDir = File(STATE_DIR).apply { mkdirs() }
+        File(stateDir, "stop").delete()
+        writePackageWhitelist(File(stateDir, "native-cache-packages.conf"), whitelistJson)
+        val beforeCount = synchronized(resultLock) { items.size }
+        val logDir = File(stateDir, "logs").apply { mkdirs() }
+        val appLog = File(logDir, "app-cache-clean-${System.currentTimeMillis()}.log")
+        taskStateJson = JSONObject()
+            .put("running", true)
+            .put("operation", "cache-snapshot-clean")
+            .put("mode", "cache-clean")
+            .put("phase", "正在清理刚才的缓存扫描快照")
+            .put("elapsedMs", 0)
+            .toString()
+
+        val process = ProcessBuilder("/system/bin/sh", cleaner.absolutePath, "cache-clean", "app")
+            .redirectErrorStream(true)
+            .redirectOutput(appLog)
+            .start()
+
+        pollModuleProcess(process, stateDir, started, "cache-snapshot-clean")
+        val code = process.exitValue()
+        val elapsed = SystemClock.elapsedRealtime() - started
+        val wasCancelled = code == 9 || cancelled.get()
+        val latest = readEnv(File(stateDir, "latest.env"))
+        val report = parseCleanReport(File(stateDir, "reports/latest.tsv"))
+        val output = tailText(appLog, 6_000)
+        val message = latest.optString("result").ifBlank {
+            when {
+                wasCancelled -> "缓存快照清理已停止"
+                code == 0 -> "缓存快照清理完成"
+                else -> output.lineSequence().filter { it.isNotBlank() }.lastOrNull()
+                    ?: "缓存快照清理失败（代码 $code）"
+            }
+        }
+
+        if (code == 3) return busy("cache-clean")
+        if (code == 0 && !wasCancelled) clearSnapshotMemory()
+        val result = JSONObject()
+            .put("success", code == 0)
+            .put("cancelled", wasCancelled)
+            .put("elapsedMs", elapsed)
+            .put("deletedBytes", latest.optLong("bytes", report.deletedBytes).coerceAtLeast(0L))
+            .put("deletedFiles", latest.optLong("files", report.deletedFiles).coerceAtLeast(0L))
+            .put("deletedDirectories", 0L)
+            .put(
+                "cleanedCandidates",
+                if (report.cleanedCandidates > 0) report.cleanedCandidates
+                else if (code == 0) beforeCount else 0
+            )
+            .put("failures", latest.optInt("errors", report.failures).coerceAtLeast(0))
+            .put("message", message)
+            .put("output", output)
+        if (code != 0 && !wasCancelled) result.put("error", "cache_clean_exit_$code")
+        return result.toString()
+    }
+
+    private fun pollModuleProcess(
+        process: java.lang.Process,
+        stateDir: File,
+        started: Long,
+        operation: String
+    ) {
+        while (!process.waitFor(200, TimeUnit.MILLISECONDS)) {
+            if (cancelled.get()) runCatching { File(stateDir, "stop").writeText("1\n") }
+            val state = readEnv(File(stateDir, "running.env"))
+            taskStateJson = state
+                .put("running", true)
+                .put("operation", operation)
+                .put("elapsedMs", SystemClock.elapsedRealtime() - started)
+                .toString()
+        }
     }
 
     private fun restoreSnapshotFromDisk(force: Boolean = false): Boolean {
@@ -282,8 +394,12 @@ class BaiZeRootService : RootService() {
         val cmdline = runCatching {
             File(proc, "cmdline").readBytes().toString(Charsets.UTF_8).replace('\u0000', ' ')
         }.getOrDefault("")
-        return cmdline.contains("baize_v2") &&
-            (cmdline.contains("cleaner.sh") || cmdline.contains("baize_engine"))
+        return cmdline.contains("baize_v2") && (
+            cmdline.contains("cleaner.sh") ||
+                cmdline.contains("cleaner.native.sh") ||
+                cmdline.contains("cache-snapshot-clean.sh") ||
+                cmdline.contains("baize_engine")
+            )
     }
 
     private fun repairStaleTaskFiles() {
@@ -328,6 +444,31 @@ class BaiZeRootService : RootService() {
                 )
             }
         }.sortedWith(compareByDescending<CacheItem> { it.bytes }.thenBy { it.packageName }.thenBy { it.path })
+    }
+
+    private fun parseCleanReport(file: File): CleanReport {
+        if (!file.isFile) return CleanReport(0, 0L, 0L, 0)
+        var candidates = 0
+        var files = 0L
+        var bytes = 0L
+        var failures = 0
+        runCatching {
+            file.forEachLine { raw ->
+                val columns = raw.split('\t', limit = 6)
+                if (columns.size < 6 || columns[0] == "action") return@forEachLine
+                val items = columns[3].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+                val itemBytes = columns[4].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+                when (columns[0]) {
+                    "cleaned" -> {
+                        if (items > 0L) candidates += 1
+                        files += items
+                        bytes += itemBytes
+                    }
+                    "failed" -> failures += items.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+                }
+            }
+        }
+        return CleanReport(candidates, files, bytes, failures)
     }
 
     private fun snapshotValid(id: String): Boolean =

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
@@ -8,14 +8,14 @@ import com.topjohnwu.superuser.ipc.RootService
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Alpha 42.4 cache scanner bridge.
- * Discovery and directory measurement run in the module's arm64 C engine. Cleaning still goes
- * through the mature module cleaner so the existing safety checks and history format remain intact.
+ * Alpha 42.5 cache task bridge.
+ *
+ * The module owns the persistent task lock, progress file and scan snapshot. The RootService only
+ * launches the task and exposes those files to the UI, so leaving the page never loses progress.
  */
 class BaiZeRootService : RootService() {
     private data class CacheItem(
@@ -33,19 +33,34 @@ class BaiZeRootService : RootService() {
 
     @Volatile private var snapshotId = ""
     @Volatile private var snapshotCreatedAt = 0L
+    @Volatile private var snapshotFiles = 0L
+    @Volatile private var snapshotBytes = 0L
+    @Volatile private var snapshotWhitelisted = 0
     @Volatile private var items: List<CacheItem> = emptyList()
     @Volatile private var taskStateJson = idleState()
 
     private val binder = object : IBaiZeRootService.Stub() {
-        override fun ping(): String = JSONObject()
-            .put("uid", Process.myUid())
-            .put("root", Process.myUid() == 0)
-            .put("engine", "native-c-arm64-cache-v42.4")
-            .put("available", File(MODULE_DIR, "bin/arm64-v8a/baize_engine").canExecute())
-            .put("snapshotReady", snapshotValid(snapshotId))
-            .toString()
+        override fun ping(): String {
+            val ready = restoreSnapshotFromDisk()
+            return JSONObject()
+                .put("uid", Process.myUid())
+                .put("root", Process.myUid() == 0)
+                .put("engine", "native-c-arm64-cache-v42.5")
+                .put("available", File(MODULE_DIR, "bin/arm64-v8a/baize_engine").canExecute())
+                .put("snapshotReady", ready)
+                .put("snapshotId", if (ready) snapshotId else "")
+                .put("snapshotItems", if (ready) synchronized(resultLock) { items.size } else 0)
+                .put("snapshotFiles", if (ready) snapshotFiles else 0L)
+                .put("snapshotBytes", if (ready) snapshotBytes else 0L)
+                .put("snapshotWhitelisted", if (ready) snapshotWhitelisted else 0)
+                .put("snapshotCreatedAt", if (ready) snapshotCreatedAt else 0L)
+                .put("snapshotExpiresInMs", SNAPSHOT_MAX_AGE_MS)
+                .put("taskRunning", moduleTaskAlive())
+                .toString()
+        }
 
         override fun scanCandidates(whitelistJson: String?): String {
+            if (moduleTaskAlive()) return busy("cache-scan")
             if (!running.compareAndSet(false, true)) return busy("cache-scan")
             cancelled.set(false)
             val started = SystemClock.elapsedRealtime()
@@ -62,8 +77,9 @@ class BaiZeRootService : RootService() {
             }
         }
 
-        override fun getResultPage(snapshotId: String?, offset: Int, limit: Int): String {
-            val id = snapshotId.orEmpty()
+        override fun getResultPage(requestedSnapshotId: String?, offset: Int, limit: Int): String {
+            restoreSnapshotFromDisk()
+            val id = requestedSnapshotId.orEmpty()
             if (!snapshotValid(id)) {
                 return JSONObject()
                     .put("error", "snapshot_expired")
@@ -103,19 +119,27 @@ class BaiZeRootService : RootService() {
         override fun cleanSelected(snapshotId: String?, selectionJson: String?, whitelistJson: String?): String =
             JSONObject()
                 .put("error", "module_clean_required")
-                .put("message", "请使用模块一键清理执行二次安全校验")
+                .put("message", "请使用扫描快照一键清理")
                 .toString()
 
         override fun getTaskState(): String {
-            val runningState = readEnv(File(STATE_DIR, "running.env"))
-            if (runningState.length() > 0) {
-                return runningState
-                    .put("running", true)
-                    .put("cancelRequested", cancelled.get())
-                    .toString()
+            val alive = moduleTaskAlive()
+            if (alive) {
+                val runningState = readEnv(File(STATE_DIR, "running.env"))
+                if (runningState.length() > 0) {
+                    return runningState
+                        .put("running", true)
+                        .put("cancelRequested", cancelled.get())
+                        .toString()
+                }
+            } else {
+                repairStaleTaskFiles()
             }
             return runCatching {
-                JSONObject(taskStateJson).put("cancelRequested", cancelled.get()).toString()
+                JSONObject(taskStateJson)
+                    .put("running", running.get())
+                    .put("cancelRequested", cancelled.get())
+                    .toString()
             }.getOrDefault(taskStateJson)
         }
 
@@ -145,6 +169,7 @@ class BaiZeRootService : RootService() {
         taskStateJson = JSONObject()
             .put("running", true)
             .put("operation", "native-cache-scan")
+            .put("mode", "cache-scan")
             .put("phase", "正在启动 C 原生缓存扫描")
             .put("elapsedMs", 0)
             .toString()
@@ -168,6 +193,7 @@ class BaiZeRootService : RootService() {
         val elapsed = SystemClock.elapsedRealtime() - started
         if (code != 0) {
             val wasCancelled = code == 9 || cancelled.get()
+            if (code == 3) return busy("cache-scan")
             val result = JSONObject()
                 .put("cancelled", wasCancelled)
                 .put(
@@ -180,23 +206,90 @@ class BaiZeRootService : RootService() {
             return result.toString()
         }
 
-        val parsed = parseItems(File(stateDir, "cache_scan.items.tsv"))
-        val newSnapshot = UUID.randomUUID().toString()
-        synchronized(resultLock) { items = parsed }
-        snapshotId = newSnapshot
-        snapshotCreatedAt = System.currentTimeMillis()
-        val latest = readEnv(File(stateDir, "latest.env"))
+        if (!restoreSnapshotFromDisk(force = true)) {
+            return JSONObject()
+                .put("error", "snapshot_missing")
+                .put("message", "扫描完成但快照未生成，请查看原始日志")
+                .put("elapsedMs", elapsed)
+                .toString()
+        }
         return JSONObject()
             .put("cancelled", false)
             .put("elapsedMs", elapsed)
-            .put("snapshotId", newSnapshot)
+            .put("snapshotId", snapshotId)
             .put("snapshotExpiresInMs", SNAPSHOT_MAX_AGE_MS)
-            .put("totalCandidates", parsed.size)
-            .put("whitelisted", latest.optInt("whitelisted", 0))
-            .put("totalFiles", latest.optLong("regular_files", 0L))
-            .put("totalBytes", latest.optLong("bytes", 0L))
-            .put("engine", latest.optString("engine", "native-c-arm64"))
+            .put("totalCandidates", synchronized(resultLock) { items.size })
+            .put("whitelisted", snapshotWhitelisted)
+            .put("totalFiles", snapshotFiles)
+            .put("totalBytes", snapshotBytes)
+            .put("engine", "native-c-arm64")
             .toString()
+    }
+
+    private fun restoreSnapshotFromDisk(force: Boolean = false): Boolean {
+        val stateFile = File(STATE_DIR, "cache_scan.env")
+        val itemFile = File(STATE_DIR, "cache_scan.items.tsv")
+        val targetFile = File(STATE_DIR, "cache_scan.targets")
+        if (!stateFile.isFile || !itemFile.isFile || !targetFile.isFile) {
+            clearSnapshotMemory()
+            return false
+        }
+        val state = readEnv(stateFile)
+        val id = state.optString("snapshot_id").trim()
+        val epochSeconds = state.optLong("epoch", 0L)
+        val createdAt = epochSeconds * 1_000L
+        val age = System.currentTimeMillis() - createdAt
+        if (id.isBlank() || createdAt <= 0L || age !in 0..SNAPSHOT_MAX_AGE_MS) {
+            clearSnapshotMemory()
+            return false
+        }
+        if (!force && id == snapshotId && snapshotValid(id)) return true
+
+        val parsed = parseItems(itemFile)
+        val expected = state.optInt("items", parsed.size).coerceAtLeast(0)
+        if (expected > 0 && parsed.isEmpty()) {
+            clearSnapshotMemory()
+            return false
+        }
+        synchronized(resultLock) { items = parsed }
+        snapshotId = id
+        snapshotCreatedAt = createdAt
+        snapshotFiles = state.optLong("files", 0L).coerceAtLeast(0L)
+        snapshotBytes = state.optLong("bytes", 0L).coerceAtLeast(0L)
+        snapshotWhitelisted = readEnv(File(STATE_DIR, "latest.env")).optInt("whitelisted", 0).coerceAtLeast(0)
+        return true
+    }
+
+    private fun clearSnapshotMemory() {
+        synchronized(resultLock) { items = emptyList() }
+        snapshotId = ""
+        snapshotCreatedAt = 0L
+        snapshotFiles = 0L
+        snapshotBytes = 0L
+        snapshotWhitelisted = 0
+    }
+
+    private fun moduleTaskAlive(): Boolean {
+        val lockDir = File(STATE_DIR, "run.lock")
+        val pid = File(lockDir, "pid").takeIf { it.isFile }
+            ?.readText()
+            ?.trim()
+            ?.toIntOrNull()
+            ?: return false
+        if (pid <= 1) return false
+        val proc = File("/proc/$pid")
+        if (!proc.exists()) return false
+        val cmdline = runCatching {
+            File(proc, "cmdline").readBytes().toString(Charsets.UTF_8).replace('\u0000', ' ')
+        }.getOrDefault("")
+        return cmdline.contains("baize_v2") &&
+            (cmdline.contains("cleaner.sh") || cmdline.contains("baize_engine"))
+    }
+
+    private fun repairStaleTaskFiles() {
+        val lockDir = File(STATE_DIR, "run.lock")
+        if (lockDir.exists() && !moduleTaskAlive()) runCatching { lockDir.deleteRecursively() }
+        runCatching { File(STATE_DIR, "running.env").delete() }
     }
 
     private fun writePackageWhitelist(file: File, raw: String) {
@@ -238,17 +331,20 @@ class BaiZeRootService : RootService() {
     }
 
     private fun snapshotValid(id: String): Boolean =
-        id.isNotBlank() && id == snapshotId && System.currentTimeMillis() - snapshotCreatedAt in 0..SNAPSHOT_MAX_AGE_MS
+        id.isNotBlank() && id == snapshotId &&
+            System.currentTimeMillis() - snapshotCreatedAt in 0..SNAPSHOT_MAX_AGE_MS
 
     private fun readEnv(file: File): JSONObject {
         val result = JSONObject()
         if (!file.isFile) return result
-        file.forEachLine { raw ->
-            val line = raw.trim()
-            if (line.isBlank() || line.startsWith("#") || !line.contains('=')) return@forEachLine
-            val key = line.substringBefore('=').trim()
-            val value = line.substringAfter('=').trim()
-            result.put(key, value.toLongOrNull() ?: value)
+        runCatching {
+            file.forEachLine { raw ->
+                val line = raw.trim()
+                if (line.isBlank() || line.startsWith("#") || !line.contains('=')) return@forEachLine
+                val key = line.substringBefore('=').trim()
+                val value = line.substringAfter('=').trim()
+                result.put(key, value.toLongOrNull() ?: value)
+            }
         }
         return result
     }
@@ -261,7 +357,7 @@ class BaiZeRootService : RootService() {
     private fun busy(operation: String): String = JSONObject()
         .put("error", "busy")
         .put("operation", operation)
-        .put("message", "已有任务正在运行")
+        .put("message", "已有扫描或清理任务正在运行")
         .toString()
 
     private fun idleState(): String = JSONObject()
@@ -273,7 +369,7 @@ class BaiZeRootService : RootService() {
     companion object {
         private const val MODULE_DIR = "/data/adb/modules/baize_v2"
         private const val STATE_DIR = "/data/adb/baize-v2"
-        private const val SNAPSHOT_MAX_AGE_MS = 30L * 60L * 1000L
+        private const val SNAPSHOT_MAX_AGE_MS = 30L * 60L * 1_000L
         private val PACKAGE_NAME = Regex("""^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_-]+)+$""")
     }
 }

--- a/v2/module/.alpha42.5-trigger
+++ b/v2/module/.alpha42.5-trigger
@@ -1,0 +1,1 @@
+alpha42.5-cache-snapshot-regression

--- a/v2/module/.alpha42.5-trigger
+++ b/v2/module/.alpha42.5-trigger
@@ -1,1 +1,0 @@
-alpha42.5-cache-snapshot-regression

--- a/v2/module/cache-snapshot-clean.sh
+++ b/v2/module/cache-snapshot-clean.sh
@@ -153,8 +153,8 @@ wait_with_stop() {
 find_snapshot_files() {
   target=$1 output=$2 max_bytes=$3 min_days=$4
   if [ "$min_days" -gt 0 ]; then
-    # The state file is written only after scanning completes. -newer therefore protects every file
-    # created or modified after that scan, while -mtime keeps the configured retention period.
+    # cache_scan.env is created only after scanning completes. Files created or modified later are
+    # newer than this state file and therefore cannot be selected by the old snapshot.
     find "$target" -xdev -mindepth 1 -type f ! -size "+${max_bytes}c" ! -newer "$CACHE_SCAN_STATE" -mtime "+$((min_days - 1))" -print0 >"$output" 2>/dev/null &
   else
     find "$target" -xdev -mindepth 1 -type f ! -size "+${max_bytes}c" ! -newer "$CACHE_SCAN_STATE" -print0 >"$output" 2>/dev/null &
@@ -268,7 +268,9 @@ while IFS= read -r target || [ -n "$target" ]; do
   list="$TMP_DIR/cache-clean.$current.files0"
   remaining="$TMP_DIR/cache-clean.$current.remaining0"
   : >"$list"
-  if ! find_snapshot_files "$target" "$list" "$max_file_bytes" "$min_age_days"; then
+  if find_snapshot_files "$target" "$list" "$max_file_bytes" "$min_age_days"; then
+    :
+  else
     find_code=$?
     if [ "$find_code" -eq 9 ] || should_stop; then code=9; break; fi
     errors=$((errors + 1))
@@ -280,9 +282,11 @@ while IFS= read -r target || [ -n "$target" ]; do
   if [ "$count" -gt 0 ]; then
     estimated=$(bytes_from_list "$list")
     case "$estimated" in ''|*[!0-9]*) estimated=0 ;; esac
-    if ! delete_file_list "$list"; then
+    if delete_file_list "$list"; then
+      :
+    else
       delete_code=$?
-      [ "$delete_code" -eq 9 ] || should_stop && code=9
+      if [ "$delete_code" -eq 9 ] || should_stop; then code=9; fi
     fi
     existing_files_to_list "$list" "$remaining"
     remain=$(count_nul "$remaining")

--- a/v2/module/cache-snapshot-clean.sh
+++ b/v2/module/cache-snapshot-clean.sh
@@ -1,0 +1,337 @@
+#!/system/bin/sh
+
+MODDIR=${0%/*}
+TRIGGER=${2:-${1:-manual}}
+STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
+MEDIA_ROOT=${BAIZE_MEDIA_ROOT:-/data/media}
+DATA_ROOT=${BAIZE_DATA_ROOT:-/data}
+CONFIG="$STATE_DIR/config.conf"
+WHITELIST="$STATE_DIR/whitelist.conf"
+PACKAGE_WHITELIST=${BAIZE_PACKAGE_WHITELIST:-$STATE_DIR/native-cache-packages.conf}
+REPORT_DIR="$STATE_DIR/reports"
+LOG_DIR="$STATE_DIR/logs"
+LOCK_DIR="$STATE_DIR/run.lock"
+RUNNING_FILE="$STATE_DIR/running.env"
+STOP_FILE="$STATE_DIR/stop"
+HISTORY_FILE="$STATE_DIR/history.tsv"
+CACHE_SCAN_STATE="$STATE_DIR/cache_scan.env"
+CACHE_SCAN_ITEMS="$STATE_DIR/cache_scan.items.tsv"
+CACHE_SCAN_TARGETS="$STATE_DIR/cache_scan.targets"
+
+mkdir -p "$STATE_DIR" "$REPORT_DIR" "$LOG_DIR"
+[ -f "$WHITELIST" ] || : >"$WHITELIST"
+[ -f "$PACKAGE_WHITELIST" ] || : >"$PACKAGE_WHITELIST"
+
+pid_is_baize_task() {
+  pid=$1
+  [ "$pid" -gt 1 ] 2>/dev/null || return 1
+  [ -r "/proc/$pid/cmdline" ] || return 1
+  cmdline=$(tr '\000' ' ' <"/proc/$pid/cmdline" 2>/dev/null)
+  case "$cmdline" in
+    *baize_v2*cleaner.sh*|*baize-v2*cleaner.sh*|*cache-snapshot-clean.sh*|*baize_engine*) return 0 ;;
+  esac
+  return 1
+}
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  old_pid=$(sed -n '1p' "$LOCK_DIR/pid" 2>/dev/null)
+  case "$old_pid" in ''|*[!0-9]*) old_pid=0 ;; esac
+  if [ "$old_pid" -gt 1 ] && kill -0 "$old_pid" 2>/dev/null && pid_is_baize_task "$old_pid"; then
+    echo "已有扫描或清理任务正在运行"
+    exit 3
+  fi
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+  mkdir "$LOCK_DIR" 2>/dev/null || { echo "无法恢复任务锁，请重试"; exit 4; }
+fi
+printf '%s\n' "$$" >"$LOCK_DIR/pid"
+TMP_DIR="$LOCK_DIR/tmp"
+mkdir -p "$TMP_DIR"
+
+cleanup_lock() {
+  rm -f "$RUNNING_FILE" 2>/dev/null
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+}
+handle_signal() {
+  trap - EXIT INT TERM
+  : >"$STOP_FILE" 2>/dev/null
+  cleanup_lock
+  exit 9
+}
+trap cleanup_lock EXIT
+trap handle_signal INT TERM
+rm -f "$STOP_FILE"
+
+START_EPOCH=$(date +%s)
+STAMP=$(date '+%Y-%m-%d_%H-%M-%S')
+REPORT_FILE="$REPORT_DIR/$STAMP-cache-clean.tsv"
+LOG_FILE="$LOG_DIR/$STAMP-cache-clean.log"
+
+state_value() { sed -n "s/^$1=//p" "$CACHE_SCAN_STATE" 2>/dev/null | tail -n 1; }
+file_sha() { [ -f "$1" ] && sha256sum "$1" 2>/dev/null | awk 'NR==1{print $1}' || echo missing; }
+human_bytes() { awk -v b="$1" 'BEGIN { if (b>=1073741824) printf "%.2f GB",b/1073741824; else if(b>=1048576) printf "%.2f MB",b/1048576; else if(b>=1024) printf "%.2f KB",b/1024; else printf "%.0f B",b }'; }
+count_nul() { tr -cd '\000' <"$1" | wc -c | tr -d ' '; }
+bytes_from_list() {
+  [ -s "$1" ] || { echo 0; return; }
+  xargs -0 du -k <"$1" 2>/dev/null | awk '{sum += $1} END {printf "%.0f", sum * 1024}'
+}
+existing_files_to_list() {
+  source_list=$1 target_list=$2
+  : >"$target_list"
+  while IFS= read -r -d '' candidate; do
+    [ -f "$candidate" ] && [ ! -L "$candidate" ] && printf '%s\0' "$candidate" >>"$target_list"
+  done <"$source_list"
+}
+should_stop() { [ -f "$STOP_FILE" ]; }
+
+set_phase() {
+  phase=$1
+  current=${2:-0}
+  total=${3:-0}
+  path=${4:-}
+  tmp="$RUNNING_FILE.tmp.$$"
+  {
+    echo "mode=cache-clean"
+    echo "phase=$phase"
+    echo "started=$START_EPOCH"
+    echo "progress_current=$current"
+    echo "progress_total=$total"
+    printf 'current_path=%s\n' "$path" | tr '\r\n' '  '
+    echo "engine=snapshot-shell-v42.5"
+  } >"$tmp"
+  mv -f "$tmp" "$RUNNING_FILE"
+}
+
+cache_target_package() {
+  target=${1%/}
+  user="" package="" leaf=""
+  case "$target" in
+    "$DATA_ROOT"/user/*/*/cache|"$DATA_ROOT"/user/*/*/code_cache)
+      rest=${target#"$DATA_ROOT"/user/}; user=${rest%%/*}; rest=${rest#*/}; package=${rest%%/*}; leaf=${rest#*/}
+      ;;
+    "$DATA_ROOT"/user_de/*/*/cache|"$DATA_ROOT"/user_de/*/*/code_cache)
+      rest=${target#"$DATA_ROOT"/user_de/}; user=${rest%%/*}; rest=${rest#*/}; package=${rest%%/*}; leaf=${rest#*/}
+      ;;
+    "$MEDIA_ROOT"/*/Android/data/*/cache|"$MEDIA_ROOT"/*/Android/data/*/code_cache)
+      rest=${target#"$MEDIA_ROOT"/}; user=${rest%%/*}; rest=${rest#*/Android/data/}; package=${rest%%/*}; leaf=${rest#*/}
+      ;;
+    *) return 1 ;;
+  esac
+  case "$user" in ''|*[!0-9]*) return 1 ;; esac
+  case "$leaf" in cache|code_cache) ;; *) return 1 ;; esac
+  printf '%s' "$package" | grep -Eq '^[A-Za-z0-9_]+([.][A-Za-z0-9_-]+)+$' || return 1
+  printf '%s\n' "$package"
+}
+
+path_conflicts_whitelist() {
+  target=${1%/}
+  [ -f "$WHITELIST" ] || return 1
+  while IFS= read -r raw || [ -n "$raw" ]; do
+    item=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    case "$item" in ''|'#'*) continue ;; esac
+    case "$item" in /*) ;; *) continue ;; esac
+    item=${item%/}
+    [ -n "$item" ] || item=/
+    case "$target" in "$item"|"$item"/*) return 0 ;; esac
+    case "$item" in "$target"|"$target"/*) return 0 ;; esac
+  done <"$WHITELIST"
+  return 1
+}
+
+wait_with_stop() {
+  child=$1
+  while kill -0 "$child" 2>/dev/null; do
+    if should_stop; then
+      kill "$child" 2>/dev/null
+      wait "$child" 2>/dev/null
+      return 9
+    fi
+    sleep 1
+  done
+  wait "$child"
+}
+
+find_snapshot_files() {
+  target=$1 output=$2 max_bytes=$3 min_days=$4
+  if [ "$min_days" -gt 0 ]; then
+    # The state file is written only after scanning completes. -newer therefore protects every file
+    # created or modified after that scan, while -mtime keeps the configured retention period.
+    find "$target" -xdev -mindepth 1 -type f ! -size "+${max_bytes}c" ! -newer "$CACHE_SCAN_STATE" -mtime "+$((min_days - 1))" -print0 >"$output" 2>/dev/null &
+  else
+    find "$target" -xdev -mindepth 1 -type f ! -size "+${max_bytes}c" ! -newer "$CACHE_SCAN_STATE" -print0 >"$output" 2>/dev/null &
+  fi
+  find_pid=$!
+  wait_with_stop "$find_pid"
+}
+
+delete_file_list() {
+  input=$1
+  xargs -0 -n 200 rm -f -- <"$input" 2>/dev/null &
+  delete_pid=$!
+  wait_with_stop "$delete_pid"
+}
+
+write_latest() {
+  files=$1 bytes=$2 errors=$3 skipped=$4 elapsed=$5 result=$6
+  {
+    echo "mode=cache-clean"
+    echo "time=$(date '+%Y-%m-%d %H:%M:%S')"
+    echo "files=$files"
+    echo "regular_files=$files"
+    echo "empty_files=0"
+    echo "empty_dirs=0"
+    echo "hidden_items=0"
+    echo "fragment_files=0"
+    echo "bytes=$bytes"
+    echo "skipped=$skipped"
+    echo "errors=$errors"
+    echo "protected_items=$skipped"
+    echo "protected_bytes=0"
+    echo "risk_low=$files"
+    echo "risk_medium=0"
+    echo "risk_high=0"
+    echo "risk_critical=0"
+    echo "deep_slow_items=0"
+    echo "deep_mount_items=0"
+    echo "deep_truncated=0"
+    echo "cache_slow_dirs=0"
+    echo "cache_truncated=0"
+    echo "deep_progress_current=0"
+    echo "deep_progress_total=0"
+    echo "whitelisted=0"
+    echo "elapsed=$elapsed"
+    echo "engine=snapshot-shell-v42.5"
+    echo "result=$result"
+  } >"$STATE_DIR/latest.env"
+}
+
+if [ ! -s "$CACHE_SCAN_STATE" ] || [ ! -s "$CACHE_SCAN_TARGETS" ] || [ ! -s "$CACHE_SCAN_ITEMS" ]; then
+  echo "没有可用的缓存扫描快照，请先扫描"
+  exit 6
+fi
+
+epoch=$(state_value epoch)
+snapshot_id=$(state_value snapshot_id)
+expected_targets_sha=$(state_value targets_sha)
+expected_whitelist_sha=$(state_value whitelist_sha)
+expected_package_sha=$(state_value package_whitelist_sha)
+min_age_days=$(state_value min_age_days)
+max_file_bytes=$(state_value max_file_bytes)
+authorized_files=$(state_value files)
+authorized_bytes=$(state_value bytes)
+case "$epoch" in ''|*[!0-9]*) epoch=0 ;; esac
+case "$min_age_days" in ''|*[!0-9]*) min_age_days=0 ;; esac
+case "$max_file_bytes" in ''|*[!0-9]*) max_file_bytes=$((256 * 1024 * 1024)) ;; esac
+case "$authorized_files" in ''|*[!0-9]*) authorized_files=0 ;; esac
+case "$authorized_bytes" in ''|*[!0-9]*) authorized_bytes=0 ;; esac
+
+now=$(date +%s)
+age=$((now - epoch))
+if [ "$epoch" -le 0 ] || [ "$age" -lt 0 ] || [ "$age" -gt 1800 ] || [ -z "$snapshot_id" ]; then
+  echo "缓存扫描快照已过期，请重新扫描"
+  exit 6
+fi
+[ "$(file_sha "$CACHE_SCAN_TARGETS")" = "$expected_targets_sha" ] || { echo "缓存扫描快照校验失败，请重新扫描"; exit 7; }
+[ "$(file_sha "$WHITELIST")" = "$expected_whitelist_sha" ] || { echo "白名单已变化，请重新扫描"; exit 7; }
+[ "$(file_sha "$PACKAGE_WHITELIST")" = "$expected_package_sha" ] || { echo "应用白名单已变化，请重新扫描"; exit 7; }
+
+total=$(wc -l <"$CACHE_SCAN_TARGETS" 2>/dev/null | tr -d ' ')
+case "$total" in ''|*[!0-9]*) total=0 ;; esac
+[ "$total" -gt 0 ] || { echo "缓存扫描快照为空，请重新扫描"; exit 6; }
+
+printf 'action\trisk\tcategory\titems\tbytes\tpath\n' >"$REPORT_FILE"
+set_phase "正在校验缓存扫描快照" 0 "$total" ""
+current=0
+deleted_files=0
+deleted_bytes=0
+errors=0
+skipped=0
+code=0
+
+while IFS= read -r target || [ -n "$target" ]; do
+  [ -n "$target" ] || continue
+  current=$((current + 1))
+  if should_stop; then code=9; break; fi
+
+  package=$(cache_target_package "$target" 2>/dev/null)
+  if [ -z "$package" ] || [ ! -d "$target" ] || [ -L "$target" ]; then
+    skipped=$((skipped + 1))
+    printf 'protected\tlow\t缓存快照\t1\t0\t%s\n' "$target" >>"$REPORT_FILE"
+    continue
+  fi
+  if grep -Fqx -- "$package" "$PACKAGE_WHITELIST" 2>/dev/null || path_conflicts_whitelist "$target"; then
+    skipped=$((skipped + 1))
+    printf 'protected\tlow\t缓存白名单\t1\t0\t%s\n' "$target" >>"$REPORT_FILE"
+    continue
+  fi
+
+  set_phase "正在清理刚才扫描到的缓存" "$current" "$total" "$target"
+  list="$TMP_DIR/cache-clean.$current.files0"
+  remaining="$TMP_DIR/cache-clean.$current.remaining0"
+  : >"$list"
+  if ! find_snapshot_files "$target" "$list" "$max_file_bytes" "$min_age_days"; then
+    find_code=$?
+    if [ "$find_code" -eq 9 ] || should_stop; then code=9; break; fi
+    errors=$((errors + 1))
+    continue
+  fi
+
+  count=$(count_nul "$list")
+  case "$count" in ''|*[!0-9]*) count=0 ;; esac
+  if [ "$count" -gt 0 ]; then
+    estimated=$(bytes_from_list "$list")
+    case "$estimated" in ''|*[!0-9]*) estimated=0 ;; esac
+    if ! delete_file_list "$list"; then
+      delete_code=$?
+      [ "$delete_code" -eq 9 ] || should_stop && code=9
+    fi
+    existing_files_to_list "$list" "$remaining"
+    remain=$(count_nul "$remaining")
+    case "$remain" in ''|*[!0-9]*) remain=0 ;; esac
+    remaining_bytes=$(bytes_from_list "$remaining")
+    case "$remaining_bytes" in ''|*[!0-9]*) remaining_bytes=0 ;; esac
+    actual=$((count - remain))
+    [ "$actual" -lt 0 ] && actual=0
+    actual_bytes=$((estimated - remaining_bytes))
+    [ "$actual_bytes" -lt 0 ] && actual_bytes=0
+    deleted_files=$((deleted_files + actual))
+    deleted_bytes=$((deleted_bytes + actual_bytes))
+    errors=$((errors + remain))
+    printf 'cleaned\tlow\t缓存快照:%s\t%s\t%s\t%s\n' "$package" "$actual" "$actual_bytes" "$target" >>"$REPORT_FILE"
+    [ "$remain" -gt 0 ] && printf 'failed\tlow\t缓存快照:%s\t%s\t%s\t%s\n' "$package" "$remain" "$remaining_bytes" "$target" >>"$REPORT_FILE"
+  fi
+  [ "$code" -eq 9 ] && break
+  find "$target" -xdev -depth -mindepth 1 -type d -empty -delete 2>/dev/null
+  rm -f "$list" "$remaining"
+  if should_stop; then code=9; break; fi
+done <"$CACHE_SCAN_TARGETS"
+
+end=$(date +%s)
+elapsed=$((end - START_EPOCH))
+if [ "$code" -eq 9 ]; then
+  result="缓存快照清理已停止，已清理 $(human_bytes "$deleted_bytes")"
+else
+  result="缓存快照清理完成，已清理 $(human_bytes "$deleted_bytes")"
+  rm -f "$CACHE_SCAN_STATE" "$CACHE_SCAN_TARGETS" "$CACHE_SCAN_ITEMS"
+fi
+
+write_latest "$deleted_files" "$deleted_bytes" "$errors" "$skipped" "$elapsed" "$result"
+cp -f "$REPORT_FILE" "$REPORT_DIR/latest.tsv"
+{
+  echo "----------------------------------------"
+  echo "$result"
+  echo "扫描快照: $snapshot_id"
+  echo "授权项目: $authorized_files 个 / $(human_bytes "$authorized_bytes")"
+  echo "实际清理: $deleted_files 个 / $(human_bytes "$deleted_bytes") | 跳过: $skipped | 失败: $errors | 耗时: ${elapsed}s"
+} >>"$LOG_FILE"
+cp -f "$LOG_FILE" "$LOG_DIR/latest.log"
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$(date '+%Y-%m-%d %H:%M:%S')" "cache-clean" "$deleted_bytes" "$deleted_files" "0" "$errors" \
+  "$result" "$TRIGGER" "应用缓存|$deleted_bytes|$deleted_files" "$snapshot_id" >>"$HISTORY_FILE"
+tail -n 100 "$HISTORY_FILE" >"$HISTORY_FILE.tmp.$$" 2>/dev/null && mv -f "$HISTORY_FILE.tmp.$$" "$HISTORY_FILE"
+
+echo "$result"
+echo "扫描快照: $snapshot_id | 实际清理: $deleted_files 个 | 跳过: $skipped | 失败: $errors | 耗时: ${elapsed}s"
+cleanup_lock
+trap - EXIT INT TERM
+[ "$code" -eq 9 ] && exit 9
+exit 0

--- a/v2/module/cleaner.sh
+++ b/v2/module/cleaner.sh
@@ -20,6 +20,7 @@ CORPSE_SCAN_STATE="$STATE_DIR/corpse_scan.env"
 CORPSE_SCAN_TARGETS="$STATE_DIR/corpse_scan.targets"
 DEEP_SCAN_STATE="$STATE_DIR/deep_scan.env"
 DEEP_SCAN_TARGETS="$STATE_DIR/deep_scan.targets"
+CACHE_SCAN_STATE="$STATE_DIR/cache_scan.env"
 CACHE_SCAN_ITEMS="$STATE_DIR/cache_scan.items.tsv"
 CACHE_SCAN_TARGETS="$STATE_DIR/cache_scan.targets"
 DEEP_RULES=${BAIZE_DEEP_RULES:-$MODDIR/config/deep.rules}
@@ -31,48 +32,72 @@ fallback() {
 }
 
 case "$REQUEST_MODE" in
-  corpse-scan|deep-scan|cache-scan) ;;
+  corpse-scan|deep-scan|cache-scan|cache-clean) ;;
   *) fallback "$@" ;;
-esac
-
-[ -x "$NATIVE_ENGINE" ] || {
-  [ "$REQUEST_MODE" = "cache-scan" ] && { echo "原生缓存扫描器不可用" >&2; exit 8; }
-  fallback "$@"
-}
-case "$(uname -m 2>/dev/null)" in
-  aarch64|arm64) ;;
-  x86_64) [ -n "${BAIZE_NATIVE_TEST:-}" ] || {
-    [ "$REQUEST_MODE" = "cache-scan" ] && exit 8
-    fallback "$@"
-  } ;;
-  *) [ "$REQUEST_MODE" = "cache-scan" ] && exit 8; fallback "$@" ;;
 esac
 
 mkdir -p "$STATE_DIR" "$REPORT_DIR" "$LOG_DIR"
 [ -f "$CONFIG" ] || cp -f "$MODDIR/config/default.conf" "$CONFIG"
 [ -f "$WHITELIST" ] || cp -f "$MODDIR/config/whitelist.conf" "$WHITELIST"
 [ -f "$PACKAGE_WHITELIST" ] || : >"$PACKAGE_WHITELIST"
-native_enabled=$(sed -n 's/^native_scanner_enabled=//p' "$CONFIG" 2>/dev/null | tail -n 1)
-[ "$native_enabled" = "0" ] && {
-  [ "$REQUEST_MODE" = "cache-scan" ] && exit 8
-  fallback "$@"
+
+if [ "$REQUEST_MODE" != "cache-clean" ]; then
+  [ -x "$NATIVE_ENGINE" ] || {
+    [ "$REQUEST_MODE" = "cache-scan" ] && { echo "原生缓存扫描器不可用" >&2; exit 8; }
+    fallback "$@"
+  }
+  case "$(uname -m 2>/dev/null)" in
+    aarch64|arm64) ;;
+    x86_64) [ -n "${BAIZE_NATIVE_TEST:-}" ] || {
+      [ "$REQUEST_MODE" = "cache-scan" ] && exit 8
+      fallback "$@"
+    } ;;
+    *) [ "$REQUEST_MODE" = "cache-scan" ] && exit 8; fallback "$@" ;;
+  esac
+  native_enabled=$(sed -n 's/^native_scanner_enabled=//p' "$CONFIG" 2>/dev/null | tail -n 1)
+  [ "$native_enabled" = "0" ] && {
+    [ "$REQUEST_MODE" = "cache-scan" ] && exit 8
+    fallback "$@"
+  }
+fi
+
+pid_is_baize_task() {
+  pid=$1
+  [ "$pid" -gt 1 ] 2>/dev/null || return 1
+  [ -r "/proc/$pid/cmdline" ] || return 1
+  cmdline=$(tr '\000' ' ' <"/proc/$pid/cmdline" 2>/dev/null)
+  case "$cmdline" in
+    *baize_v2*cleaner.sh*|*baize-v2*cleaner.sh*|*baize_engine*) return 0 ;;
+  esac
+  return 1
 }
 
 if ! mkdir "$LOCK_DIR" 2>/dev/null; then
   old_pid=$(sed -n '1p' "$LOCK_DIR/pid" 2>/dev/null)
   case "$old_pid" in ''|*[!0-9]*) old_pid=0 ;; esac
-  if [ "$old_pid" -gt 1 ] && kill -0 "$old_pid" 2>/dev/null; then
+  if [ "$old_pid" -gt 1 ] && kill -0 "$old_pid" 2>/dev/null && pid_is_baize_task "$old_pid"; then
     echo "已有扫描或清理任务正在运行"
     exit 3
   fi
   rm -rf -- "$LOCK_DIR" 2>/dev/null
-  mkdir "$LOCK_DIR" 2>/dev/null || { echo "无法恢复任务锁"; exit 4; }
+  mkdir "$LOCK_DIR" 2>/dev/null || { echo "无法恢复任务锁，请重试"; exit 4; }
 fi
 printf '%s\n' "$$" >"$LOCK_DIR/pid"
 TMP_DIR="$LOCK_DIR/tmp"
 mkdir -p "$TMP_DIR"
-cleanup_lock() { rm -f "$RUNNING_FILE" 2>/dev/null; rm -rf -- "$LOCK_DIR" 2>/dev/null; }
-trap cleanup_lock EXIT INT TERM
+
+cleanup_lock() {
+  rm -f "$RUNNING_FILE" 2>/dev/null
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+}
+handle_signal() {
+  trap - EXIT INT TERM
+  : >"$STOP_FILE" 2>/dev/null
+  cleanup_lock
+  exit 9
+}
+trap cleanup_lock EXIT
+trap handle_signal INT TERM
 rm -f "$STOP_FILE"
 
 START_EPOCH=$(date +%s)
@@ -84,8 +109,6 @@ SUMMARY_FILE="$TMP_DIR/native-summary.env"
 LOG_FILE="$LOG_DIR/$STAMP-$REQUEST_MODE.log"
 INSTALLED_ROOT=${BAIZE_INSTALLED_ROOT:-$TMP_DIR/installed}
 mkdir -p "$INSTALLED_ROOT"
-printf 'package\tcategory\tfiles\tbytes\n' >"$REPORT_DIR/apps-latest.tsv"
-printf 'package\tcategory\tfiles\tbytes\terrors\tsample_path\n' >"$REPORT_DIR/app-items-latest.tsv"
 
 set_phase() {
   phase=$1
@@ -113,9 +136,226 @@ get_config_uint() {
   [ "$value" -gt "$max" ] && value=$max
   echo "$value"
 }
-value() { sed -n "s/^$1=//p" "$SUMMARY_FILE" 2>/dev/null | tail -n 1; }
-number() { result=$(value "$1"); case "$result" in ''|*[!0-9]*) result=0 ;; esac; echo "$result"; }
+summary_value() { sed -n "s/^$1=//p" "$SUMMARY_FILE" 2>/dev/null | tail -n 1; }
+summary_number() { result=$(summary_value "$1"); case "$result" in ''|*[!0-9]*) result=0 ;; esac; echo "$result"; }
+state_value() { sed -n "s/^$1=//p" "$CACHE_SCAN_STATE" 2>/dev/null | tail -n 1; }
 human_bytes() { awk -v b="$1" 'BEGIN { if (b>=1073741824) printf "%.2f GB",b/1073741824; else if(b>=1048576) printf "%.2f MB",b/1048576; else if(b>=1024) printf "%.2f KB",b/1024; else printf "%.0f B",b }'; }
+file_sha() { [ -f "$1" ] && sha256sum "$1" 2>/dev/null | awk 'NR==1{print $1}' || echo missing; }
+count_nul() { tr -cd '\000' <"$1" | wc -c | tr -d ' '; }
+bytes_from_list() {
+  [ -s "$1" ] || { echo 0; return; }
+  xargs -0 du -k <"$1" 2>/dev/null | awk '{sum += $1} END {printf "%.0f", sum * 1024}'
+}
+existing_files_to_list() {
+  source_list=$1 target_list=$2
+  : >"$target_list"
+  while IFS= read -r -d '' candidate; do
+    [ -f "$candidate" ] && [ ! -L "$candidate" ] && printf '%s\0' "$candidate" >>"$target_list"
+  done <"$source_list"
+}
+
+should_stop() { [ -f "$STOP_FILE" ]; }
+
+cache_target_package() {
+  target=${1%/}
+  user="" package="" leaf=""
+  case "$target" in
+    "$DATA_ROOT"/user/*/*/cache|"$DATA_ROOT"/user/*/*/code_cache)
+      rest=${target#"$DATA_ROOT"/user/}; user=${rest%%/*}; rest=${rest#*/}; package=${rest%%/*}; leaf=${rest#*/}
+      ;;
+    "$DATA_ROOT"/user_de/*/*/cache|"$DATA_ROOT"/user_de/*/*/code_cache)
+      rest=${target#"$DATA_ROOT"/user_de/}; user=${rest%%/*}; rest=${rest#*/}; package=${rest%%/*}; leaf=${rest#*/}
+      ;;
+    "$MEDIA_ROOT"/*/Android/data/*/cache|"$MEDIA_ROOT"/*/Android/data/*/code_cache)
+      rest=${target#"$MEDIA_ROOT"/}; user=${rest%%/*}; rest=${rest#*/Android/data/}; package=${rest%%/*}; leaf=${rest#*/}
+      ;;
+    *) return 1 ;;
+  esac
+  case "$user" in ''|*[!0-9]*) return 1 ;; esac
+  case "$leaf" in cache|code_cache) ;; *) return 1 ;; esac
+  printf '%s' "$package" | grep -Eq '^[A-Za-z0-9_]+([.][A-Za-z0-9_-]+)+$' || return 1
+  printf '%s\n' "$package"
+}
+
+path_conflicts_whitelist() {
+  target=${1%/}
+  [ -f "$WHITELIST" ] || return 1
+  while IFS= read -r raw || [ -n "$raw" ]; do
+    item=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    case "$item" in ''|'#'*) continue ;; esac
+    case "$item" in /*) ;; *) continue ;; esac
+    item=${item%/}
+    [ -n "$item" ] || item=/
+    case "$target" in "$item"|"$item"/*) return 0 ;; esac
+    case "$item" in "$target"|"$target"/*) return 0 ;; esac
+  done <"$WHITELIST"
+  return 1
+}
+
+write_latest() {
+  mode=$1 files=$2 bytes=$3 errors=$4 skipped=$5 elapsed=$6 result=$7
+  {
+    echo "mode=$mode"
+    echo "time=$(date '+%Y-%m-%d %H:%M:%S')"
+    echo "files=$files"
+    echo "regular_files=$files"
+    echo "empty_files=0"
+    echo "empty_dirs=0"
+    echo "hidden_items=0"
+    echo "fragment_files=0"
+    echo "bytes=$bytes"
+    echo "skipped=$skipped"
+    echo "errors=$errors"
+    echo "protected_items=$skipped"
+    echo "protected_bytes=0"
+    echo "risk_low=$files"
+    echo "risk_medium=0"
+    echo "risk_high=0"
+    echo "risk_critical=0"
+    echo "deep_slow_items=0"
+    echo "deep_mount_items=0"
+    echo "deep_truncated=0"
+    echo "cache_slow_dirs=0"
+    echo "cache_truncated=0"
+    echo "deep_progress_current=0"
+    echo "deep_progress_total=0"
+    echo "whitelisted=0"
+    echo "elapsed=$elapsed"
+    echo "engine=native-c-arm64"
+    echo "result=$result"
+  } >"$STATE_DIR/latest.env"
+}
+
+run_cache_snapshot_clean() {
+  if [ ! -s "$CACHE_SCAN_STATE" ] || [ ! -s "$CACHE_SCAN_TARGETS" ] || [ ! -s "$CACHE_SCAN_ITEMS" ]; then
+    echo "没有可用的缓存扫描快照，请先扫描"
+    exit 6
+  fi
+
+  epoch=$(state_value epoch)
+  snapshot_id=$(state_value snapshot_id)
+  expected_targets_sha=$(state_value targets_sha)
+  expected_whitelist_sha=$(state_value whitelist_sha)
+  expected_package_sha=$(state_value package_whitelist_sha)
+  min_age_days=$(state_value min_age_days)
+  max_file_bytes=$(state_value max_file_bytes)
+  authorized_files=$(state_value files)
+  authorized_bytes=$(state_value bytes)
+  case "$epoch" in ''|*[!0-9]*) epoch=0 ;; esac
+  case "$min_age_days" in ''|*[!0-9]*) min_age_days=0 ;; esac
+  case "$max_file_bytes" in ''|*[!0-9]*) max_file_bytes=$((256 * 1024 * 1024)) ;; esac
+  case "$authorized_files" in ''|*[!0-9]*) authorized_files=0 ;; esac
+  case "$authorized_bytes" in ''|*[!0-9]*) authorized_bytes=0 ;; esac
+
+  now=$(date +%s)
+  age=$((now - epoch))
+  if [ "$epoch" -le 0 ] || [ "$age" -lt 0 ] || [ "$age" -gt 1800 ] || [ -z "$snapshot_id" ]; then
+    echo "缓存扫描快照已过期，请重新扫描"
+    exit 6
+  fi
+  [ "$(file_sha "$CACHE_SCAN_TARGETS")" = "$expected_targets_sha" ] || { echo "缓存扫描快照校验失败，请重新扫描"; exit 7; }
+  [ "$(file_sha "$WHITELIST")" = "$expected_whitelist_sha" ] || { echo "白名单已变化，请重新扫描"; exit 7; }
+  [ "$(file_sha "$PACKAGE_WHITELIST")" = "$expected_package_sha" ] || { echo "应用白名单已变化，请重新扫描"; exit 7; }
+
+  total=$(wc -l <"$CACHE_SCAN_TARGETS" 2>/dev/null | tr -d ' ')
+  case "$total" in ''|*[!0-9]*) total=0 ;; esac
+  [ "$total" -gt 0 ] || { echo "缓存扫描快照为空，请重新扫描"; exit 6; }
+
+  printf 'action\trisk\tcategory\titems\tbytes\tpath\n' >"$REPORT_FILE"
+  set_phase "正在校验缓存扫描快照" 0 "$total" ""
+  elapsed_minutes=$(((age + 59) / 60))
+  cutoff_minutes=$((min_age_days * 1440 + elapsed_minutes))
+  [ "$cutoff_minutes" -lt 0 ] && cutoff_minutes=0
+
+  current=0
+  deleted_files=0
+  deleted_bytes=0
+  errors=0
+  skipped=0
+  code=0
+
+  while IFS= read -r target || [ -n "$target" ]; do
+    [ -n "$target" ] || continue
+    current=$((current + 1))
+    if should_stop; then code=9; break; fi
+
+    package=$(cache_target_package "$target" 2>/dev/null)
+    if [ -z "$package" ] || [ ! -d "$target" ] || [ -L "$target" ]; then
+      skipped=$((skipped + 1))
+      printf 'protected\tlow\t缓存快照\t1\t0\t%s\n' "$target" >>"$REPORT_FILE"
+      continue
+    fi
+    if grep -Fqx -- "$package" "$PACKAGE_WHITELIST" 2>/dev/null || path_conflicts_whitelist "$target"; then
+      skipped=$((skipped + 1))
+      printf 'protected\tlow\t缓存白名单\t1\t0\t%s\n' "$target" >>"$REPORT_FILE"
+      continue
+    fi
+
+    set_phase "正在清理刚才扫描到的缓存" "$current" "$total" "$target"
+    list="$TMP_DIR/cache-clean.$current.files0"
+    remaining="$TMP_DIR/cache-clean.$current.remaining0"
+    : >"$list"
+    find "$target" -xdev -mindepth 1 -type f ! -size "+${max_file_bytes}c" -mmin "+$cutoff_minutes" -print0 >"$list" 2>/dev/null
+    count=$(count_nul "$list")
+    case "$count" in ''|*[!0-9]*) count=0 ;; esac
+    if [ "$count" -gt 0 ]; then
+      estimated=$(bytes_from_list "$list")
+      case "$estimated" in ''|*[!0-9]*) estimated=0 ;; esac
+      xargs -0 -n 200 rm -f -- <"$list" 2>/dev/null
+      existing_files_to_list "$list" "$remaining"
+      remain=$(count_nul "$remaining")
+      case "$remain" in ''|*[!0-9]*) remain=0 ;; esac
+      remaining_bytes=$(bytes_from_list "$remaining")
+      case "$remaining_bytes" in ''|*[!0-9]*) remaining_bytes=0 ;; esac
+      actual=$((count - remain))
+      [ "$actual" -lt 0 ] && actual=0
+      actual_bytes=$((estimated - remaining_bytes))
+      [ "$actual_bytes" -lt 0 ] && actual_bytes=0
+      deleted_files=$((deleted_files + actual))
+      deleted_bytes=$((deleted_bytes + actual_bytes))
+      errors=$((errors + remain))
+      printf 'cleaned\tlow\t缓存快照:%s\t%s\t%s\t%s\n' "$package" "$actual" "$actual_bytes" "$target" >>"$REPORT_FILE"
+      [ "$remain" -gt 0 ] && printf 'failed\tlow\t缓存快照:%s\t%s\t%s\t%s\n' "$package" "$remain" "$remaining_bytes" "$target" >>"$REPORT_FILE"
+    fi
+    find "$target" -xdev -depth -mindepth 1 -type d -empty -delete 2>/dev/null
+    rm -f "$list" "$remaining"
+  done <"$CACHE_SCAN_TARGETS"
+
+  end=$(date +%s)
+  elapsed=$((end - START_EPOCH))
+  if [ "$code" -eq 9 ]; then
+    result="缓存快照清理已停止，已清理 $(human_bytes "$deleted_bytes")"
+  else
+    result="缓存快照清理完成，已清理 $(human_bytes "$deleted_bytes")"
+    rm -f "$CACHE_SCAN_STATE" "$CACHE_SCAN_TARGETS" "$CACHE_SCAN_ITEMS"
+  fi
+
+  write_latest "cache-clean" "$deleted_files" "$deleted_bytes" "$errors" "$skipped" "$elapsed" "$result"
+  cp -f "$REPORT_FILE" "$REPORT_DIR/latest.tsv"
+  {
+    echo "----------------------------------------"
+    echo "$result"
+    echo "扫描快照: $snapshot_id"
+    echo "授权项目: $authorized_files 个 / $(human_bytes "$authorized_bytes")"
+    echo "实际清理: $deleted_files 个 / $(human_bytes "$deleted_bytes") | 跳过: $skipped | 失败: $errors | 耗时: ${elapsed}s"
+  } >>"$LOG_FILE"
+  cp -f "$LOG_FILE" "$LOG_DIR/latest.log"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$(date '+%Y-%m-%d %H:%M:%S')" "cache-clean" "$deleted_bytes" "$deleted_files" "0" "$errors" \
+    "$result" "$TRIGGER" "应用缓存|$deleted_bytes|$deleted_files" "$snapshot_id" >>"$HISTORY_FILE"
+  tail -n 100 "$HISTORY_FILE" >"$HISTORY_FILE.tmp.$$" 2>/dev/null && mv -f "$HISTORY_FILE.tmp.$$" "$HISTORY_FILE"
+  echo "$result"
+  echo "扫描快照: $snapshot_id | 实际清理: $deleted_files 个 | 跳过: $skipped | 失败: $errors | 耗时: ${elapsed}s"
+  [ "$code" -eq 9 ] && exit 9
+  exit 0
+}
+
+if [ "$REQUEST_MODE" = "cache-clean" ]; then
+  run_cache_snapshot_clean
+fi
+
+printf 'package\tcategory\tfiles\tbytes\n' >"$REPORT_DIR/apps-latest.tsv"
+printf 'package\tcategory\tfiles\tbytes\terrors\tsample_path\n' >"$REPORT_DIR/app-items-latest.tsv"
 
 max_mb=$(get_config_uint max_file_mb 256 1 16384)
 MAX_FILE_BYTES=$((max_mb * 1024 * 1024))
@@ -156,6 +396,7 @@ case "$REQUEST_MODE" in
       --targets "$TARGETS_TMP" --summary "$SUMMARY_FILE" --progress "$RUNNING_FILE" --stop "$STOP_FILE" >>"$LOG_FILE" 2>&1 || code=$?
     ;;
   cache-scan)
+    rm -f "$CACHE_SCAN_STATE" "$CACHE_SCAN_TARGETS" "$CACHE_SCAN_ITEMS"
     cache_days=$(get_config_uint app_cache_days 0 0 365)
     external_days=$(get_config_uint external_cache_days 0 0 365)
     [ "$external_days" -lt "$cache_days" ] && cache_days=$external_days
@@ -175,23 +416,23 @@ if [ "$code" -ne 0 ] && [ "$code" -ne 9 ]; then
   fallback "$@"
 fi
 
-FILES=$(number files)
-DIRS=$(number dirs)
-EMPTY_DIRS=$(number empty_dirs)
-BYTES=$(number bytes)
-SKIPPED=$(number skipped)
-ERRORS=$(number errors)
-PROTECTED_ITEMS=$(number protected_items)
-PROTECTED_BYTES=$(number protected_bytes)
-CANDIDATES=$(number candidates)
-TARGET_COUNT=$(number targets)
-RISK_LOW=$(number risk_low)
-RISK_MEDIUM=$(number risk_medium)
-RISK_HIGH=$(number risk_high)
-RISK_CRITICAL=$(number risk_critical)
-MOUNT_ITEMS=$(number mount_items)
-TRUNCATED=$(number truncated)
-WHITELISTED=$(number whitelisted)
+FILES=$(summary_number files)
+DIRS=$(summary_number dirs)
+EMPTY_DIRS=$(summary_number empty_dirs)
+BYTES=$(summary_number bytes)
+SKIPPED=$(summary_number skipped)
+ERRORS=$(summary_number errors)
+PROTECTED_ITEMS=$(summary_number protected_items)
+PROTECTED_BYTES=$(summary_number protected_bytes)
+CANDIDATES=$(summary_number candidates)
+TARGET_COUNT=$(summary_number targets)
+RISK_LOW=$(summary_number risk_low)
+RISK_MEDIUM=$(summary_number risk_medium)
+RISK_HIGH=$(summary_number risk_high)
+RISK_CRITICAL=$(summary_number risk_critical)
+MOUNT_ITEMS=$(summary_number mount_items)
+TRUNCATED=$(summary_number truncated)
+WHITELISTED=$(summary_number whitelisted)
 TOTAL_FILES=$((FILES + EMPTY_DIRS))
 END_EPOCH=$(date +%s)
 ELAPSED=$((END_EPOCH - START_EPOCH))
@@ -206,20 +447,38 @@ else
       RESULT="卸载残留原生扫描完成，可清理 $SPACE"
       chmod 0600 "$TARGETS_TMP" 2>/dev/null
       mv -f "$TARGETS_TMP" "$CORPSE_SCAN_TARGETS"
-      { echo "epoch=$(date +%s)"; echo "bytes=$BYTES"; echo "items=$TOTAL_FILES"; echo "engine=native-c-arm64"; echo "targets=$CANDIDATES"; } >"$CORPSE_SCAN_STATE"
+      { echo "epoch=$(date +%s)"; echo "bytes=$BYTES"; echo "items=$TOTAL_FILES"; echo "engine=native-c-arm64"; echo "targets=$TARGET_COUNT"; } >"$CORPSE_SCAN_STATE"
       ;;
     deep-scan)
       RESULT="深度规则原生扫描完成，可清理 $SPACE"
       chmod 0600 "$TARGETS_TMP" 2>/dev/null
       mv -f "$TARGETS_TMP" "$DEEP_SCAN_TARGETS"
-      rules_sha=$(sha256sum "$DEEP_RULES" 2>/dev/null | awk 'NR==1{print $1}')
-      { echo "epoch=$(date +%s)"; echo "rules_sha=$rules_sha"; echo "bytes=$BYTES"; echo "items=$TOTAL_FILES"; echo "engine=native-c-arm64"; echo "targets=$CANDIDATES"; } >"$DEEP_SCAN_STATE"
+      rules_sha=$(file_sha "$DEEP_RULES")
+      { echo "epoch=$(date +%s)"; echo "rules_sha=$rules_sha"; echo "bytes=$BYTES"; echo "items=$TOTAL_FILES"; echo "engine=native-c-arm64"; echo "targets=$TARGET_COUNT"; } >"$DEEP_SCAN_STATE"
       ;;
     cache-scan)
       RESULT="应用缓存原生扫描完成，可清理 $SPACE"
       chmod 0600 "$TARGETS_TMP" "$ITEMS_TMP" 2>/dev/null
       mv -f "$TARGETS_TMP" "$CACHE_SCAN_TARGETS"
       mv -f "$ITEMS_TMP" "$CACHE_SCAN_ITEMS"
+      scan_epoch=$(date +%s)
+      targets_sha=$(file_sha "$CACHE_SCAN_TARGETS")
+      snapshot_id="${scan_epoch}-${targets_sha%????????????????????????????????????????????????}"
+      {
+        echo "epoch=$scan_epoch"
+        echo "snapshot_id=$snapshot_id"
+        echo "targets_sha=$targets_sha"
+        echo "whitelist_sha=$(file_sha "$WHITELIST")"
+        echo "package_whitelist_sha=$(file_sha "$PACKAGE_WHITELIST")"
+        echo "min_age_days=$cache_days"
+        echo "max_file_bytes=$MAX_FILE_BYTES"
+        echo "bytes=$BYTES"
+        echo "files=$FILES"
+        echo "items=$CANDIDATES"
+        echo "targets=$TARGET_COUNT"
+        echo "engine=native-c-arm64"
+      } >"$CACHE_SCAN_STATE"
+      chmod 0600 "$CACHE_SCAN_STATE" "$CACHE_SCAN_TARGETS" "$CACHE_SCAN_ITEMS" 2>/dev/null
       awk -F '\t' 'NR==1{next}{print $1"\t"$2"\t"$3"\t"$4}' "$CACHE_SCAN_ITEMS" >>"$REPORT_DIR/apps-latest.tsv"
       awk -F '\t' 'NR==1{next}{print $1"\t"$2"\t"$3"\t"$4"\t0\t"$6}' "$CACHE_SCAN_ITEMS" >>"$REPORT_DIR/app-items-latest.tsv"
       ;;
@@ -261,7 +520,7 @@ fi
 {
   echo "----------------------------------------"
   echo "$RESULT"
-  echo "原生引擎: C arm64 42.4"
+  echo "原生引擎: C arm64 42.5"
   echo "候选: $CANDIDATES | 文件: $FILES | 目录: $DIRS | 受保护: $PROTECTED_ITEMS | 跳过: $SKIPPED | 错误: $ERRORS | 耗时: ${ELAPSED}s"
 } >>"$LOG_FILE"
 cp -f "$LOG_FILE" "$LOG_DIR/latest.log"

--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -20,6 +20,8 @@ chmod 0700 "$STATE_DIR"
 
 [ -f "$APK" ] || abort "! 模块包中缺少 app/baize.apk"
 [ -f "$MODPATH/cleaner.sh" ] || abort "! 模块包中缺少清理入口"
+[ -f "$MODPATH/cleaner.native.sh" ] || abort "! 模块包中缺少原生扫描分流入口"
+[ -f "$MODPATH/cache-snapshot-clean.sh" ] || abort "! 模块包中缺少缓存快照执行器"
 [ -f "$MODPATH/cleaner.sh.compat" ] || abort "! 模块包中缺少兼容清理引擎"
 [ -f "$NATIVE_ENGINE" ] || abort "! 模块包中缺少 arm64 原生扫描器"
 [ -f "$MODPATH/scheduler.sh" ] || abort "! 模块包中缺少自动调度器"
@@ -29,6 +31,7 @@ chmod 0700 "$STATE_DIR"
 # 刷入新版本时只清理任务运行态与旧格式缓存快照，不动用户配置、白名单和历史。
 touch "$STATE_DIR/stop" 2>/dev/null
 pkill -f '/data/adb/modules/baize_v2/cleaner.sh' >/dev/null 2>&1 || true
+pkill -f '/data/adb/modules/baize_v2/cache-snapshot-clean.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/bin/arm64-v8a/baize_engine' >/dev/null 2>&1 || true
 rm -rf "$STATE_DIR/run.lock"
 rm -f "$STATE_DIR/running.env" "$STATE_DIR/stop"
@@ -62,7 +65,8 @@ fi
 
 chmod 0600 "$STATE_DIR/config.conf" "$STATE_DIR/whitelist.conf" "$STATE_DIR/custom.rules" 2>/dev/null
 chmod 0644 "$APK" "$HASH_FILE" 2>/dev/null
-chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/cleaner.sh.compat" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" "$NATIVE_ENGINE" 2>/dev/null
+chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/cleaner.native.sh" "$MODPATH/cache-snapshot-clean.sh" 2>/dev/null
+chmod 0755 "$MODPATH/cleaner.sh.compat" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" "$NATIVE_ENGINE" 2>/dev/null
 
 install_app() {
   pm install -r -d --user 0 "$APK" >/dev/null 2>&1 && return 0

--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -9,9 +9,10 @@ APK="$MODPATH/app/baize.apk"
 HASH_FILE="$MODPATH/app/baize.apk.sha256"
 NATIVE_ENGINE="$MODPATH/bin/arm64-v8a/baize_engine"
 
-ui_print "- 安装白泽 v2 Alpha 42.4 C 原生高速扫描版"
-ui_print "- 深度规则、应用缓存与卸载残留扫描优先使用 arm64 C 引擎"
-ui_print "- 删除、授权快照、高风险保护与异常回退继续沿用稳定 Shell 引擎"
+ui_print "- 安装白泽 v2 Alpha 42.5 缓存快照修复版"
+ui_print "- 应用缓存扫描、深度规则与卸载残留优先使用 arm64 C 引擎"
+ui_print "- 缓存一键清理只消费刚才的扫描快照，不再重新扫描全机"
+ui_print "- 退出页面可恢复真实进度，停止请求会传递给模块任务"
 ui_print "- 旧版 v1 将在迁移配置后彻底移除，不再保留双模块"
 
 mkdir -p "$STATE_DIR"
@@ -23,6 +24,15 @@ chmod 0700 "$STATE_DIR"
 [ -f "$NATIVE_ENGINE" ] || abort "! 模块包中缺少 arm64 原生扫描器"
 [ -f "$MODPATH/scheduler.sh" ] || abort "! 模块包中缺少自动调度器"
 [ -f "$MODPATH/config/deep.rules" ] || abort "! 模块包中缺少完整深度规则库"
+
+# Alpha 42.4 以前可能留下只有 running.env、但实际进程已不存在的假忙状态。
+# 刷入新版本时只清理任务运行态与旧格式缓存快照，不动用户配置、白名单和历史。
+touch "$STATE_DIR/stop" 2>/dev/null
+pkill -f '/data/adb/modules/baize_v2/cleaner.sh' >/dev/null 2>&1 || true
+pkill -f '/data/adb/modules/baize_v2/bin/arm64-v8a/baize_engine' >/dev/null 2>&1 || true
+rm -rf "$STATE_DIR/run.lock"
+rm -f "$STATE_DIR/running.env" "$STATE_DIR/stop"
+rm -f "$STATE_DIR/cache_scan.env" "$STATE_DIR/cache_scan.targets" "$STATE_DIR/cache_scan.items.tsv"
 
 # v1 and v2 use different module IDs. Copy the user's configuration once, stop the old scheduler,
 # then remove the legacy module and its state completely so future flashes have no duplicate module,

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.0.0-alpha42.4
-versionCode=22240
+version=v2.0.0-alpha42.5
+versionCode=22250
 author=惜故里丶
-description=智能清理缓存、日志、空项目与存储垃圾；深度、应用缓存与卸载残留支持 C 原生高速扫描。
+description=智能清理缓存、日志、空项目与存储垃圾；缓存扫描快照可恢复，一键清理不再重复扫描。

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/debug/app-debug.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2-Alpha42.4-Native-Deep-Cache-Module.zip"
+OUTPUT="$OUT/BaiZe-v2-Alpha42.5-Cache-Snapshot-Recovery-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -18,7 +18,7 @@ mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
 cp -a "$MODULE/." "$STAGE/"
 cp -a "$REPO/config" "$STAGE/config"
 
-# 删除逻辑继续使用成熟 Shell 引擎；C 引擎只负责高速扫描和授权快照。
+# 兼容引擎继续处理其余分类；缓存清理由模块入口消费 30 分钟扫描快照，不再调用旧全量 cache-clean。
 cp -f "$REPO/cleaner.sh" "$STAGE/cleaner.sh.compat"
 cp -f "$REPO/notify.sh" "$STAGE/notify.sh"
 cp -f "$REPO/service.sh" "$STAGE/scheduler.sh"
@@ -47,6 +47,7 @@ unzip -l "$OUTPUT" | grep -q 'cleaner.sh.compat'
 unzip -l "$OUTPUT" | grep -q 'bin/arm64-v8a/baize_engine'
 unzip -l "$OUTPUT" | grep -q 'scheduler.sh'
 unzip -l "$OUTPUT" | grep -q 'config/deep.rules'
+unzip -p "$OUTPUT" module.prop | grep -q 'version=v2.0.0-alpha42.5'
 unzip -p "$OUTPUT" config/deep.rules | sha256sum | grep -q '^73d4c898630a292753adca33298c8aabbf6146debf414b2cabbe6b87d1d5c31c'
 
-echo "已生成 Alpha 42.4 C 原生深度、缓存与卸载残留扫描模块：$OUTPUT"
+echo "已生成 Alpha 42.5 缓存快照恢复与停止修复模块：$OUTPUT"

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -18,7 +18,18 @@ mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
 cp -a "$MODULE/." "$STAGE/"
 cp -a "$REPO/config" "$STAGE/config"
 
-# 兼容引擎继续处理其余分类；缓存清理由模块入口消费 30 分钟扫描快照，不再调用旧全量 cache-clean。
+# 保留 C 扫描入口，但由一个极小分流器把 cache-clean 交给独立快照执行器。
+# 这样缓存删除不会再落回旧兼容引擎，也不会触发第二次全机扫描。
+mv "$STAGE/cleaner.sh" "$STAGE/cleaner.native.sh"
+cat >"$STAGE/cleaner.sh" <<'WRAPPER'
+#!/system/bin/sh
+MODDIR=${0%/*}
+case "${1:-scan}" in
+  cache-clean) exec /system/bin/sh "$MODDIR/cache-snapshot-clean.sh" "$@" ;;
+  *) exec /system/bin/sh "$MODDIR/cleaner.native.sh" "$@" ;;
+esac
+WRAPPER
+
 cp -f "$REPO/cleaner.sh" "$STAGE/cleaner.sh.compat"
 cp -f "$REPO/notify.sh" "$STAGE/notify.sh"
 cp -f "$REPO/service.sh" "$STAGE/scheduler.sh"
@@ -26,7 +37,8 @@ sed -i 's|STATE_DIR=/data/adb/safesweep|STATE_DIR=/data/adb/baize-v2|g' "$STAGE/
 sed -i 's|\*safesweep\*cleaner.sh\*|*baize_v2*cleaner.sh*|g; s|\*safesweep\*job-runner.sh\*|*baize_v2*job-runner.sh*|g; s|\*safesweep\*webctl.sh\*|*baize_v2*webctl.sh*|g' "$STAGE/cleaner.sh.compat"
 
 cp -f "$NATIVE" "$STAGE/bin/arm64-v8a/baize_engine"
-chmod 0755 "$STAGE/cleaner.sh" "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine"
+chmod 0755 "$STAGE/cleaner.sh" "$STAGE/cleaner.native.sh" "$STAGE/cache-snapshot-clean.sh"
+chmod 0755 "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine"
 chmod 0755 "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh"
 
 cp -f "$APK" "$STAGE/app/baize.apk"
@@ -43,10 +55,13 @@ rm -f "$OUTPUT"
 unzip -tq "$OUTPUT" >/dev/null
 unzip -l "$OUTPUT" | grep -q 'app/baize.apk'
 unzip -l "$OUTPUT" | grep -q 'cleaner.sh'
+unzip -l "$OUTPUT" | grep -q 'cleaner.native.sh'
+unzip -l "$OUTPUT" | grep -q 'cache-snapshot-clean.sh'
 unzip -l "$OUTPUT" | grep -q 'cleaner.sh.compat'
 unzip -l "$OUTPUT" | grep -q 'bin/arm64-v8a/baize_engine'
 unzip -l "$OUTPUT" | grep -q 'scheduler.sh'
 unzip -l "$OUTPUT" | grep -q 'config/deep.rules'
+unzip -p "$OUTPUT" cleaner.sh | grep -q 'cache-snapshot-clean.sh'
 unzip -p "$OUTPUT" module.prop | grep -q 'version=v2.0.0-alpha42.5'
 unzip -p "$OUTPUT" config/deep.rules | sha256sum | grep -q '^73d4c898630a292753adca33298c8aabbf6146debf414b2cabbe6b87d1d5c31c'
 


### PR DESCRIPTION
## 这次修复的问题

- 修复应用缓存扫描完成后点击一键清理又重新扫描全机的问题。
- 缓存扫描结果持久化为 30 分钟模块快照，清理只消费刚才的目标列表。
- 扫描后新建或修改的缓存文件不纳入旧快照，清理时自动跳过。
- 退出缓存页面后重新进入，可恢复真实扫描/清理进度和扫描结果。
- 停止按钮将停止信号写入模块任务，页面持续显示停止状态直到任务真正退出。
- 校验并自动清理死亡进程留下的 run.lock / running.env 假忙状态。
- 刷入 Alpha 42.5 时清理 Alpha 42.4 遗留任务状态和旧缓存快照，不动用户配置、白名单及历史。
- 版本升级为 v2.0.0-alpha42.5 / 22250。

## 清理安全边界

- 缓存根目录必须匹配标准内部 cache/code_cache 或 Android/data 外部缓存路径。
- 清理前校验快照时效、目标文件哈希、路径白名单和应用白名单哈希。
- 只删除扫描时间之前且未超过大文件限制的普通文件。
- 软链接、跨挂载、异常路径、扫描后产生的新文件继续保护。
- 其余清理分类继续使用既有稳定兼容引擎。

## 回归测试

- 扫描后持久快照文件完整生成。
- 扫描后的旧文件被清理，新建文件必须保留，证明没有重新扫描。
- 停止请求返回退出码 9，快照保留以便继续处理。
- 假任务锁自动恢复。
- Android App、ARM64 原生引擎和可刷模块 ZIP 完整构建。