### PR TITLE
feat(v2): v2.1.0 Alpha 9 文件归类界面与真实定时归类

### DIFF
--- a/.github/workflows/v2.1.0-alpha9-direct-verify.yml
+++ b/.github/workflows/v2.1.0-alpha9-direct-verify.yml
@@ -69,7 +69,21 @@ jobs:
 
       - name: Build Android App
         working-directory: v2
-        run: gradle --no-daemon :app:assembleDebug
+        shell: bash
+        run: |
+          set +e
+          gradle --no-daemon :app:assembleDebug > alpha9-gradle.log 2>&1
+          code=$?
+          tail -n 160 alpha9-gradle.log
+          exit "$code"
+
+      - name: Upload Android build failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-alpha9-build-failure-log
+          path: v2/alpha9-gradle.log
+          if-no-files-found: error
 
       - name: Package Alpha 9 module
         working-directory: v2

--- a/.github/workflows/v2.1.0-alpha9-direct-verify.yml
+++ b/.github/workflows/v2.1.0-alpha9-direct-verify.yml
@@ -1,0 +1,99 @@
+name: BaiZe v2.1.0 Alpha 9 Direct Verify
+
+on:
+  pull_request:
+    branches: [feat/v2.1.0-alpha8-file-organizer]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Alpha 9 source
+        uses: actions/checkout@v4
+        with:
+          ref: feat/v2.1.0-alpha9-organizer-ui-schedule
+          fetch-depth: 0
+
+      - name: Check source and shell syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check origin/feat/v2.1.0-alpha8-file-organizer...HEAD
+          sh -n v2/module/one-pass-scan.sh
+          sh -n v2/module/native-scan.sh
+          sh -n v2/scripts/build-native.sh
+          sh -n v2/scripts/package-module.sh
+
+      - name: Verify organizer UI and schedule
+        shell: bash
+        run: |
+          set -euo pipefail
+          UI=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+          WORKER=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+          grep -q '归类到哪里' "$UI"
+          grep -q '内部存储 / BaiZe归类' "$UI"
+          grep -q '撤销上一次归类' "$UI"
+          grep -q '保存定时归类' "$UI"
+          grep -q '去向：BaiZe归类/' "$UI"
+          grep -q 'PeriodicWorkRequestBuilder<FileOrganizerWorker>' "$WORKER"
+          grep -q 'ExistingPeriodicWorkPolicy.UPDATE' "$WORKER"
+          grep -q 'scanFileOrganizer' "$WORKER"
+          grep -q 'applyFileOrganizer' "$WORKER"
+          grep -q 'screenOffOnly' "$WORKER"
+          grep -q 'setRequiresCharging' "$WORKER"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build ARM64 scanner
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build Android App
+        working-directory: v2
+        run: gradle --no-daemon :app:assembleDebug
+
+      - name: Package Alpha 9 module
+        working-directory: v2
+        run: sh scripts/package-module.sh
+
+      - name: Verify final package
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP=v2/dist/BaiZe-v2.1.0-alpha9-Module.zip
+          test -s "$ZIP"
+          unzip -tq "$ZIP"
+          unzip -p "$ZIP" module.prop | grep -qx 'version=v2.1.0-alpha9'
+          unzip -p "$ZIP" module.prop | grep -qx 'versionCode=22409'
+          grep -q 'versionName = "2.1.0-alpha9"' v2/app/build.gradle.kts
+          grep -q 'versionCode = 22409' v2/app/build.gradle.kts
+          ! unzip -Z1 "$ZIP" | grep -Eq '^(webroot|webui|www|ksu-webui)/'
+          sha256sum "$ZIP" | tee "$ZIP.sha256"
+
+      - name: Upload Alpha 9 module
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.1.0-alpha9-Organizer-UI-Schedule
+          if-no-files-found: error
+          path: |
+            v2/dist/BaiZe-v2.1.0-alpha9-Module.zip
+            v2/dist/BaiZe-v2.1.0-alpha9-Module.zip.sha256

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22408
-        versionName = "2.1.0-alpha8"
+        versionCode = 22409
+        versionName = "2.1.0-alpha9"
     }
 
     buildFeatures {
@@ -44,17 +44,13 @@ android {
     }
 
     packaging {
-        resources.excludes += setOf(
-            "META-INF/AL2.0",
-            "META-INF/LGPL2.1"
-        )
+        resources.excludes += setOf("META-INF/AL2.0", "META-INF/LGPL2.1")
     }
 }
 
 dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2025.06.01")
     implementation(composeBom)
-
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
     implementation("androidx.activity:activity-compose:1.10.1")
@@ -62,6 +58,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1")
     implementation("androidx.datastore:datastore-preferences:1.2.1")
+    implementation("androidx.work:work-runtime-ktx:2.10.2")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
@@ -75,7 +72,6 @@ dependencies {
     implementation("dev.chrisbanes.haze:haze:1.6.10")
     implementation("dev.chrisbanes.haze:haze-materials:1.6.10")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
-
     implementation("com.github.topjohnwu.libsu:core:6.0.0")
     implementation("com.github.topjohnwu.libsu:service:6.0.0")
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
@@ -11,30 +11,34 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.FolderCopy
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Restore
+import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Stop
+import androidx.compose.material.icons.rounded.Timer
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -42,11 +46,14 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -56,6 +63,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -79,12 +87,14 @@ class FileOrganizerActivity : ComponentActivity() {
     private var service: IProfileRootService? = null
     private var bound = false
     private var state by mutableStateOf(FileOrganizerUiState())
+    private var schedule by mutableStateOf(FileOrganizerScheduleSettings())
+    private var scheduleSavedText by mutableStateOf("")
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
             service = IProfileRootService.Stub.asInterface(binder)
             bound = true
-            state = state.copy(connected = true, status = "已连接 Root 文件归类服务")
+            state = state.copy(connected = true, status = "文件归类服务已就绪")
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
@@ -97,11 +107,14 @@ class FileOrganizerActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        schedule = FileOrganizerWorker.loadSettings(this)
         setContent {
             val appearance = appearanceViewModel.settings.collectAsStateWithLifecycle().value
             BaiZeTheme(appearance) {
                 FileOrganizerScreen(
                     state = state,
+                    schedule = schedule,
+                    scheduleSavedText = scheduleSavedText,
                     onBack = ::finish,
                     onScan = ::scan,
                     onToggle = ::toggle,
@@ -109,11 +122,24 @@ class FileOrganizerActivity : ComponentActivity() {
                     onCategory = { state = state.copy(category = it) },
                     onApply = ::applySelected,
                     onUndo = ::undoLast,
-                    onStop = { service?.cancelCurrentTask() }
+                    onStop = {
+                        service?.cancelCurrentTask()
+                        state = state.copy(status = "正在停止当前任务…")
+                    },
+                    onScheduleChange = {
+                        schedule = it
+                        scheduleSavedText = ""
+                    },
+                    onSaveSchedule = ::saveSchedule
                 )
             }
         }
         bindService()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        schedule = FileOrganizerWorker.loadSettings(this)
     }
 
     private fun bindService() {
@@ -131,10 +157,25 @@ class FileOrganizerActivity : ComponentActivity() {
         }
     }
 
+    private fun saveSchedule() {
+        FileOrganizerWorker.saveAndSchedule(this, schedule)
+        schedule = FileOrganizerWorker.loadSettings(this)
+        scheduleSavedText = if (schedule.enabled) {
+            "已保存：每 ${schedule.intervalHours} 小时自动归类"
+        } else {
+            "定时归类已关闭"
+        }
+    }
+
     private fun scan() {
         val root = service ?: return
         if (state.running) return
-        state = state.copy(running = true, status = "正在扫描本机所有下载目录…", items = emptyList(), selected = emptySet())
+        state = state.copy(
+            running = true,
+            status = "正在扫描本机所有下载目录…",
+            items = emptyList(),
+            selected = emptySet()
+        )
         lifecycleScope.launch {
             val json = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.scanFileOrganizer()) }.getOrElse {
@@ -142,7 +183,14 @@ class FileOrganizerActivity : ComponentActivity() {
                 }
             }
             if (json.has("error")) {
-                state = state.copy(running = false, status = json.optString("message", "文件归类扫描失败"))
+                state = state.copy(
+                    running = false,
+                    status = json.optString("message", "文件归类扫描失败")
+                )
+                return@launch
+            }
+            if (json.optBoolean("cancelled")) {
+                state = state.copy(running = false, status = "文件归类扫描已停止")
                 return@launch
             }
             val items = parseItems(json.optJSONArray("items"))
@@ -164,7 +212,7 @@ class FileOrganizerActivity : ComponentActivity() {
         val root = service ?: return
         if (state.running || state.snapshotId.isBlank() || state.selected.isEmpty()) return
         val request = JSONObject().put("ids", JSONArray(state.selected.toList())).toString()
-        state = state.copy(running = true, status = "正在按不可变计划归类所选文件…")
+        state = state.copy(running = true, status = "正在归类所选文件…")
         lifecycleScope.launch {
             val json = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.applyFileOrganizer(state.snapshotId, request)) }.getOrElse {
@@ -172,7 +220,10 @@ class FileOrganizerActivity : ComponentActivity() {
                 }
             }
             if (json.has("error")) {
-                state = state.copy(running = false, status = json.optString("message", "文件归类失败"))
+                state = state.copy(
+                    running = false,
+                    status = json.optString("message", "文件归类失败")
+                )
                 return@launch
             }
             val moved = json.optInt("moved")
@@ -185,7 +236,9 @@ class FileOrganizerActivity : ComponentActivity() {
                 items = emptyList(),
                 selected = emptySet(),
                 undoAvailable = json.optBoolean("undoAvailable"),
-                status = "归类完成：移动 $moved 个 · 跳过 $skipped 个 · 失败 $failed 个 · ${Formatter.formatFileSize(this@FileOrganizerActivity, bytes)}"
+                status = "归类完成：移动 $moved 个 · 跳过 $skipped 个 · 失败 $failed 个 · ${
+                    Formatter.formatFileSize(this@FileOrganizerActivity, bytes)
+                }"
             )
         }
     }
@@ -207,7 +260,9 @@ class FileOrganizerActivity : ComponentActivity() {
             state = state.copy(
                 running = false,
                 undoAvailable = json.optBoolean("undoAvailable"),
-                status = "撤销完成：恢复 ${json.optInt("restored")} 个 · 跳过 ${json.optInt("skipped")} 个 · 失败 ${json.optInt("failed")} 个"
+                status = "撤销完成：恢复 ${json.optInt("restored")} 个 · 跳过 ${
+                    json.optInt("skipped")
+                } 个 · 失败 ${json.optInt("failed")} 个"
             )
         }
     }
@@ -240,7 +295,8 @@ class FileOrganizerActivity : ComponentActivity() {
                     category = item.optString("category", "其他"),
                     bytes = item.optLong("bytes"),
                     sourceGroup = item.optString("sourceGroup", "公共下载"),
-                    sourceDisplay = item.optString("sourceDisplay")
+                    sourceDisplay = item.optString("sourceDisplay"),
+                    destinationName = item.optString("destinationName", item.optString("name"))
                 )
             )
         }
@@ -258,7 +314,8 @@ private data class FileOrganizerItem(
     val category: String,
     val bytes: Long,
     val sourceGroup: String,
-    val sourceDisplay: String
+    val sourceDisplay: String,
+    val destinationName: String
 )
 
 private data class FileOrganizerUiState(
@@ -276,6 +333,8 @@ private data class FileOrganizerUiState(
 @Composable
 private fun FileOrganizerScreen(
     state: FileOrganizerUiState,
+    schedule: FileOrganizerScheduleSettings,
+    scheduleSavedText: String,
     onBack: () -> Unit,
     onScan: () -> Unit,
     onToggle: (String) -> Unit,
@@ -283,7 +342,9 @@ private fun FileOrganizerScreen(
     onCategory: (String) -> Unit,
     onApply: () -> Unit,
     onUndo: () -> Unit,
-    onStop: () -> Unit
+    onStop: () -> Unit,
+    onScheduleChange: (FileOrganizerScheduleSettings) -> Unit,
+    onSaveSchedule: () -> Unit
 ) {
     val categories = listOf("全部", "图片", "视频", "音频", "文档", "安装包", "压缩包", "电子书", "其他")
     val visible = if (state.category == "全部") state.items else state.items.filter { it.category == state.category }
@@ -294,123 +355,54 @@ private fun FileOrganizerScreen(
             TopAppBar(
                 title = {
                     Column {
-                        Text("文件归类", fontWeight = FontWeight.Black)
-                        Text("所有下载目录 · 不覆盖同名文件", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("文件归类", fontWeight = FontWeight.Black, fontSize = 24.sp)
+                        Text("扫描、预览、归类与定时", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Rounded.ArrowBack, contentDescription = "返回")
-                    }
-                },
+                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") } },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }
     ) { padding ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(padding),
-            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 32.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp)
+            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(padding),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 36.dp),
+            verticalArrangement = Arrangement.spacedBy(14.dp)
         ) {
-            item {
-                Card(
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
-                    shape = RoundedCornerShape(24.dp)
-                ) {
-                    Column(Modifier.padding(18.dp)) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Rounded.FolderCopy, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                            Spacer(Modifier.size(12.dp))
-                            Column(Modifier.weight(1f)) {
-                                Text(state.status, fontWeight = FontWeight.Bold)
-                                Text(
-                                    "扫描公共 Download、应用自建下载目录、Android/data、Android/media 及 Root 可读取的应用私有下载子目录。扫描后变化的文件会自动跳过。",
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontSize = 11.sp,
-                                    lineHeight = 16.sp
-                                )
-                            }
-                            if (state.running) CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
-                        }
-                        Spacer(Modifier.height(14.dp))
-                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Button(onClick = onScan, enabled = state.connected && !state.running, modifier = Modifier.weight(1f)) {
-                                Icon(Icons.Rounded.Refresh, contentDescription = null)
-                                Spacer(Modifier.size(6.dp))
-                                Text("扫描下载目录")
-                            }
-                            OutlinedButton(onClick = onUndo, enabled = state.connected && !state.running && state.undoAvailable) {
-                                Icon(Icons.Rounded.Restore, contentDescription = null)
-                                Spacer(Modifier.size(6.dp))
-                                Text("撤销")
-                            }
-                            if (state.running) {
-                                OutlinedButton(onClick = onStop) {
-                                    Icon(Icons.Rounded.Stop, contentDescription = null)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
+            item { OrganizerHeroCard(state, onScan, onUndo, onStop) }
+            item { DestinationCard() }
+            item { ScheduleCard(schedule, scheduleSavedText, onScheduleChange, onSaveSchedule) }
             if (state.items.isNotEmpty()) {
+                item { CategoryStrip(categories, state.category, onCategory) }
                 item {
-                    LazyColumnLikeChipRow(categories, state.category, onCategory)
-                }
-                item {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text("${visible.size} 个文件 · 已选 ${state.selected.size}", fontWeight = FontWeight.Bold)
+                    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Column {
+                            Text("${visible.size} 个文件", fontWeight = FontWeight.Black, fontSize = 18.sp)
+                            Text("已选 ${state.selected.size} 个", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                        }
                         Spacer(Modifier.weight(1f))
-                        Text(
-                            if (visibleIds.isNotEmpty() && visibleIds.all { it in state.selected }) "取消本页" else "选择本页",
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.clickable { onSelectAll(visibleIds) }.padding(8.dp),
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                }
-                items(visible, key = { it.id }) { item ->
-                    Card(
-                        modifier = Modifier.fillMaxWidth().clickable { onToggle(item.id) },
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-                        shape = RoundedCornerShape(20.dp)
-                    ) {
-                        Row(Modifier.padding(horizontal = 14.dp, vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
-                            Checkbox(checked = item.id in state.selected, onCheckedChange = { onToggle(item.id) })
-                            Column(Modifier.weight(1f)) {
-                                Text(item.name, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                                Text(
-                                    "${item.category} · ${item.sourceGroup} · ${Formatter.formatFileSize(androidx.compose.ui.platform.LocalContext.current, item.bytes)}",
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontSize = 11.sp,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                Text(
-                                    item.sourceDisplay,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontSize = 9.sp,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
+                        Surface(modifier = Modifier.clickable { onSelectAll(visibleIds) }, color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(50)) {
+                            Text(
+                                if (visibleIds.isNotEmpty() && visibleIds.all { it in state.selected }) "取消本页" else "选择本页",
+                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 12.sp
+                            )
                         }
                     }
                 }
+                items(visible, key = { it.id }) { item -> OrganizerFileCard(item, item.id in state.selected) { onToggle(item.id) } }
                 item {
                     Button(
                         onClick = onApply,
                         enabled = state.connected && !state.running && state.selected.isNotEmpty(),
-                        modifier = Modifier.fillMaxWidth().height(56.dp),
-                        shape = RoundedCornerShape(20.dp)
+                        modifier = Modifier.fillMaxWidth().height(58.dp),
+                        shape = RoundedCornerShape(22.dp)
                     ) {
                         Icon(Icons.Rounded.CheckCircle, contentDescription = null)
                         Spacer(Modifier.size(8.dp))
-                        Text("归类所选 ${state.selected.size} 个文件", fontWeight = FontWeight.Black)
+                        Text("归类所选 ${state.selected.size} 个文件", fontWeight = FontWeight.Black, maxLines = 1)
                     }
                 }
             }
@@ -419,33 +411,162 @@ private fun FileOrganizerScreen(
 }
 
 @Composable
-private fun LazyColumnLikeChipRow(
-    categories: List<String>,
-    selected: String,
-    onCategory: (String) -> Unit
-) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
-    ) {
-        categories.take(5).forEach { category ->
-            FilterChip(
-                selected = selected == category,
-                onClick = { onCategory(category) },
-                label = { Text(category, fontSize = 10.sp) }
-            )
+private fun OrganizerHeroCard(state: FileOrganizerUiState, onScan: () -> Unit, onUndo: () -> Unit, onStop: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer), shape = RoundedCornerShape(30.dp)) {
+        Column(Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary) {
+                    Box(modifier = Modifier.size(46.dp), contentAlignment = Alignment.Center) {
+                        Icon(Icons.Rounded.FolderCopy, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary)
+                    }
+                }
+                Spacer(Modifier.size(14.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(state.status, fontWeight = FontWeight.Black, fontSize = 18.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
+                    Text("只读取明确命名为 Download、Downloads 或“下载”的目录；扫描后变化的文件会自动跳过。", color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f), fontSize = 12.sp, lineHeight = 18.sp)
+                }
+                if (state.running) CircularProgressIndicator(modifier = Modifier.size(26.dp), strokeWidth = 2.5.dp, color = MaterialTheme.colorScheme.primary)
+            }
+            Spacer(Modifier.height(18.dp))
+            if (state.running) {
+                OutlinedButton(onClick = onStop, modifier = Modifier.fillMaxWidth().height(54.dp), shape = RoundedCornerShape(20.dp)) {
+                    Icon(Icons.Rounded.Stop, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("停止当前任务", fontWeight = FontWeight.Black, maxLines = 1)
+                }
+            } else {
+                Button(onClick = onScan, enabled = state.connected, modifier = Modifier.fillMaxWidth().height(56.dp), shape = RoundedCornerShape(20.dp)) {
+                    Icon(Icons.Rounded.Refresh, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("扫描所有下载目录", fontWeight = FontWeight.Black, maxLines = 1)
+                }
+                Spacer(Modifier.height(10.dp))
+                OutlinedButton(onClick = onUndo, enabled = state.connected && state.undoAvailable, modifier = Modifier.fillMaxWidth().height(50.dp), shape = RoundedCornerShape(18.dp)) {
+                    Icon(Icons.Rounded.Restore, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("撤销上一次归类", fontWeight = FontWeight.Bold, maxLines = 1)
+                }
+            }
         }
     }
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(6.dp)
-    ) {
-        categories.drop(5).forEach { category ->
-            FilterChip(
-                selected = selected == category,
-                onClick = { onCategory(category) },
-                label = { Text(category, fontSize = 10.sp) }
-            )
+}
+
+@Composable
+private fun DestinationCard() {
+    val destinationCategories = listOf("图片", "视频", "音频", "文档", "安装包", "压缩包", "电子书", "其他")
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer), shape = RoundedCornerShape(28.dp)) {
+        Column(Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Rounded.AutoAwesome, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.size(10.dp))
+                Column {
+                    Text("归类到哪里", fontWeight = FontWeight.Black, fontSize = 18.sp)
+                    Text("内部存储 / BaiZe归类", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
+                }
+            }
+            Spacer(Modifier.height(14.dp))
+            Text("每个文件会移动到对应分类子目录，原文件名保持不变；目标中已有同名文件时直接跳过，不会覆盖。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 18.sp)
+            Spacer(Modifier.height(14.dp))
+            destinationCategories.chunked(4).forEachIndexed { rowIndex, row ->
+                if (rowIndex > 0) Spacer(Modifier.height(8.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    row.forEach { category ->
+                        Surface(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(14.dp)) {
+                            Text(category, modifier = Modifier.padding(vertical = 9.dp), fontSize = 11.sp, fontWeight = FontWeight.Bold, textAlign = androidx.compose.ui.text.style.TextAlign.Center, color = MaterialTheme.colorScheme.onSecondaryContainer)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScheduleCard(settings: FileOrganizerScheduleSettings, savedText: String, onChange: (FileOrganizerScheduleSettings) -> Unit, onSave: () -> Unit) {
+    val context = LocalContext.current
+    val intervals = listOf(6, 12, 24, 72, 168)
+    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer), shape = RoundedCornerShape(28.dp)) {
+        Column(Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.tertiaryContainer) {
+                    Box(modifier = Modifier.size(42.dp), contentAlignment = Alignment.Center) {
+                        Icon(Icons.Rounded.Schedule, contentDescription = null, tint = MaterialTheme.colorScheme.onTertiaryContainer)
+                    }
+                }
+                Spacer(Modifier.size(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text("定时归类", fontWeight = FontWeight.Black, fontSize = 18.sp)
+                    Text(if (settings.enabled) "每 ${settings.intervalHours} 小时执行一次" else "当前未启用", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                }
+                Switch(checked = settings.enabled, onCheckedChange = { onChange(settings.copy(enabled = it)) })
+            }
+            Spacer(Modifier.height(14.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Spacer(Modifier.height(14.dp))
+            Text("执行间隔", fontWeight = FontWeight.Bold, fontSize = 13.sp)
+            Spacer(Modifier.height(8.dp))
+            Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                intervals.forEach { hours ->
+                    FilterChip(
+                        selected = settings.intervalHours == hours,
+                        onClick = { onChange(settings.copy(intervalHours = hours)) },
+                        label = { Text(when (hours) { 24 -> "每天"; 72 -> "每 3 天"; 168 -> "每周"; else -> "每 $hours 小时" }, maxLines = 1) },
+                        leadingIcon = if (settings.intervalHours == hours) ({ Icon(Icons.Rounded.Timer, contentDescription = null, modifier = Modifier.size(16.dp)) }) else null
+                    )
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            ScheduleToggleRow("仅息屏时执行", "亮屏时等待，避免打扰正在使用的应用", settings.screenOffOnly) { onChange(settings.copy(screenOffOnly = it)) }
+            ScheduleToggleRow("仅充电时执行", "交给系统调度器等待充电条件满足", settings.chargingOnly) { onChange(settings.copy(chargingOnly = it)) }
+            Spacer(Modifier.height(8.dp))
+            Surface(color = MaterialTheme.colorScheme.surfaceContainerHigh, shape = RoundedCornerShape(18.dp)) {
+                Column(Modifier.padding(14.dp)) {
+                    Text("上次执行：${FileOrganizerWorker.lastRunText(context, settings)}", fontWeight = FontWeight.Bold, fontSize = 12.sp)
+                    Text(settings.lastResult, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, lineHeight = 16.sp)
+                }
+            }
+            Spacer(Modifier.height(12.dp))
+            Button(onClick = onSave, modifier = Modifier.fillMaxWidth().height(52.dp), shape = RoundedCornerShape(18.dp)) {
+                Icon(Icons.Rounded.CheckCircle, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text(if (settings.enabled) "保存定时归类" else "保存并关闭定时", fontWeight = FontWeight.Black, maxLines = 1)
+            }
+            if (savedText.isNotBlank()) Text(savedText, modifier = Modifier.padding(top = 8.dp), color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun ScheduleToggleRow(title: String, subtitle: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth().clickable { onCheckedChange(!checked) }.padding(vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) {
+            Text(title, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, lineHeight = 16.sp)
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun CategoryStrip(categories: List<String>, selected: String, onCategory: (String) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        categories.forEach { category -> FilterChip(selected = selected == category, onClick = { onCategory(category) }, label = { Text(category, maxLines = 1) }) }
+    }
+}
+
+@Composable
+private fun OrganizerFileCard(item: FileOrganizerItem, checked: Boolean, onToggle: () -> Unit) {
+    val context = LocalContext.current
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow), shape = RoundedCornerShape(22.dp)) {
+        Row(modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(checked = checked, onCheckedChange = { onToggle() })
+            Spacer(Modifier.size(4.dp))
+            Column(Modifier.weight(1f)) {
+                Text(item.name, fontWeight = FontWeight.Black, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("${item.category} · ${item.sourceGroup} · ${Formatter.formatFileSize(context, item.bytes)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("来源：${item.sourceDisplay}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text("去向：BaiZe归类/${item.category}/${item.destinationName}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            }
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
@@ -1,0 +1,194 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.os.PowerManager
+import android.text.format.Formatter
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.BaiZeProfileRootService
+import io.github.xgl34222220.baize.root.IProfileRootService
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import org.json.JSONArray
+import org.json.JSONObject
+import java.text.DateFormat
+import java.util.Date
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal data class FileOrganizerScheduleSettings(
+    val enabled: Boolean = false,
+    val intervalHours: Int = 24,
+    val chargingOnly: Boolean = false,
+    val screenOffOnly: Boolean = true,
+    val lastRunEpoch: Long = 0L,
+    val lastResult: String = "尚未执行定时归类"
+)
+
+class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val settings = loadSettings(applicationContext)
+        if (!settings.enabled) return Result.success()
+
+        val power = applicationContext.getSystemService(PowerManager::class.java)
+        if (settings.screenOffOnly && power?.isInteractive == true) {
+            writeResult(applicationContext, "等待息屏后执行")
+            return Result.retry()
+        }
+
+        val session = runCatching { withTimeout(ROOT_BIND_TIMEOUT_MS) { bindRootService() } }.getOrElse {
+            writeResult(applicationContext, "Root 服务连接失败：${it.message ?: it.javaClass.simpleName}")
+            return Result.retry()
+        }
+
+        return try {
+            val scan = runCatching { JSONObject(session.service.scanFileOrganizer()) }.getOrElse {
+                writeResult(applicationContext, "扫描失败：${it.message ?: it.javaClass.simpleName}")
+                return Result.retry()
+            }
+            if (scan.has("error")) {
+                writeResult(applicationContext, scan.optString("message", "文件归类扫描失败"))
+                return Result.retry()
+            }
+            if (scan.optBoolean("cancelled")) {
+                writeResult(applicationContext, "定时归类已停止")
+                return Result.success()
+            }
+
+            val snapshotId = scan.optString("snapshotId")
+            val items = scan.optJSONArray("items") ?: JSONArray()
+            val ids = JSONArray()
+            for (index in 0 until items.length()) {
+                val id = items.optJSONObject(index)?.optString("id").orEmpty()
+                if (id.isNotBlank()) ids.put(id)
+            }
+            if (snapshotId.isBlank() || ids.length() == 0) {
+                writeResult(applicationContext, "扫描完成，没有需要归类的新文件")
+                return Result.success()
+            }
+
+            val request = JSONObject().put("ids", ids).toString()
+            val applied = runCatching { JSONObject(session.service.applyFileOrganizer(snapshotId, request)) }.getOrElse {
+                writeResult(applicationContext, "归类失败：${it.message ?: it.javaClass.simpleName}")
+                return Result.retry()
+            }
+            if (applied.has("error")) {
+                writeResult(applicationContext, applied.optString("message", "定时归类失败"))
+                return Result.retry()
+            }
+
+            val moved = applied.optInt("moved")
+            val skipped = applied.optInt("skipped")
+            val failed = applied.optInt("failed")
+            val size = Formatter.formatFileSize(applicationContext, applied.optLong("bytes"))
+            writeResult(applicationContext, "已归类 $moved 个文件 · $size；跳过 $skipped 个，失败 $failed 个")
+            if (failed == 0) Result.success() else Result.retry()
+        } finally {
+            session.close()
+        }
+    }
+
+    private suspend fun bindRootService(): RootSession = suspendCancellableCoroutine { continuation ->
+        lateinit var connection: ServiceConnection
+        connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                val root = IProfileRootService.Stub.asInterface(binder)
+                if (root == null) {
+                    if (continuation.isActive) continuation.resumeWithException(IllegalStateException("Root Binder 为空"))
+                    return
+                }
+                if (continuation.isActive) continuation.resume(RootSession(root, connection))
+                else runCatching { RootService.unbind(connection) }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                if (continuation.isActive) continuation.resumeWithException(IllegalStateException("Root 服务已断开"))
+            }
+        }
+        continuation.invokeOnCancellation { runCatching { RootService.unbind(connection) } }
+        runCatching {
+            RootService.bind(
+                Intent(applicationContext, BaiZeProfileRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                connection
+            )
+        }.onFailure { if (continuation.isActive) continuation.resumeWithException(it) }
+    }
+
+    private data class RootSession(val service: IProfileRootService, val connection: ServiceConnection) {
+        fun close() { runCatching { RootService.unbind(connection) } }
+    }
+
+    companion object {
+        private const val PREFS = "file_organizer_schedule"
+        private const val KEY_ENABLED = "enabled"
+        private const val KEY_INTERVAL = "interval_hours"
+        private const val KEY_CHARGING = "charging_only"
+        private const val KEY_SCREEN_OFF = "screen_off_only"
+        private const val KEY_LAST_RUN = "last_run_epoch"
+        private const val KEY_LAST_RESULT = "last_result"
+        private const val UNIQUE_WORK = "baize_file_organizer_periodic"
+        private const val ROOT_BIND_TIMEOUT_MS = 20_000L
+        private val ALLOWED_INTERVALS = setOf(6, 12, 24, 72, 168)
+
+        fun loadSettings(context: Context): FileOrganizerScheduleSettings {
+            val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            val interval = prefs.getInt(KEY_INTERVAL, 24).let { if (it in ALLOWED_INTERVALS) it else 24 }
+            return FileOrganizerScheduleSettings(
+                enabled = prefs.getBoolean(KEY_ENABLED, false),
+                intervalHours = interval,
+                chargingOnly = prefs.getBoolean(KEY_CHARGING, false),
+                screenOffOnly = prefs.getBoolean(KEY_SCREEN_OFF, true),
+                lastRunEpoch = prefs.getLong(KEY_LAST_RUN, 0L),
+                lastResult = prefs.getString(KEY_LAST_RESULT, "尚未执行定时归类") ?: "尚未执行定时归类"
+            )
+        }
+
+        fun saveAndSchedule(context: Context, settings: FileOrganizerScheduleSettings) {
+            val safe = settings.copy(intervalHours = if (settings.intervalHours in ALLOWED_INTERVALS) settings.intervalHours else 24)
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+                .putBoolean(KEY_ENABLED, safe.enabled)
+                .putInt(KEY_INTERVAL, safe.intervalHours)
+                .putBoolean(KEY_CHARGING, safe.chargingOnly)
+                .putBoolean(KEY_SCREEN_OFF, safe.screenOffOnly)
+                .apply()
+
+            val workManager = WorkManager.getInstance(context)
+            if (!safe.enabled) {
+                workManager.cancelUniqueWork(UNIQUE_WORK)
+                return
+            }
+            val constraints = Constraints.Builder()
+                .setRequiresCharging(safe.chargingOnly)
+                .setRequiresBatteryNotLow(true)
+                .build()
+            val request = PeriodicWorkRequestBuilder<FileOrganizerWorker>(
+                safe.intervalHours.toLong(), TimeUnit.HOURS, 15, TimeUnit.MINUTES
+            ).setInitialDelay(safe.intervalHours.toLong(), TimeUnit.HOURS)
+                .setConstraints(constraints)
+                .build()
+            workManager.enqueueUniquePeriodicWork(UNIQUE_WORK, ExistingPeriodicWorkPolicy.UPDATE, request)
+        }
+
+        fun lastRunText(context: Context, settings: FileOrganizerScheduleSettings): String {
+            if (settings.lastRunEpoch <= 0L) return "尚未执行"
+            return DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(Date(settings.lastRunEpoch))
+        }
+
+        private fun writeResult(context: Context, result: String) {
+            context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+                .putLong(KEY_LAST_RUN, System.currentTimeMillis())
+                .putString(KEY_LAST_RESULT, result)
+                .apply()
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-internal data class FileOrganizerScheduleSettings(
+data class FileOrganizerScheduleSettings(
     val enabled: Boolean = false,
     val intervalHours: Int = 24,
     val chargingOnly: Boolean = false,

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.1.0-alpha8
-versionCode=22408
+version=v2.1.0-alpha9
+versionCode=22409
 author=惜故里丶
-description=白泽 v2.1.0 Alpha 8：全下载目录文件归类、空项目修复与自动扫描策略。
+description=白泽 v2.1.0 Alpha 9：文件归类界面重做、归类去向展示与真实定时归类。

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/debug/app-debug.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2.1.0-alpha8-Module.zip"
+OUTPUT="$OUT/BaiZe-v2.1.0-alpha9-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -16,11 +16,9 @@ OUTPUT="$OUT/BaiZe-v2.1.0-alpha8-Module.zip"
 rm -rf "$STAGE"
 mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
 cp -a "$MODULE/." "$STAGE/"
-# App-only package: never ship WebUI assets, including stale source directories.
 rm -rf "$STAGE/webroot" "$STAGE/webui" "$STAGE/www" "$STAGE/ksu-webui"
 cp -a "$REPO/config" "$STAGE/config"
 
-# Ship dedicated cache, APK, deep/corpse snapshot executors behind one stable task router.
 cp -f "$STAGE/cleaner42_6.sh" "$STAGE/cleaner.sh"
 cp -f "$STAGE/native-scan.sh" "$STAGE/native-cleaner.sh"
 cp -f "$STAGE/profile-snapshot-clean.sh" "$STAGE/profile-cleaner.sh"
@@ -77,17 +75,16 @@ unzip -p "$OUTPUT" config/default.conf | grep -q '^scan_root_workers=0$'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-scanner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
-unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha8$'
-unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22408$'
+unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha9$'
+unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22409$'
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1
 fi
 unzip -p "$OUTPUT" config/deep.rules | sha256sum | grep -q '^73d4c898630a292753adca33298c8aabbf6146debf414b2cabbe6b87d1d5c31c'
-
 unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -q 'clean-cache-snapshot'
 if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache|xargs[[:space:]].*rm'; then
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.1.0 Alpha 8 文件归类与空项目修复模块：$OUTPUT"
+echo "已生成白泽 v2.1.0 Alpha 9 文件归类界面与定时归类模块：$OUTPUT"


### PR DESCRIPTION
## 修复真机反馈

- 彻底移除被窄屏和大字体压成竖排的三按钮布局，扫描、停止、撤销全部改为独立全宽操作。
- 页面常驻展示归类根目录 `内部存储 / BaiZe归类`，并展示图片、视频、音频、文档、安装包、压缩包、电子书和其他八个目标目录。
- 每个扫描结果同时展示来源路径和最终去向，不再让用户猜文件会移动到哪里。
- 重做状态卡、目标卡、定时卡和文件结果卡，统一圆角、间距、层级与 MIUIx 风格。

## 真实定时归类

- 新增 `FileOrganizerWorker`，使用 Android WorkManager 创建持久化周期任务。
- 支持每 6 小时、12 小时、每天、每 3 天、每周执行。
- 支持仅息屏、仅充电和低电量保护。
- 定时任务实际连接 Root 服务，调用现有不可变扫描计划与 `applyFileOrganizer`，不是仅保存一个 UI 开关。
- 显示上次执行时间和执行结果，关闭开关时取消唯一周期任务。

## 版本

- App：`2.1.0-alpha9`
- 模块：`v2.1.0-alpha9`
- versionCode：`22409`

## 验证

新增 Alpha 9 源码、Android App、ARM64 引擎和模块 ZIP 验证工作流。PR 保持 Draft，等待 CI 和真机确认。