### PR TITLE
fix(v2): v2.1.0 Alpha 10 修复 Binder 崩溃并支持 QQ/TIM 接收目录

### DIFF
--- a/.github/workflows/v2.1.0-alpha10-direct-verify.yml
+++ b/.github/workflows/v2.1.0-alpha10-direct-verify.yml
@@ -1,0 +1,111 @@
+name: BaiZe v2.1.0 Alpha 10 Direct Verify
+
+on:
+  pull_request:
+    branches: [feat/v2.1.0-alpha9-organizer-ui-schedule]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Alpha 10 source
+        uses: actions/checkout@v4
+        with:
+          ref: feat/v2.1.0-alpha10-binder-pagination
+          fetch-depth: 0
+
+      - name: Check source and shell syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check origin/feat/v2.1.0-alpha9-organizer-ui-schedule...HEAD
+          sh -n v2/module/one-pass-scan.sh
+          sh -n v2/module/native-scan.sh
+          sh -n v2/scripts/build-native.sh
+          sh -n v2/scripts/package-module.sh
+
+      - name: Verify Binder-safe organizer and QQ paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENGINE=v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
+          UI=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+          WORKER=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+          grep -q 'immutable.take(DEFAULT_PAGE_SIZE)' "$ENGINE"
+          grep -q 'MAX_RESULT_DETAILS = 40' "$ENGINE"
+          grep -q 'MAX_ITEMS = 20_000' "$ENGINE"
+          grep -q 'qqfile_recv' "$ENGINE"
+          grep -q 'timfile_recv' "$ENGINE"
+          grep -q 'QQ 接收文件' "$ENGINE"
+          grep -q 'put("all", true)' "$WORKER"
+          grep -q 'excludeIds' "$UI"
+          grep -q '预览前' "$UI"
+          grep -q 'QQ/TIM 接收目录' "$UI"
+          ! grep -q 'immutable.forEach.*array.put' "$ENGINE"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build ARM64 scanner
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build Android App
+        working-directory: v2
+        shell: bash
+        run: |
+          set -o pipefail
+          gradle --no-daemon :app:assembleDebug 2>&1 | tee android-build.log
+
+      - name: Upload Android build failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-alpha10-build-failure-log
+          path: v2/android-build.log
+          if-no-files-found: ignore
+
+      - name: Package Alpha 10 module
+        working-directory: v2
+        run: sh scripts/package-module.sh
+
+      - name: Verify final package
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP=v2/dist/BaiZe-v2.1.0-alpha10-Module.zip
+          test -s "$ZIP"
+          unzip -tq "$ZIP"
+          unzip -p "$ZIP" module.prop | grep -qx 'version=v2.1.0-alpha10'
+          unzip -p "$ZIP" module.prop | grep -qx 'versionCode=22410'
+          grep -q 'versionName = "2.1.0-alpha10"' v2/app/build.gradle.kts
+          grep -q 'versionCode = 22410' v2/app/build.gradle.kts
+          ! unzip -Z1 "$ZIP" | grep -Eq '^(webroot|webui|www|ksu-webui)/'
+          sha256sum "$ZIP" | tee "$ZIP.sha256"
+
+      - name: Upload Alpha 10 module
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.1.0-alpha10-Binder-Safe-QQ-Organizer
+          if-no-files-found: error
+          path: |
+            v2/dist/BaiZe-v2.1.0-alpha10-Module.zip
+            v2/dist/BaiZe-v2.1.0-alpha10-Module.zip.sha256

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22409
-        versionName = "2.1.0-alpha9"
+        versionCode = 22410
+        versionName = "2.1.0-alpha10"
     }
 
     buildFeatures {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -26,18 +25,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBack
-import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.FolderCopy
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Stop
-import androidx.compose.material.icons.rounded.Timer
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -51,7 +47,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -99,7 +94,7 @@ class FileOrganizerActivity : ComponentActivity() {
         override fun onServiceDisconnected(name: ComponentName?) {
             service = null
             bound = false
-            state = state.copy(connected = false, running = false, status = "Root 服务已断开")
+            state = state.copy(connected = false, running = false, status = "Root 服务已断开，请重新进入页面")
         }
     }
 
@@ -117,8 +112,7 @@ class FileOrganizerActivity : ComponentActivity() {
                     onBack = ::finish,
                     onScan = ::scan,
                     onToggle = ::toggle,
-                    onSelectAll = ::selectAll,
-                    onCategory = { state = state.copy(category = it) },
+                    onToggleAll = ::toggleAll,
                     onApply = ::applySelected,
                     onUndo = ::undoLast,
                     onStop = {
@@ -145,8 +139,7 @@ class FileOrganizerActivity : ComponentActivity() {
         state = state.copy(status = "正在连接 Root 文件归类服务…")
         runCatching {
             RootService.bind(
-                Intent(this, BaiZeProfileRootService::class.java)
-                    .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                Intent(this, BaiZeProfileRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
                 connection
             )
             bound = true
@@ -159,49 +152,50 @@ class FileOrganizerActivity : ComponentActivity() {
     private fun saveSchedule() {
         FileOrganizerWorker.saveAndSchedule(this, schedule)
         schedule = FileOrganizerWorker.loadSettings(this)
-        scheduleSavedText = if (schedule.enabled) {
-            "已保存：每 ${schedule.intervalHours} 小时自动归类"
-        } else {
-            "定时归类已关闭"
-        }
+        scheduleSavedText = if (schedule.enabled) "已保存：每 ${schedule.intervalHours} 小时自动归类" else "定时归类已关闭"
     }
 
     private fun scan() {
         val root = service ?: return
         if (state.running) return
-        state = state.copy(
+        state = FileOrganizerUiState(
+            connected = true,
             running = true,
-            status = "正在扫描本机所有下载目录…",
-            items = emptyList(),
-            selected = emptySet()
+            status = "正在扫描下载目录、QQ/TIM 接收目录…",
+            undoAvailable = state.undoAvailable
         )
         lifecycleScope.launch {
-            val json = withContext(Dispatchers.IO) {
+            val summary = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.scanFileOrganizer()) }.getOrElse {
-                    JSONObject().put("error", "scan_failed").put("message", it.message)
+                    JSONObject().put("error", "scan_failed").put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
-            if (json.has("error")) {
-                state = state.copy(
-                    running = false,
-                    status = json.optString("message", "文件归类扫描失败")
-                )
+            if (summary.has("error")) {
+                state = state.copy(running = false, status = summary.optString("message", "文件归类扫描失败"))
                 return@launch
             }
-            if (json.optBoolean("cancelled")) {
+            if (summary.optBoolean("cancelled")) {
                 state = state.copy(running = false, status = "文件归类扫描已停止")
                 return@launch
             }
-            val items = parseItems(json.optJSONArray("items"))
+            val snapshotId = summary.optString("snapshotId")
+            val total = summary.optInt("total")
+            val preview = parseItems(summary.optJSONArray("items"))
             state = state.copy(
                 running = false,
-                snapshotId = json.optString("snapshotId"),
-                items = items,
-                selected = items.mapTo(linkedSetOf()) { it.id },
-                category = "全部",
+                snapshotId = snapshotId,
+                total = total,
+                totalBytes = summary.optLong("totalBytes"),
+                roots = summary.optInt("roots"),
+                truncated = summary.optBoolean("truncated"),
+                items = preview,
+                allSelected = true,
+                selected = emptySet(),
+                excluded = emptySet(),
                 status = buildString {
-                    append("扫描完成：${json.optInt("roots")} 个下载目录 · ${items.size} 个文件")
-                    if (json.optBoolean("truncated")) append(" · 已达到本次安全上限")
+                    if (total == 0) append("扫描完成：没有需要归类的新文件")
+                    else append("扫描完成：${summary.optInt("roots")} 个目录 · $total 个文件")
+                    if (summary.optBoolean("truncated")) append(" · 已达到安全上限")
                 }
             )
         }
@@ -209,35 +203,29 @@ class FileOrganizerActivity : ComponentActivity() {
 
     private fun applySelected() {
         val root = service ?: return
-        if (state.running || state.snapshotId.isBlank() || state.selected.isEmpty()) return
-        val request = JSONObject().put("ids", JSONArray(state.selected.toList())).toString()
-        state = state.copy(running = true, status = "正在归类所选文件…")
+        if (state.running || state.snapshotId.isBlank() || selectedCount(state) <= 0) return
+        val request = JSONObject()
+            .put("all", state.allSelected)
+            .put("ids", JSONArray(state.selected.toList()))
+            .put("excludeIds", JSONArray(state.excluded.toList()))
+            .toString()
+        state = state.copy(running = true, status = "正在归类 ${selectedCount(state)} 个文件…")
         lifecycleScope.launch {
-            val json = withContext(Dispatchers.IO) {
+            val result = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.applyFileOrganizer(state.snapshotId, request)) }.getOrElse {
-                    JSONObject().put("error", "apply_failed").put("message", it.message)
+                    JSONObject().put("error", "apply_failed").put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
-            if (json.has("error")) {
-                state = state.copy(
-                    running = false,
-                    status = json.optString("message", "文件归类失败")
-                )
+            if (result.has("error")) {
+                state = state.copy(running = false, status = result.optString("message", "文件归类失败"))
                 return@launch
             }
-            val moved = json.optInt("moved")
-            val skipped = json.optInt("skipped")
-            val failed = json.optInt("failed")
-            val bytes = json.optLong("bytes")
-            state = state.copy(
+            val text = "归类完成：移动 ${result.optInt("moved")} 个 · 跳过 ${result.optInt("skipped")} 个 · 失败 ${result.optInt("failed")} 个 · ${Formatter.formatFileSize(this@FileOrganizerActivity, result.optLong("bytes"))}"
+            state = FileOrganizerUiState(
+                connected = true,
                 running = false,
-                snapshotId = "",
-                items = emptyList(),
-                selected = emptySet(),
-                undoAvailable = json.optBoolean("undoAvailable"),
-                status = "归类完成：移动 $moved 个 · 跳过 $skipped 个 · 失败 $failed 个 · ${
-                    Formatter.formatFileSize(this@FileOrganizerActivity, bytes)
-                }"
+                status = text,
+                undoAvailable = result.optBoolean("undoAvailable")
             )
         }
     }
@@ -247,38 +235,43 @@ class FileOrganizerActivity : ComponentActivity() {
         if (state.running) return
         state = state.copy(running = true, status = "正在撤销上一次文件归类…")
         lifecycleScope.launch {
-            val json = withContext(Dispatchers.IO) {
+            val result = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.undoFileOrganizer()) }.getOrElse {
-                    JSONObject().put("error", "undo_failed").put("message", it.message)
+                    JSONObject().put("error", "undo_failed").put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
-            if (json.has("error")) {
-                state = state.copy(running = false, status = json.optString("message", "撤销失败"))
+            if (result.has("error")) {
+                state = state.copy(running = false, status = result.optString("message", "撤销失败"))
                 return@launch
             }
             state = state.copy(
                 running = false,
-                undoAvailable = json.optBoolean("undoAvailable"),
-                status = "撤销完成：恢复 ${json.optInt("restored")} 个 · 跳过 ${
-                    json.optInt("skipped")
-                } 个 · 失败 ${json.optInt("failed")} 个"
+                undoAvailable = result.optBoolean("undoAvailable"),
+                status = "撤销完成：恢复 ${result.optInt("restored")} 个 · 跳过 ${result.optInt("skipped")} 个 · 失败 ${result.optInt("failed")} 个"
             )
         }
     }
 
     private fun toggle(id: String) {
         if (state.running) return
-        val next = state.selected.toMutableSet()
-        if (!next.add(id)) next.remove(id)
-        state = state.copy(selected = next)
+        if (state.allSelected) {
+            val next = state.excluded.toMutableSet()
+            if (!next.add(id)) next.remove(id)
+            state = state.copy(excluded = next)
+        } else {
+            val next = state.selected.toMutableSet()
+            if (!next.add(id)) next.remove(id)
+            state = state.copy(selected = next)
+        }
     }
 
-    private fun selectAll(visible: List<String>) {
-        if (state.running) return
-        val next = state.selected.toMutableSet()
-        val allSelected = visible.isNotEmpty() && visible.all { it in next }
-        if (allSelected) next.removeAll(visible.toSet()) else next.addAll(visible)
-        state = state.copy(selected = next)
+    private fun toggleAll() {
+        if (state.running || state.total == 0) return
+        state = if (state.allSelected) {
+            state.copy(allSelected = false, selected = emptySet(), excluded = emptySet())
+        } else {
+            state.copy(allSelected = true, selected = emptySet(), excluded = emptySet())
+        }
     }
 
     private fun parseItems(array: JSONArray?): List<FileOrganizerItem> = buildList {
@@ -295,7 +288,7 @@ class FileOrganizerActivity : ComponentActivity() {
                     bytes = item.optLong("bytes"),
                     sourceGroup = item.optString("sourceGroup", "公共下载"),
                     sourceDisplay = item.optString("sourceDisplay"),
-                    destinationName = item.optString("destinationName", item.optString("name"))
+                    destinationDisplay = item.optString("destinationDisplay")
                 )
             )
         }
@@ -314,7 +307,7 @@ private data class FileOrganizerItem(
     val bytes: Long,
     val sourceGroup: String,
     val sourceDisplay: String,
-    val destinationName: String
+    val destinationDisplay: String
 )
 
 private data class FileOrganizerUiState(
@@ -322,11 +315,22 @@ private data class FileOrganizerUiState(
     val running: Boolean = false,
     val status: String = "等待连接",
     val snapshotId: String = "",
+    val roots: Int = 0,
+    val total: Int = 0,
+    val totalBytes: Long = 0,
+    val truncated: Boolean = false,
     val items: List<FileOrganizerItem> = emptyList(),
+    val allSelected: Boolean = true,
     val selected: Set<String> = emptySet(),
-    val category: String = "全部",
+    val excluded: Set<String> = emptySet(),
     val undoAvailable: Boolean = true
 )
+
+private fun selectedCount(state: FileOrganizerUiState): Int =
+    if (state.allSelected) (state.total - state.excluded.size).coerceAtLeast(0) else state.selected.size
+
+private fun isChecked(state: FileOrganizerUiState, id: String): Boolean =
+    if (state.allSelected) id !in state.excluded else id in state.selected
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -337,25 +341,21 @@ private fun FileOrganizerScreen(
     onBack: () -> Unit,
     onScan: () -> Unit,
     onToggle: (String) -> Unit,
-    onSelectAll: (List<String>) -> Unit,
-    onCategory: (String) -> Unit,
+    onToggleAll: () -> Unit,
     onApply: () -> Unit,
     onUndo: () -> Unit,
     onStop: () -> Unit,
     onScheduleChange: (FileOrganizerScheduleSettings) -> Unit,
     onSaveSchedule: () -> Unit
 ) {
-    val categories = listOf("全部", "图片", "视频", "音频", "文档", "安装包", "压缩包", "电子书", "其他")
-    val visible = if (state.category == "全部") state.items else state.items.filter { it.category == state.category }
-    val visibleIds = visible.map { it.id }
-
+    val context = LocalContext.current
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
                     Column {
                         Text("文件归类", fontWeight = FontWeight.Black, fontSize = 24.sp)
-                        Text("扫描、预览、归类与定时", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("下载、QQ/TIM 接收文件与定时归类", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 },
                 navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") } },
@@ -365,85 +365,101 @@ private fun FileOrganizerScreen(
     ) { padding ->
         LazyColumn(
             modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(padding),
-            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 36.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp)
+            contentPadding = PaddingValues(16.dp, 8.dp, 16.dp, 36.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            item { OrganizerHeroCard(state, onScan, onUndo, onStop) }
-            item { DestinationCard() }
-            item { ScheduleCard(schedule, scheduleSavedText, onScheduleChange, onSaveSchedule) }
-            if (state.items.isNotEmpty()) {
-                item { CategoryStrip(categories, state.category, onCategory) }
-                item {
-                    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                        Column {
-                            Text("${visible.size} 个文件", fontWeight = FontWeight.Black, fontSize = 18.sp)
-                            Text("已选 ${state.selected.size} 个", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            item {
+                Card(
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+                    shape = RoundedCornerShape(28.dp)
+                ) {
+                    Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(Icons.Rounded.FolderCopy, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(32.dp))
+                            Spacer(Modifier.size(12.dp))
+                            Column(Modifier.weight(1f)) {
+                                Text(state.status, fontWeight = FontWeight.Black, fontSize = 18.sp)
+                                Text("支持 Download、Downloads、下载、QQfile_recv 与 TIMfile_recv；大量文件只预览前 60 个，完整计划保留在 Root 端。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 18.sp)
+                            }
+                            if (state.running) CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
                         }
-                        Spacer(Modifier.weight(1f))
-                        Surface(modifier = Modifier.clickable { onSelectAll(visibleIds) }, color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(50)) {
-                            Text(
-                                if (visibleIds.isNotEmpty() && visibleIds.all { it in state.selected }) "取消本页" else "选择本页",
-                                modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-                                color = MaterialTheme.colorScheme.onSecondaryContainer,
-                                fontWeight = FontWeight.Bold,
-                                fontSize = 12.sp
-                            )
+                        Button(
+                            onClick = if (state.running) onStop else onScan,
+                            enabled = state.connected,
+                            modifier = Modifier.fillMaxWidth().height(54.dp),
+                            shape = RoundedCornerShape(18.dp)
+                        ) {
+                            Icon(if (state.running) Icons.Rounded.Stop else Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text(if (state.running) "停止当前任务" else "扫描下载与 QQ/TIM 接收目录", fontWeight = FontWeight.Black)
+                        }
+                        OutlinedButton(
+                            onClick = onUndo,
+                            enabled = state.connected && !state.running && state.undoAvailable,
+                            modifier = Modifier.fillMaxWidth().height(50.dp),
+                            shape = RoundedCornerShape(18.dp)
+                        ) {
+                            Icon(Icons.Rounded.Restore, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("撤销上一次归类", fontWeight = FontWeight.Bold)
                         }
                     }
                 }
-                items(visible, key = { it.id }) { item -> OrganizerFileCard(item, item.id in state.selected) { onToggle(item.id) } }
+            }
+
+            item { DestinationCard() }
+            item { ScheduleCard(schedule, scheduleSavedText, onScheduleChange, onSaveSchedule) }
+
+            if (state.snapshotId.isNotBlank()) {
+                item {
+                    Card(
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+                        shape = RoundedCornerShape(24.dp)
+                    ) {
+                        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Text("扫描结果", fontWeight = FontWeight.Black, fontSize = 19.sp)
+                            Text("${state.total} 个文件 · ${Formatter.formatFileSize(context, state.totalBytes)} · 预览前 ${state.items.size} 个", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            Text(
+                                if (state.allSelected) "默认归类全部；当前排除 ${state.excluded.size} 个" else "当前只归类手动勾选的 ${state.selected.size} 个",
+                                color = MaterialTheme.colorScheme.primary,
+                                fontWeight = FontWeight.Bold
+                            )
+                            OutlinedButton(onClick = onToggleAll, enabled = !state.running, modifier = Modifier.fillMaxWidth()) {
+                                Text(if (state.allSelected) "取消全选" else "选择全部 ${state.total} 个")
+                            }
+                        }
+                    }
+                }
+
+                items(state.items, key = { it.id }) { item ->
+                    Card(
+                        modifier = Modifier.fillMaxWidth().clickable(enabled = !state.running) { onToggle(item.id) },
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+                        shape = RoundedCornerShape(20.dp)
+                    ) {
+                        Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(checked = isChecked(state, item.id), onCheckedChange = { onToggle(item.id) }, enabled = !state.running)
+                            Column(Modifier.weight(1f)) {
+                                Text(item.name, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                                Text("${item.category} · ${item.sourceGroup} · ${Formatter.formatFileSize(context, item.bytes)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                                Text("来源：${item.sourceDisplay}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                                Text("去向：${item.destinationDisplay}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                            }
+                        }
+                    }
+                }
+
                 item {
                     Button(
                         onClick = onApply,
-                        enabled = state.connected && !state.running && state.selected.isNotEmpty(),
+                        enabled = state.connected && !state.running && selectedCount(state) > 0,
                         modifier = Modifier.fillMaxWidth().height(58.dp),
-                        shape = RoundedCornerShape(22.dp)
+                        shape = RoundedCornerShape(20.dp)
                     ) {
                         Icon(Icons.Rounded.CheckCircle, contentDescription = null)
                         Spacer(Modifier.size(8.dp))
-                        Text("归类所选 ${state.selected.size} 个文件", fontWeight = FontWeight.Black, maxLines = 1)
+                        Text("归类 ${selectedCount(state)} 个文件", fontWeight = FontWeight.Black)
                     }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun OrganizerHeroCard(state: FileOrganizerUiState, onScan: () -> Unit, onUndo: () -> Unit, onStop: () -> Unit) {
-    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer), shape = RoundedCornerShape(30.dp)) {
-        Column(Modifier.padding(20.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary) {
-                    Box(modifier = Modifier.size(46.dp), contentAlignment = Alignment.Center) {
-                        Icon(Icons.Rounded.FolderCopy, contentDescription = null, tint = MaterialTheme.colorScheme.onPrimary)
-                    }
-                }
-                Spacer(Modifier.size(14.dp))
-                Column(Modifier.weight(1f)) {
-                    Text(state.status, fontWeight = FontWeight.Black, fontSize = 18.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
-                    Text("只读取明确命名为 Download、Downloads 或“下载”的目录；扫描后变化的文件会自动跳过。", color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.72f), fontSize = 12.sp, lineHeight = 18.sp)
-                }
-                if (state.running) CircularProgressIndicator(modifier = Modifier.size(26.dp), strokeWidth = 2.5.dp, color = MaterialTheme.colorScheme.primary)
-            }
-            Spacer(Modifier.height(18.dp))
-            if (state.running) {
-                OutlinedButton(onClick = onStop, modifier = Modifier.fillMaxWidth().height(54.dp), shape = RoundedCornerShape(20.dp)) {
-                    Icon(Icons.Rounded.Stop, contentDescription = null)
-                    Spacer(Modifier.size(8.dp))
-                    Text("停止当前任务", fontWeight = FontWeight.Black, maxLines = 1)
-                }
-            } else {
-                Button(onClick = onScan, enabled = state.connected, modifier = Modifier.fillMaxWidth().height(56.dp), shape = RoundedCornerShape(20.dp)) {
-                    Icon(Icons.Rounded.Refresh, contentDescription = null)
-                    Spacer(Modifier.size(8.dp))
-                    Text("扫描所有下载目录", fontWeight = FontWeight.Black, maxLines = 1)
-                }
-                Spacer(Modifier.height(10.dp))
-                OutlinedButton(onClick = onUndo, enabled = state.connected && state.undoAvailable, modifier = Modifier.fillMaxWidth().height(50.dp), shape = RoundedCornerShape(18.dp)) {
-                    Icon(Icons.Rounded.Restore, contentDescription = null)
-                    Spacer(Modifier.size(8.dp))
-                    Text("撤销上一次归类", fontWeight = FontWeight.Bold, maxLines = 1)
                 }
             }
         }
@@ -452,120 +468,71 @@ private fun OrganizerHeroCard(state: FileOrganizerUiState, onScan: () -> Unit, o
 
 @Composable
 private fun DestinationCard() {
-    val destinationCategories = listOf("图片", "视频", "音频", "文档", "安装包", "压缩包", "电子书", "其他")
-    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer), shape = RoundedCornerShape(28.dp)) {
-        Column(Modifier.padding(20.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Rounded.AutoAwesome, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
-                Spacer(Modifier.size(10.dp))
-                Column {
-                    Text("归类到哪里", fontWeight = FontWeight.Black, fontSize = 18.sp)
-                    Text("内部存储 / BaiZe归类", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold, fontSize = 13.sp)
-                }
-            }
-            Spacer(Modifier.height(14.dp))
-            Text("每个文件会移动到对应分类子目录，原文件名保持不变；目标中已有同名文件时直接跳过，不会覆盖。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 18.sp)
-            Spacer(Modifier.height(14.dp))
-            destinationCategories.chunked(4).forEachIndexed { rowIndex, row ->
-                if (rowIndex > 0) Spacer(Modifier.height(8.dp))
-                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    row.forEach { category ->
-                        Surface(modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.secondaryContainer, shape = RoundedCornerShape(14.dp)) {
-                            Text(category, modifier = Modifier.padding(vertical = 9.dp), fontSize = 11.sp, fontWeight = FontWeight.Bold, textAlign = androidx.compose.ui.text.style.TextAlign.Center, color = MaterialTheme.colorScheme.onSecondaryContainer)
-                        }
-                    }
-                }
+    val categories = listOf("图片", "视频", "音频", "文档", "安装包", "压缩包", "电子书", "其他")
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("归类到哪里", fontWeight = FontWeight.Black, fontSize = 19.sp)
+            Text("内部存储 / BaiZe归类", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+            Text("每个文件按类型移动到对应子目录；遇到同名文件直接跳过，不覆盖。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            Row(
+                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                categories.forEach { category -> FilterChip(selected = false, onClick = {}, label = { Text(category) }) }
             }
         }
     }
 }
 
 @Composable
-private fun ScheduleCard(settings: FileOrganizerScheduleSettings, savedText: String, onChange: (FileOrganizerScheduleSettings) -> Unit, onSave: () -> Unit) {
-    val context = LocalContext.current
+private fun ScheduleCard(
+    schedule: FileOrganizerScheduleSettings,
+    savedText: String,
+    onChange: (FileOrganizerScheduleSettings) -> Unit,
+    onSave: () -> Unit
+) {
     val intervals = listOf(6, 12, 24, 72, 168)
-    Card(modifier = Modifier.fillMaxWidth(), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer), shape = RoundedCornerShape(28.dp)) {
-        Column(Modifier.padding(20.dp)) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Surface(shape = CircleShape, color = MaterialTheme.colorScheme.tertiaryContainer) {
-                    Box(modifier = Modifier.size(42.dp), contentAlignment = Alignment.Center) {
-                        Icon(Icons.Rounded.Schedule, contentDescription = null, tint = MaterialTheme.colorScheme.onTertiaryContainer)
-                    }
-                }
-                Spacer(Modifier.size(12.dp))
+                Icon(Icons.Rounded.Schedule, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.size(10.dp))
                 Column(Modifier.weight(1f)) {
-                    Text("定时归类", fontWeight = FontWeight.Black, fontSize = 18.sp)
-                    Text(if (settings.enabled) "每 ${settings.intervalHours} 小时执行一次" else "当前未启用", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                    Text("定时归类", fontWeight = FontWeight.Black, fontSize = 19.sp)
+                    Text("由 WorkManager 实际执行扫描与归类", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
                 }
-                Switch(checked = settings.enabled, onCheckedChange = { onChange(settings.copy(enabled = it)) })
+                Switch(checked = schedule.enabled, onCheckedChange = { onChange(schedule.copy(enabled = it)) })
             }
-            Spacer(Modifier.height(14.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
-            Spacer(Modifier.height(14.dp))
-            Text("执行间隔", fontWeight = FontWeight.Bold, fontSize = 13.sp)
-            Spacer(Modifier.height(8.dp))
-            Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 intervals.forEach { hours ->
                     FilterChip(
-                        selected = settings.intervalHours == hours,
-                        onClick = { onChange(settings.copy(intervalHours = hours)) },
-                        label = { Text(when (hours) { 24 -> "每天"; 72 -> "每 3 天"; 168 -> "每周"; else -> "每 $hours 小时" }, maxLines = 1) },
-                        leadingIcon = if (settings.intervalHours == hours) ({ Icon(Icons.Rounded.Timer, contentDescription = null, modifier = Modifier.size(16.dp)) }) else null
+                        selected = schedule.intervalHours == hours,
+                        onClick = { onChange(schedule.copy(intervalHours = hours)) },
+                        label = { Text(when (hours) { 24 -> "每天"; 72 -> "每3天"; 168 -> "每周"; else -> "${hours}小时" }) }
                     )
                 }
             }
-            Spacer(Modifier.height(12.dp))
-            ScheduleToggleRow("仅息屏时执行", "亮屏时等待，避免打扰正在使用的应用", settings.screenOffOnly) { onChange(settings.copy(screenOffOnly = it)) }
-            ScheduleToggleRow("仅充电时执行", "交给系统调度器等待充电条件满足", settings.chargingOnly) { onChange(settings.copy(chargingOnly = it)) }
-            Spacer(Modifier.height(8.dp))
-            Surface(color = MaterialTheme.colorScheme.surfaceContainerHigh, shape = RoundedCornerShape(18.dp)) {
-                Column(Modifier.padding(14.dp)) {
-                    Text("上次执行：${FileOrganizerWorker.lastRunText(context, settings)}", fontWeight = FontWeight.Bold, fontSize = 12.sp)
-                    Text(settings.lastResult, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, lineHeight = 16.sp)
-                }
-            }
-            Spacer(Modifier.height(12.dp))
-            Button(onClick = onSave, modifier = Modifier.fillMaxWidth().height(52.dp), shape = RoundedCornerShape(18.dp)) {
-                Icon(Icons.Rounded.CheckCircle, contentDescription = null)
-                Spacer(Modifier.size(8.dp))
-                Text(if (settings.enabled) "保存定时归类" else "保存并关闭定时", fontWeight = FontWeight.Black, maxLines = 1)
-            }
-            if (savedText.isNotBlank()) Text(savedText, modifier = Modifier.padding(top = 8.dp), color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+            HorizontalDivider()
+            SettingSwitch("仅充电时执行", schedule.chargingOnly) { onChange(schedule.copy(chargingOnly = it)) }
+            SettingSwitch("仅息屏时执行", schedule.screenOffOnly) { onChange(schedule.copy(screenOffOnly = it)) }
+            Text("上次执行：${FileOrganizerWorker.lastRunText(LocalContext.current, schedule)}", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(schedule.lastResult, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            if (savedText.isNotBlank()) Text(savedText, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+            Button(onClick = onSave, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) { Text("保存定时归类", fontWeight = FontWeight.Black) }
         }
     }
 }
 
 @Composable
-private fun ScheduleToggleRow(title: String, subtitle: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
-    Row(modifier = Modifier.fillMaxWidth().clickable { onCheckedChange(!checked) }.padding(vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
-        Column(Modifier.weight(1f)) {
-            Text(title, fontWeight = FontWeight.Bold, fontSize = 14.sp)
-            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, lineHeight = 16.sp)
-        }
+private fun SettingSwitch(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Text(label, modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
         Switch(checked = checked, onCheckedChange = onCheckedChange)
-    }
-}
-
-@Composable
-private fun CategoryStrip(categories: List<String>, selected: String, onCategory: (String) -> Unit) {
-    Row(modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        categories.forEach { category -> FilterChip(selected = selected == category, onClick = { onCategory(category) }, label = { Text(category, maxLines = 1) }) }
-    }
-}
-
-@Composable
-private fun OrganizerFileCard(item: FileOrganizerItem, checked: Boolean, onToggle: () -> Unit) {
-    val context = LocalContext.current
-    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow), shape = RoundedCornerShape(22.dp)) {
-        Row(modifier = Modifier.padding(horizontal = 14.dp, vertical = 14.dp), verticalAlignment = Alignment.CenterVertically) {
-            Checkbox(checked = checked, onCheckedChange = { onToggle() })
-            Spacer(Modifier.size(4.dp))
-            Column(Modifier.weight(1f)) {
-                Text(item.name, fontWeight = FontWeight.Black, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text("${item.category} · ${item.sourceGroup} · ${Formatter.formatFileSize(context, item.bytes)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text("来源：${item.sourceDisplay}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text("去向：BaiZe归类/${item.category}/${item.destinationName}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            }
-        }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
@@ -18,7 +18,6 @@ import io.github.xgl34222220.baize.root.BaiZeProfileRootService
 import io.github.xgl34222220.baize.root.IProfileRootService
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
-import org.json.JSONArray
 import org.json.JSONObject
 import java.text.DateFormat
 import java.util.Date
@@ -26,7 +25,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-data class FileOrganizerScheduleSettings(
+internal data class FileOrganizerScheduleSettings(
     val enabled: Boolean = false,
     val intervalHours: Int = 24,
     val chargingOnly: Boolean = false,
@@ -66,18 +65,13 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
             }
 
             val snapshotId = scan.optString("snapshotId")
-            val items = scan.optJSONArray("items") ?: JSONArray()
-            val ids = JSONArray()
-            for (index in 0 until items.length()) {
-                val id = items.optJSONObject(index)?.optString("id").orEmpty()
-                if (id.isNotBlank()) ids.put(id)
-            }
-            if (snapshotId.isBlank() || ids.length() == 0) {
+            val total = scan.optInt("total")
+            if (snapshotId.isBlank() || total == 0) {
                 writeResult(applicationContext, "扫描完成，没有需要归类的新文件")
                 return Result.success()
             }
 
-            val request = JSONObject().put("ids", ids).toString()
+            val request = JSONObject().put("all", true).toString()
             val applied = runCatching { JSONObject(session.service.applyFileOrganizer(snapshotId, request)) }.getOrElse {
                 writeResult(applicationContext, "归类失败：${it.message ?: it.javaClass.simpleName}")
                 return Result.retry()
@@ -91,7 +85,7 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
             val skipped = applied.optInt("skipped")
             val failed = applied.optInt("failed")
             val size = Formatter.formatFileSize(applicationContext, applied.optLong("bytes"))
-            writeResult(applicationContext, "已归类 $moved 个文件 · $size；跳过 $skipped 个，失败 $failed 个")
+            writeResult(applicationContext, "已归类 $moved/$total 个文件 · $size；跳过 $skipped 个，失败 $failed 个")
             if (failed == 0) Result.success() else Result.retry()
         } finally {
             session.close()
@@ -173,7 +167,8 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
                 .build()
             val request = PeriodicWorkRequestBuilder<FileOrganizerWorker>(
                 safe.intervalHours.toLong(), TimeUnit.HOURS, 15, TimeUnit.MINUTES
-            ).setInitialDelay(safe.intervalHours.toLong(), TimeUnit.HOURS)
+            )
+                .setInitialDelay(safe.intervalHours.toLong(), TimeUnit.HOURS)
                 .setConstraints(constraints)
                 .build()
             workManager.enqueueUniquePeriodicWork(UNIQUE_WORK, ExistingPeriodicWorkPolicy.UPDATE, request)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
-internal data class FileOrganizerScheduleSettings(
+data class FileOrganizerScheduleSettings(
     val enabled: Boolean = false,
     val intervalHours: Int = 24,
     val chargingOnly: Boolean = false,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
@@ -14,12 +14,11 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * Explicit file organizer for download trees.
+ * Root-side immutable file organizer plan.
  *
- * It discovers directories named Download / Downloads / 下载 across public storage,
- * Android/data, Android/media and root-readable app-private storage. A scan only creates an
- * in-memory immutable move plan. Applying a plan revalidates lstat fingerprints and never
- * overwrites an existing destination. The last successful batch can be undone.
+ * Binder responses are deliberately bounded: scan returns only a summary and the first preview
+ * page, while apply/undo detail arrays are capped. The complete move plan remains inside the Root
+ * process so large QQ/TIM receive folders never overflow Binder's transaction buffer.
  */
 class FileOrganizerEngine(
     private val cancelled: AtomicBoolean,
@@ -50,7 +49,15 @@ class FileOrganizerEngine(
     private data class Snapshot(
         val id: String,
         val createdAt: Long,
+        val roots: Int,
+        val truncated: Boolean,
         val items: List<PlannedMove>
+    )
+
+    private data class Selection(
+        val all: Boolean,
+        val ids: Set<String>,
+        val excludedIds: Set<String>
     )
 
     @Volatile
@@ -67,38 +74,64 @@ class FileOrganizerEngine(
         val items = LinkedHashMap<String, PlannedMove>()
         for ((index, root) in roots.withIndex()) {
             if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) break
-            progress(Progress("正在读取下载目录", index, roots.size, displayPath(root.path)))
+            progress(Progress("正在读取下载目录", index + 1, roots.size, displayPath(root.path)))
             collectFiles(root, started, items, progress)
             if (items.size >= MAX_ITEMS) break
         }
 
-        val id = UUID.randomUUID().toString()
         val immutable = items.values.sortedWith(
-            compareBy<PlannedMove> { it.category }.thenBy { it.sourceGroup }.thenBy { it.name.lowercase() }
+            compareBy<PlannedMove> { it.category }
+                .thenBy { it.sourceGroup }
+                .thenBy { it.name.lowercase() }
         )
-        snapshot = Snapshot(id, System.currentTimeMillis(), immutable)
+        val id = UUID.randomUUID().toString()
+        val truncated = immutable.size >= MAX_ITEMS || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS
+        snapshot = Snapshot(id, System.currentTimeMillis(), roots.size, truncated, immutable)
 
-        val array = JSONArray()
+        val categoryCounts = JSONObject()
+        val sourceCounts = JSONObject()
+        var totalBytes = 0L
         immutable.forEach { item ->
-            array.put(
-                JSONObject()
-                    .put("id", item.id)
-                    .put("name", item.name)
-                    .put("category", item.category)
-                    .put("bytes", item.bytes)
-                    .put("sourceGroup", item.sourceGroup)
-                    .put("sourceDisplay", displayPath(item.source))
-                    .put("destinationName", File(item.destination).name)
-            )
+            categoryCounts.put(item.category, categoryCounts.optInt(item.category) + 1)
+            sourceCounts.put(item.sourceGroup, sourceCounts.optInt(item.sourceGroup) + 1)
+            totalBytes += item.bytes
         }
+        val preview = JSONArray()
+        immutable.take(DEFAULT_PAGE_SIZE).forEach { preview.put(itemJson(it)) }
+
         return JSONObject()
             .put("success", true)
             .put("snapshotId", id)
             .put("expiresInMs", SNAPSHOT_TTL_MS)
             .put("roots", roots.size)
             .put("total", immutable.size)
-            .put("truncated", immutable.size >= MAX_ITEMS || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS)
+            .put("totalBytes", totalBytes)
+            .put("truncated", truncated)
             .put("elapsedMs", SystemClock.elapsedRealtime() - started)
+            .put("pageSize", DEFAULT_PAGE_SIZE)
+            .put("categoryCounts", categoryCounts)
+            .put("sourceCounts", sourceCounts)
+            .put("previewCount", preview.length())
+            .put("items", preview)
+            .toString()
+    }
+
+    fun page(snapshotId: String, offset: Int, limit: Int): String {
+        val current = validSnapshot(snapshotId)
+            ?: return error("snapshot_expired", "文件归类计划不存在或已过期，请重新扫描")
+        val safeOffset = offset.coerceIn(0, current.items.size)
+        val safeLimit = limit.coerceIn(1, MAX_PAGE_SIZE)
+        val end = (safeOffset + safeLimit).coerceAtMost(current.items.size)
+        val array = JSONArray()
+        current.items.subList(safeOffset, end).forEach { item -> array.put(itemJson(item)) }
+        return JSONObject()
+            .put("success", true)
+            .put("snapshotId", current.id)
+            .put("offset", safeOffset)
+            .put("nextOffset", end)
+            .put("limit", safeLimit)
+            .put("total", current.items.size)
+            .put("hasMore", end < current.items.size)
             .put("items", array)
             .toString()
     }
@@ -106,28 +139,39 @@ class FileOrganizerEngine(
     fun apply(snapshotId: String, selectionJson: String, progress: (Progress) -> Unit): String {
         val current = validSnapshot(snapshotId)
             ?: return error("snapshot_expired", "文件归类计划不存在或已过期，请重新扫描")
-        val selectedIds = parseSelection(selectionJson)
-        if (selectedIds.isEmpty()) return error("empty_selection", "没有选择需要归类的文件")
-
-        val selected = current.items.filter { it.id in selectedIds }
-        if (selected.isEmpty()) return error("empty_selection", "所选文件不属于当前归类计划")
+        val selection = parseSelection(selectionJson)
+        val selected = if (selection.all) {
+            current.items.filterNot { it.id in selection.excludedIds }
+        } else {
+            current.items.filter { it.id in selection.ids }
+        }
+        if (selected.isEmpty()) return error("empty_selection", "没有选择需要归类的文件")
 
         val moves = JSONArray()
         val details = JSONArray()
+        var detailTruncated = false
         var moved = 0
         var skipped = 0
         var failed = 0
         var bytes = 0L
 
+        fun appendDetail(item: PlannedMove, action: String, reason: String) {
+            if (details.length() < MAX_RESULT_DETAILS) {
+                details.put(detail(item, action, reason))
+            } else {
+                detailTruncated = true
+            }
+        }
+
         for ((index, item) in selected.withIndex()) {
             if (cancelled.get()) break
-            progress(Progress("正在归类 ${item.category}", index, selected.size, displayPath(item.source)))
+            progress(Progress("正在归类 ${item.category}", index + 1, selected.size, displayPath(item.source)))
             val source = File(item.source)
             val destination = File(item.destination)
             val reason = validatePlannedMove(item, source, destination)
             if (reason != null) {
                 skipped += 1
-                details.put(detail(item, "skipped", reason))
+                appendDetail(item, "skipped", reason)
                 continue
             }
 
@@ -145,20 +189,18 @@ class FileOrganizerEngine(
             if (result.getOrDefault(false)) {
                 moved += 1
                 bytes += item.bytes
-                val destinationFingerprint = fingerprint(destination)
                 moves.put(
                     JSONObject()
                         .put("source", item.source)
                         .put("destination", item.destination)
-                        .put("destinationFingerprint", destinationFingerprint)
+                        .put("destinationFingerprint", fingerprint(destination))
                         .put("sourceUid", item.sourceUid)
                         .put("sourceGid", item.sourceGid)
                         .put("sourceMode", item.sourceMode)
                 )
-                details.put(detail(item, "moved", ""))
             } else {
                 failed += 1
-                details.put(detail(item, "failed", result.exceptionOrNull()?.message ?: "移动失败"))
+                appendDetail(item, "failed", result.exceptionOrNull()?.message ?: "移动失败")
             }
         }
 
@@ -167,11 +209,13 @@ class FileOrganizerEngine(
         return JSONObject()
             .put("success", failed == 0)
             .put("cancelled", cancelled.get())
+            .put("requested", selected.size)
             .put("moved", moved)
             .put("skipped", skipped)
             .put("failed", failed)
             .put("bytes", bytes)
             .put("undoAvailable", moves.length() > 0)
+            .put("detailTruncated", detailTruncated)
             .put("details", details)
             .toString()
     }
@@ -184,9 +228,14 @@ class FileOrganizerEngine(
 
         val remaining = JSONArray()
         val details = JSONArray()
+        var detailTruncated = false
         var restored = 0
         var skipped = 0
         var failed = 0
+
+        fun appendDetail(value: JSONObject) {
+            if (details.length() < MAX_RESULT_DETAILS) details.put(value) else detailTruncated = true
+        }
 
         for (index in moves.length() - 1 downTo 0) {
             if (cancelled.get()) {
@@ -210,7 +259,7 @@ class FileOrganizerEngine(
             if (reason != null) {
                 skipped += 1
                 remaining.put(move)
-                details.put(JSONObject().put("destination", displayPath(destination.path)).put("action", "skipped").put("reason", reason))
+                appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "skipped").put("reason", reason))
                 continue
             }
 
@@ -218,7 +267,7 @@ class FileOrganizerEngine(
             if (sourceParent?.isDirectory != true) {
                 skipped += 1
                 remaining.put(move)
-                details.put(JSONObject().put("destination", displayPath(destination.path)).put("action", "skipped").put("reason", "原目录已不存在"))
+                appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "skipped").put("reason", "原目录已不存在"))
                 continue
             }
             val ok = runCatching {
@@ -234,19 +283,14 @@ class FileOrganizerEngine(
             }.getOrDefault(false)
             if (ok) {
                 restored += 1
-                details.put(JSONObject().put("source", displayPath(source.path)).put("action", "restored"))
             } else {
                 failed += 1
                 remaining.put(move)
-                details.put(JSONObject().put("destination", displayPath(destination.path)).put("action", "failed").put("reason", "恢复失败"))
+                appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "failed").put("reason", "恢复失败"))
             }
         }
 
-        if (remaining.length() == 0) {
-            undoFile().delete()
-        } else {
-            persistUndo(remaining)
-        }
+        if (remaining.length() == 0) undoFile().delete() else persistUndo(remaining)
         return JSONObject()
             .put("success", failed == 0)
             .put("cancelled", cancelled.get())
@@ -254,6 +298,7 @@ class FileOrganizerEngine(
             .put("skipped", skipped)
             .put("failed", failed)
             .put("undoAvailable", remaining.length() > 0)
+            .put("detailTruncated", detailTruncated)
             .put("details", details)
             .toString()
     }
@@ -263,15 +308,15 @@ class FileOrganizerEngine(
         val scanBases = mutableListOf<Pair<File, Int>>()
 
         File("/data/media").listFiles()
-            ?.filter { it.isDirectory && it.name.all { char -> char.isDigit() } }
-            ?.forEach { scanBases += it to 7 }
+            ?.filter { it.isDirectory && it.name.all(Char::isDigit) }
+            ?.forEach { scanBases += it to 8 }
 
         listOf(File("/data/user"), File("/data/user_de")).forEach { base ->
             base.listFiles()
-                ?.filter { it.isDirectory && it.name.all { char -> char.isDigit() } }
+                ?.filter { it.isDirectory && it.name.all(Char::isDigit) }
                 ?.forEach { user ->
-                    user.listFiles()?.filter { it.isDirectory }?.forEach { packageDir ->
-                        scanBases += packageDir to 6
+                    user.listFiles()?.filter(File::isDirectory)?.forEach { packageDir ->
+                        scanBases += packageDir to 7
                     }
                 }
         }
@@ -288,14 +333,14 @@ class FileOrganizerEngine(
                 val path = canonical(dir)
                 if (path.contains("/BaiZe归类/") || path.endsWith("/BaiZe归类")) continue
                 visited += 1
-                if (visited % 500 == 0) progress(Progress("正在发现全部下载目录", visited, 0, displayPath(path)))
+                if (visited % 500 == 0) progress(Progress("正在发现下载与接收目录", visited, 0, displayPath(path)))
                 if (isDownloadDirectoryName(dir.name) && allowedDownloadRoot(path)) {
                     roots.putIfAbsent(path, dir)
                     continue
                 }
                 if (depth >= depthLimit || shouldPruneDiscovery(path, dir.name)) continue
-                val children = dir.listFiles() ?: continue
-                children.filter { it.isDirectory && !isSymlink(it) }.forEach { stack.add(it to depth + 1) }
+                dir.listFiles()?.filter { it.isDirectory && !isSymlink(it) }
+                    ?.forEach { stack.add(it to depth + 1) }
             }
         }
         return roots.values.sortedBy { it.path }
@@ -323,13 +368,12 @@ class FileOrganizerEngine(
             if (!path.startsWith("$rootPath/") && path != rootPath) continue
             if (file.isDirectory) {
                 if (depth >= MAX_FILE_DEPTH) continue
-                val children = file.listFiles() ?: continue
-                children.forEach { stack.add(it to depth + 1) }
+                file.listFiles()?.forEach { stack.add(it to depth + 1) }
                 continue
             }
             if (!file.isFile || skipFile(file)) continue
             visited += 1
-            if (visited % 200 == 0) progress(Progress("正在建立不可变归类计划", visited, 0, displayPath(path)))
+            if (visited % 200 == 0) progress(Progress("正在建立不可变归类计划", out.size, MAX_ITEMS, displayPath(path)))
             val sourceStat = runCatching { Os.lstat(file.path) }.getOrNull() ?: continue
             val statFingerprint = fingerprint(sourceStat)
             val category = category(file.name)
@@ -360,7 +404,7 @@ class FileOrganizerEngine(
         if (sourcePath != item.source) return "源路径已变化"
         if (!source.isFile) return "文件已不存在"
         if (isSymlink(source)) return "符号链接受保护"
-        if (!allowedDownloadSource(sourcePath)) return "源文件不再属于下载目录"
+        if (!allowedDownloadSource(sourcePath)) return "源文件不再属于下载或接收目录"
         if (fingerprint(source) != item.fingerprint) return "文件在扫描后发生变化"
         if (destination.exists()) return "归类目录已有同名文件"
         if (!destination.path.startsWith("/data/media/")) return "目标路径超出公共归类目录"
@@ -413,13 +457,22 @@ class FileOrganizerEngine(
         return current
     }
 
-    private fun parseSelection(raw: String): Set<String> {
+    private fun parseSelection(raw: String): Selection {
         val json = runCatching { JSONObject(raw) }.getOrDefault(JSONObject())
-        val array = json.optJSONArray("ids") ?: JSONArray()
+        return Selection(
+            all = json.optBoolean("all", false),
+            ids = parseIds(json.optJSONArray("ids")),
+            excludedIds = parseIds(json.optJSONArray("excludeIds"))
+        )
+    }
+
+    private fun parseIds(array: JSONArray?): Set<String> {
         val result = LinkedHashSet<String>()
+        if (array == null) return result
         for (index in 0 until array.length()) {
             val id = array.optString(index)
-            if (id.matches(Regex("^[a-f0-9]{64}$"))) result += id
+            if (id.matches(ID_PATTERN)) result += id
+            if (result.size >= MAX_SELECTION_IDS) break
         }
         return result
     }
@@ -450,12 +503,12 @@ class FileOrganizerEngine(
         var parent = file.parentFile
         while (parent != null && canonical(parent).startsWith(root.path + "/")) {
             Os.chown(parent.path, owner.st_uid, owner.st_gid)
-            Os.chmod(parent.path, 0x1F8) // 0770
+            Os.chmod(parent.path, 0x1F8)
             if (canonical(parent) == root.path) break
             parent = parent.parentFile
         }
         Os.chown(file.path, owner.st_uid, owner.st_gid)
-        Os.chmod(file.path, 0x1B0) // 0660
+        Os.chmod(file.path, 0x1B0)
         true
     }.getOrDefault(false)
 
@@ -477,7 +530,7 @@ class FileOrganizerEngine(
     private fun allowedDownloadRoot(path: String): Boolean {
         if (!path.startsWith("/data/media/") && !path.startsWith("/data/user/") && !path.startsWith("/data/user_de/")) return false
         if (path.contains("/BaiZe归类/") || path.endsWith("/BaiZe归类")) return false
-        return path.split('/').any { segment -> isDownloadDirectoryName(segment) }
+        return path.split('/').any(::isDownloadDirectoryName)
     }
 
     private fun allowedDownloadSource(path: String): Boolean =
@@ -491,8 +544,8 @@ class FileOrganizerEngine(
     }
 
     private fun isDownloadDirectoryName(name: String): Boolean {
-        val normalized = name.trim().lowercase()
-        return normalized == "download" || normalized == "downloads" || normalized == "下载"
+        val normalized = name.trim().lowercase().replace('-', '_').replace(' ', '_')
+        return normalized in DOWNLOAD_DIRECTORY_NAMES
     }
 
     private fun skipFile(file: File): Boolean {
@@ -520,6 +573,9 @@ class FileOrganizerEngine(
     }
 
     private fun sourceGroup(path: String): String {
+        val lower = path.lowercase()
+        if (lower.contains("/qqfile_recv/") || lower.endsWith("/qqfile_recv")) return "QQ 接收文件"
+        if (lower.contains("/timfile_recv/") || lower.endsWith("/timfile_recv")) return "TIM 接收文件"
         val packageName = Regex("/Android/(?:data|media)/([^/]+)/").find("$path/")?.groupValues?.getOrNull(1)
             ?: Regex("/data/(?:user|user_de)/\\d+/([^/]+)/").find("$path/")?.groupValues?.getOrNull(1)
         return packageName ?: "公共下载"
@@ -567,23 +623,47 @@ class FileOrganizerEngine(
             .digest(value.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
 
+    private fun itemJson(item: PlannedMove): JSONObject =
+        JSONObject()
+            .put("id", item.id)
+            .put("name", item.name.take(MAX_NAME_CHARS))
+            .put("category", item.category)
+            .put("bytes", item.bytes)
+            .put("sourceGroup", item.sourceGroup.take(MAX_GROUP_CHARS))
+            .put("sourceDisplay", displayPath(item.source).take(MAX_PATH_CHARS))
+            .put("destinationDisplay", displayPath(item.destination).take(MAX_PATH_CHARS))
+            .put("destinationName", File(item.destination).name.take(MAX_NAME_CHARS))
+
     private fun detail(item: PlannedMove, action: String, reason: String): JSONObject =
         JSONObject()
             .put("id", item.id)
-            .put("name", item.name)
+            .put("name", item.name.take(MAX_NAME_CHARS))
             .put("category", item.category)
-            .put("sourceGroup", item.sourceGroup)
+            .put("sourceGroup", item.sourceGroup.take(MAX_GROUP_CHARS))
             .put("action", action)
-            .put("reason", reason)
+            .put("reason", reason.take(160))
 
     private fun error(code: String, message: String): String =
         JSONObject().put("success", false).put("error", code).put("message", message).toString()
 
     companion object {
+        private val ID_PATTERN = Regex("^[a-f0-9]{64}$")
+        private val DOWNLOAD_DIRECTORY_NAMES = setOf(
+            "download", "downloads", "下载",
+            "qqfile_recv", "qqmy_file_recv", "qqfile_receive",
+            "timfile_recv", "tim_file_recv"
+        )
         private const val SNAPSHOT_TTL_MS = 30L * 60_000L
-        private const val DISCOVERY_BUDGET_MS = 45_000L
-        private const val SCAN_BUDGET_MS = 2L * 60_000L
-        private const val MAX_ITEMS = 5_000
+        private const val DISCOVERY_BUDGET_MS = 60_000L
+        private const val SCAN_BUDGET_MS = 3L * 60_000L
+        private const val MAX_ITEMS = 20_000
         private const val MAX_FILE_DEPTH = 12
+        private const val DEFAULT_PAGE_SIZE = 60
+        private const val MAX_PAGE_SIZE = 100
+        private const val MAX_SELECTION_IDS = 20_000
+        private const val MAX_RESULT_DETAILS = 40
+        private const val MAX_PATH_CHARS = 360
+        private const val MAX_NAME_CHARS = 160
+        private const val MAX_GROUP_CHARS = 80
     }
 }

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.1.0-alpha9
-versionCode=22409
+version=v2.1.0-alpha10
+versionCode=22410
 author=惜故里丶
-description=白泽 v2.1.0 Alpha 9：文件归类界面重做、归类去向展示与真实定时归类。
+description=白泽 v2.1.0 Alpha 10：修复大量文件 Binder 崩溃，支持 QQ/TIM 接收目录与服务端完整归类计划。

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/debug/app-debug.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2.1.0-alpha9-Module.zip"
+OUTPUT="$OUT/BaiZe-v2.1.0-alpha10-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -75,8 +75,8 @@ unzip -p "$OUTPUT" config/default.conf | grep -q '^scan_root_workers=0$'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-scanner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
-unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha9$'
-unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22409$'
+unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha10$'
+unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22410$'
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1
@@ -87,4 +87,4 @@ if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.1.0 Alpha 9 文件归类界面与定时归类模块：$OUTPUT"
+echo "已生成白泽 v2.1.0 Alpha 10 Binder 安全文件归类模块：$OUTPUT"


### PR DESCRIPTION
## 真机问题根因

Alpha 9 有两个独立缺陷：

- 文件归类扫描把最多 5000 条完整文件详情一次通过 Binder 返回，QQ 下载文件较多时会超过 Binder 事务缓冲区，Root 进程断开并显示 `Transaction failed on small parcel`。
- 下载目录识别只接受 `Download`、`Downloads` 和 `下载`，没有识别 QQ/TIM 实际使用的 `Tencent/QQfile_recv`、`TIMfile_recv`。

## Alpha 10 修复

- Root 端保存完整不可变移动计划，扫描响应只返回统计与前 60 条预览，Binder 数据量固定受限。
- 手动和定时归类使用微小的服务端 `all=true` 请求，不再传递几千个文件 ID。
- Apply/Undo 结果详情最多返回 40 条，避免归类完成时再次撑爆 Binder。
- 扫描上限提高至 20000 个文件，扫描时间预算提高至 3 分钟。
- 新增 `QQfile_recv`、`QQMy file_recv`、`TIMfile_recv` 等接收目录识别，并标记为 QQ/TIM 接收文件。
- UI 明确显示总文件数、总大小和前 60 条预览；默认归类完整计划，可排除预览中的文件。

## 版本

- App：`2.1.0-alpha10`
- 模块：`v2.1.0-alpha10`
- versionCode：`22410`

## 验证

新增 Alpha 10 独立 CI：检查 Binder 边界、QQ/TIM 路径、Android App、ARM64 引擎、模块 ZIP、版本一致性和无 WebUI。