### PR TITLE
feat(v2): v2.1.0 Alpha 11 根目录散落文件与一键归类

### DIFF
--- a/.github/workflows/v2.1.0-alpha11-direct-verify.yml
+++ b/.github/workflows/v2.1.0-alpha11-direct-verify.yml
@@ -1,0 +1,113 @@
+name: BaiZe v2.1.0 Alpha 11 Direct Verify
+
+on:
+  pull_request:
+    branches: [feat/v2.1.0-alpha10-binder-pagination]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Alpha 11 source
+        uses: actions/checkout@v4
+        with:
+          ref: feat/v2.1.0-alpha11-root-one-tap
+          fetch-depth: 0
+
+      - name: Check source and shell syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check origin/feat/v2.1.0-alpha10-binder-pagination...HEAD
+          sh -n v2/module/one-pass-scan.sh
+          sh -n v2/module/native-scan.sh
+          sh -n v2/scripts/build-native.sh
+          sh -n v2/scripts/package-module.sh
+
+      - name: Verify root files and one-tap organizer
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENGINE=v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
+          UI=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+          WORKER=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+          grep -q 'collectTopLevelMediaFiles' "$ENGINE"
+          grep -q 'MEDIA_ROOT_FILE' "$ENGINE"
+          grep -q '内部存储根目录' "$ENGINE"
+          grep -q 'mediaRoot.listFiles()?.filter { it.isFile' "$ENGINE"
+          grep -q 'allowedOrganizerSource' "$ENGINE"
+          grep -q '一键归类全部散落文件' "$UI"
+          grep -q '无需二次确认' "$UI"
+          grep -q 'put("all", true)' "$UI"
+          grep -q '内部存储根目录、下载与 QQ/TIM 接收目录' "$UI"
+          grep -q 'put("all", true)' "$WORKER"
+          ! grep -q 'Checkbox' "$UI"
+          ! grep -q '扫描结果' "$UI"
+          ! grep -q 'onApply' "$UI"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build ARM64 scanner
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build Android App
+        working-directory: v2
+        shell: bash
+        run: |
+          set -o pipefail
+          gradle --no-daemon :app:assembleDebug 2>&1 | tee android-build.log
+
+      - name: Upload Android build failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-alpha11-build-failure-log
+          path: v2/android-build.log
+          if-no-files-found: ignore
+
+      - name: Package Alpha 11 module
+        working-directory: v2
+        run: sh scripts/package-module.sh
+
+      - name: Verify final package
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP=v2/dist/BaiZe-v2.1.0-alpha11-Module.zip
+          test -s "$ZIP"
+          unzip -tq "$ZIP"
+          unzip -p "$ZIP" module.prop | grep -qx 'version=v2.1.0-alpha11'
+          unzip -p "$ZIP" module.prop | grep -qx 'versionCode=22411'
+          grep -q 'versionName = "2.1.0-alpha11"' v2/app/build.gradle.kts
+          grep -q 'versionCode = 22411' v2/app/build.gradle.kts
+          ! unzip -Z1 "$ZIP" | grep -Eq '^(webroot|webui|www|ksu-webui)/'
+          sha256sum "$ZIP" | tee "$ZIP.sha256"
+
+      - name: Upload Alpha 11 module
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.1.0-alpha11-Root-One-Tap-Organizer
+          if-no-files-found: error
+          path: |
+            v2/dist/BaiZe-v2.1.0-alpha11-Module.zip
+            v2/dist/BaiZe-v2.1.0-alpha11-Module.zip.sha256

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22410
-        versionName = "2.1.0-alpha10"
+        versionCode = 22411
+        versionName = "2.1.0-alpha11"
     }
 
     buildFeatures {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
@@ -10,7 +10,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -24,20 +23,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ArrowBack
-import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.FolderCopy
-import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Restore
 import androidx.compose.material.icons.rounded.Schedule
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -59,7 +55,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
@@ -73,7 +68,6 @@ import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.json.JSONArray
 import org.json.JSONObject
 
 class FileOrganizerActivity : ComponentActivity() {
@@ -110,10 +104,7 @@ class FileOrganizerActivity : ComponentActivity() {
                     schedule = schedule,
                     scheduleSavedText = scheduleSavedText,
                     onBack = ::finish,
-                    onScan = ::scan,
-                    onToggle = ::toggle,
-                    onToggleAll = ::toggleAll,
-                    onApply = ::applySelected,
+                    onOneTap = ::oneTapOrganize,
                     onUndo = ::undoLast,
                     onStop = {
                         service?.cancelCurrentTask()
@@ -155,64 +146,52 @@ class FileOrganizerActivity : ComponentActivity() {
         scheduleSavedText = if (schedule.enabled) "已保存：每 ${schedule.intervalHours} 小时自动归类" else "定时归类已关闭"
     }
 
-    private fun scan() {
+    private fun oneTapOrganize() {
         val root = service ?: return
         if (state.running) return
-        state = FileOrganizerUiState(
-            connected = true,
+        state = state.copy(
             running = true,
-            status = "正在扫描下载目录、QQ/TIM 接收目录…",
-            undoAvailable = state.undoAvailable
+            status = "正在扫描内部存储根目录、下载与 QQ/TIM 接收目录…",
+            lastTotal = 0,
+            lastBytes = 0L
         )
         lifecycleScope.launch {
-            val summary = withContext(Dispatchers.IO) {
+            val scan = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.scanFileOrganizer()) }.getOrElse {
                     JSONObject().put("error", "scan_failed").put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
-            if (summary.has("error")) {
-                state = state.copy(running = false, status = summary.optString("message", "文件归类扫描失败"))
+            if (scan.has("error")) {
+                state = state.copy(running = false, status = scan.optString("message", "文件归类扫描失败"))
                 return@launch
             }
-            if (summary.optBoolean("cancelled")) {
-                state = state.copy(running = false, status = "文件归类扫描已停止")
+            if (scan.optBoolean("cancelled")) {
+                state = state.copy(running = false, status = "一键归类已停止")
                 return@launch
             }
-            val snapshotId = summary.optString("snapshotId")
-            val total = summary.optInt("total")
-            val preview = parseItems(summary.optJSONArray("items"))
-            state = state.copy(
-                running = false,
-                snapshotId = snapshotId,
-                total = total,
-                totalBytes = summary.optLong("totalBytes"),
-                roots = summary.optInt("roots"),
-                truncated = summary.optBoolean("truncated"),
-                items = preview,
-                allSelected = true,
-                selected = emptySet(),
-                excluded = emptySet(),
-                status = buildString {
-                    if (total == 0) append("扫描完成：没有需要归类的新文件")
-                    else append("扫描完成：${summary.optInt("roots")} 个目录 · $total 个文件")
-                    if (summary.optBoolean("truncated")) append(" · 已达到安全上限")
-                }
-            )
-        }
-    }
 
-    private fun applySelected() {
-        val root = service ?: return
-        if (state.running || state.snapshotId.isBlank() || selectedCount(state) <= 0) return
-        val request = JSONObject()
-            .put("all", state.allSelected)
-            .put("ids", JSONArray(state.selected.toList()))
-            .put("excludeIds", JSONArray(state.excluded.toList()))
-            .toString()
-        state = state.copy(running = true, status = "正在归类 ${selectedCount(state)} 个文件…")
-        lifecycleScope.launch {
+            val snapshotId = scan.optString("snapshotId")
+            val total = scan.optInt("total")
+            val totalBytes = scan.optLong("totalBytes")
+            if (snapshotId.isBlank() || total == 0) {
+                state = state.copy(
+                    running = false,
+                    status = "一键归类完成：没有需要移动的散落文件",
+                    lastTotal = 0,
+                    lastBytes = 0L
+                )
+                return@launch
+            }
+
+            state = state.copy(
+                status = "扫描到 $total 个文件，正在自动归类，无需二次确认…",
+                lastTotal = total,
+                lastBytes = totalBytes
+            )
             val result = withContext(Dispatchers.IO) {
-                runCatching { JSONObject(root.applyFileOrganizer(state.snapshotId, request)) }.getOrElse {
+                runCatching {
+                    JSONObject(root.applyFileOrganizer(snapshotId, JSONObject().put("all", true).toString()))
+                }.getOrElse {
                     JSONObject().put("error", "apply_failed").put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
@@ -220,12 +199,17 @@ class FileOrganizerActivity : ComponentActivity() {
                 state = state.copy(running = false, status = result.optString("message", "文件归类失败"))
                 return@launch
             }
-            val text = "归类完成：移动 ${result.optInt("moved")} 个 · 跳过 ${result.optInt("skipped")} 个 · 失败 ${result.optInt("failed")} 个 · ${Formatter.formatFileSize(this@FileOrganizerActivity, result.optLong("bytes"))}"
-            state = FileOrganizerUiState(
-                connected = true,
+
+            val moved = result.optInt("moved")
+            val skipped = result.optInt("skipped")
+            val failed = result.optInt("failed")
+            val bytes = result.optLong("bytes")
+            state = state.copy(
                 running = false,
-                status = text,
-                undoAvailable = result.optBoolean("undoAvailable")
+                status = "一键归类完成：移动 $moved/$total 个 · 跳过 $skipped 个 · 失败 $failed 个 · ${Formatter.formatFileSize(this@FileOrganizerActivity, bytes)}",
+                undoAvailable = result.optBoolean("undoAvailable"),
+                lastTotal = total,
+                lastBytes = bytes
             )
         }
     }
@@ -252,85 +236,20 @@ class FileOrganizerActivity : ComponentActivity() {
         }
     }
 
-    private fun toggle(id: String) {
-        if (state.running) return
-        if (state.allSelected) {
-            val next = state.excluded.toMutableSet()
-            if (!next.add(id)) next.remove(id)
-            state = state.copy(excluded = next)
-        } else {
-            val next = state.selected.toMutableSet()
-            if (!next.add(id)) next.remove(id)
-            state = state.copy(selected = next)
-        }
-    }
-
-    private fun toggleAll() {
-        if (state.running || state.total == 0) return
-        state = if (state.allSelected) {
-            state.copy(allSelected = false, selected = emptySet(), excluded = emptySet())
-        } else {
-            state.copy(allSelected = true, selected = emptySet(), excluded = emptySet())
-        }
-    }
-
-    private fun parseItems(array: JSONArray?): List<FileOrganizerItem> = buildList {
-        if (array == null) return@buildList
-        for (index in 0 until array.length()) {
-            val item = array.optJSONObject(index) ?: continue
-            val id = item.optString("id")
-            if (id.isBlank()) continue
-            add(
-                FileOrganizerItem(
-                    id = id,
-                    name = item.optString("name"),
-                    category = item.optString("category", "其他"),
-                    bytes = item.optLong("bytes"),
-                    sourceGroup = item.optString("sourceGroup", "公共下载"),
-                    sourceDisplay = item.optString("sourceDisplay"),
-                    destinationDisplay = item.optString("destinationDisplay")
-                )
-            )
-        }
-    }
-
     override fun onDestroy() {
         if (bound) runCatching { RootService.unbind(connection) }
         super.onDestroy()
     }
 }
 
-private data class FileOrganizerItem(
-    val id: String,
-    val name: String,
-    val category: String,
-    val bytes: Long,
-    val sourceGroup: String,
-    val sourceDisplay: String,
-    val destinationDisplay: String
-)
-
 private data class FileOrganizerUiState(
     val connected: Boolean = false,
     val running: Boolean = false,
     val status: String = "等待连接",
-    val snapshotId: String = "",
-    val roots: Int = 0,
-    val total: Int = 0,
-    val totalBytes: Long = 0,
-    val truncated: Boolean = false,
-    val items: List<FileOrganizerItem> = emptyList(),
-    val allSelected: Boolean = true,
-    val selected: Set<String> = emptySet(),
-    val excluded: Set<String> = emptySet(),
-    val undoAvailable: Boolean = true
+    val undoAvailable: Boolean = true,
+    val lastTotal: Int = 0,
+    val lastBytes: Long = 0L
 )
-
-private fun selectedCount(state: FileOrganizerUiState): Int =
-    if (state.allSelected) (state.total - state.excluded.size).coerceAtLeast(0) else state.selected.size
-
-private fun isChecked(state: FileOrganizerUiState, id: String): Boolean =
-    if (state.allSelected) id !in state.excluded else id in state.selected
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -339,26 +258,26 @@ private fun FileOrganizerScreen(
     schedule: FileOrganizerScheduleSettings,
     scheduleSavedText: String,
     onBack: () -> Unit,
-    onScan: () -> Unit,
-    onToggle: (String) -> Unit,
-    onToggleAll: () -> Unit,
-    onApply: () -> Unit,
+    onOneTap: () -> Unit,
     onUndo: () -> Unit,
     onStop: () -> Unit,
     onScheduleChange: (FileOrganizerScheduleSettings) -> Unit,
     onSaveSchedule: () -> Unit
 ) {
-    val context = LocalContext.current
     Scaffold(
         topBar = {
             TopAppBar(
                 title = {
                     Column {
                         Text("文件归类", fontWeight = FontWeight.Black, fontSize = 24.sp)
-                        Text("下载、QQ/TIM 接收文件与定时归类", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text("一键归类与定时归类", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                 },
-                navigationIcon = { IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") } },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Rounded.ArrowBack, contentDescription = "返回")
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
             )
         }
@@ -375,23 +294,33 @@ private fun FileOrganizerScreen(
                 ) {
                     Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(Icons.Rounded.FolderCopy, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(32.dp))
+                            Icon(
+                                Icons.Rounded.FolderCopy,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(32.dp)
+                            )
                             Spacer(Modifier.size(12.dp))
                             Column(Modifier.weight(1f)) {
                                 Text(state.status, fontWeight = FontWeight.Black, fontSize = 18.sp)
-                                Text("支持 Download、Downloads、下载、QQfile_recv 与 TIMfile_recv；大量文件只预览前 60 个，完整计划保留在 Root 端。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 18.sp)
+                                Text(
+                                    "点一次自动扫描并归类，无需再确认。范围包括内部存储根目录的散落文件、Download、QQ/TIM 接收目录及可读取的应用下载目录。",
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    fontSize = 12.sp,
+                                    lineHeight = 18.sp
+                                )
                             }
                             if (state.running) CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
                         }
                         Button(
-                            onClick = if (state.running) onStop else onScan,
+                            onClick = if (state.running) onStop else onOneTap,
                             enabled = state.connected,
-                            modifier = Modifier.fillMaxWidth().height(54.dp),
+                            modifier = Modifier.fillMaxWidth().height(56.dp),
                             shape = RoundedCornerShape(18.dp)
                         ) {
-                            Icon(if (state.running) Icons.Rounded.Stop else Icons.Rounded.Refresh, contentDescription = null)
+                            Icon(if (state.running) Icons.Rounded.Stop else Icons.Rounded.AutoAwesome, contentDescription = null)
                             Spacer(Modifier.size(8.dp))
-                            Text(if (state.running) "停止当前任务" else "扫描下载与 QQ/TIM 接收目录", fontWeight = FontWeight.Black)
+                            Text(if (state.running) "停止当前任务" else "一键归类全部散落文件", fontWeight = FontWeight.Black)
                         }
                         OutlinedButton(
                             onClick = onUndo,
@@ -407,61 +336,28 @@ private fun FileOrganizerScreen(
                 }
             }
 
+            item { SourceCard() }
             item { DestinationCard() }
             item { ScheduleCard(schedule, scheduleSavedText, onScheduleChange, onSaveSchedule) }
+        }
+    }
+}
 
-            if (state.snapshotId.isNotBlank()) {
-                item {
-                    Card(
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-                        shape = RoundedCornerShape(24.dp)
-                    ) {
-                        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Text("扫描结果", fontWeight = FontWeight.Black, fontSize = 19.sp)
-                            Text("${state.total} 个文件 · ${Formatter.formatFileSize(context, state.totalBytes)} · 预览前 ${state.items.size} 个", color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            Text(
-                                if (state.allSelected) "默认归类全部；当前排除 ${state.excluded.size} 个" else "当前只归类手动勾选的 ${state.selected.size} 个",
-                                color = MaterialTheme.colorScheme.primary,
-                                fontWeight = FontWeight.Bold
-                            )
-                            OutlinedButton(onClick = onToggleAll, enabled = !state.running, modifier = Modifier.fillMaxWidth()) {
-                                Text(if (state.allSelected) "取消全选" else "选择全部 ${state.total} 个")
-                            }
-                        }
-                    }
-                }
-
-                items(state.items, key = { it.id }) { item ->
-                    Card(
-                        modifier = Modifier.fillMaxWidth().clickable(enabled = !state.running) { onToggle(item.id) },
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
-                        shape = RoundedCornerShape(20.dp)
-                    ) {
-                        Row(Modifier.padding(14.dp), verticalAlignment = Alignment.CenterVertically) {
-                            Checkbox(checked = isChecked(state, item.id), onCheckedChange = { onToggle(item.id) }, enabled = !state.running)
-                            Column(Modifier.weight(1f)) {
-                                Text(item.name, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                                Text("${item.category} · ${item.sourceGroup} · ${Formatter.formatFileSize(context, item.bytes)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
-                                Text("来源：${item.sourceDisplay}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                                Text("去向：${item.destinationDisplay}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                            }
-                        }
-                    }
-                }
-
-                item {
-                    Button(
-                        onClick = onApply,
-                        enabled = state.connected && !state.running && selectedCount(state) > 0,
-                        modifier = Modifier.fillMaxWidth().height(58.dp),
-                        shape = RoundedCornerShape(20.dp)
-                    ) {
-                        Icon(Icons.Rounded.CheckCircle, contentDescription = null)
-                        Spacer(Modifier.size(8.dp))
-                        Text("归类 ${selectedCount(state)} 个文件", fontWeight = FontWeight.Black)
-                    }
-                }
-            }
+@Composable
+private fun SourceCard() {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        shape = RoundedCornerShape(24.dp)
+    ) {
+        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text("从哪里归类", fontWeight = FontWeight.Black, fontSize = 19.sp)
+            Text("内部存储根目录", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+            Text(
+                "只处理根目录中直接散落的文件，不递归搬动 Android、DCIM、Documents、Movies 等正常文件夹。另会扫描 Download、QQfile_recv、TIMfile_recv 和应用下载目录。",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                lineHeight = 18.sp
+            )
         }
     }
 }
@@ -476,12 +372,14 @@ private fun DestinationCard() {
         Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Text("归类到哪里", fontWeight = FontWeight.Black, fontSize = 19.sp)
             Text("内部存储 / BaiZe归类", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
-            Text("每个文件按类型移动到对应子目录；遇到同名文件直接跳过，不覆盖。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            Text("按类型移动到对应子目录；遇到同名文件直接跳过，不覆盖。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
             Row(
                 modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                categories.forEach { category -> FilterChip(selected = false, onClick = {}, label = { Text(category) }) }
+                categories.forEach { category ->
+                    FilterChip(selected = false, onClick = {}, label = { Text(category) })
+                }
             }
         }
     }
@@ -505,16 +403,26 @@ private fun ScheduleCard(
                 Spacer(Modifier.size(10.dp))
                 Column(Modifier.weight(1f)) {
                     Text("定时归类", fontWeight = FontWeight.Black, fontSize = 19.sp)
-                    Text("由 WorkManager 实际执行扫描与归类", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                    Text("定时任务同样自动扫描并直接归类", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
                 }
                 Switch(checked = schedule.enabled, onCheckedChange = { onChange(schedule.copy(enabled = it)) })
             }
-            Row(Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 intervals.forEach { hours ->
                     FilterChip(
                         selected = schedule.intervalHours == hours,
                         onClick = { onChange(schedule.copy(intervalHours = hours)) },
-                        label = { Text(when (hours) { 24 -> "每天"; 72 -> "每3天"; 168 -> "每周"; else -> "${hours}小时" }) }
+                        label = {
+                            Text(when (hours) {
+                                24 -> "每天"
+                                72 -> "每3天"
+                                168 -> "每周"
+                                else -> "${hours}小时"
+                            })
+                        }
                     )
                 }
             }
@@ -524,7 +432,9 @@ private fun ScheduleCard(
             Text("上次执行：${FileOrganizerWorker.lastRunText(LocalContext.current, schedule)}", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Text(schedule.lastResult, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             if (savedText.isNotBlank()) Text(savedText, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
-            Button(onClick = onSave, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) { Text("保存定时归类", fontWeight = FontWeight.Black) }
+            Button(onClick = onSave, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) {
+                Text("保存定时归类", fontWeight = FontWeight.Black)
+            }
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
@@ -16,9 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Root-side immutable file organizer plan.
  *
- * Binder responses are deliberately bounded: scan returns only a summary and the first preview
- * page, while apply/undo detail arrays are capped. The complete move plan remains inside the Root
- * process so large QQ/TIM receive folders never overflow Binder's transaction buffer.
+ * Binder responses are bounded. The complete move plan remains inside the Root process, while the
+ * App only receives a small summary. Alpha 11 also treats regular files placed directly in
+ * /data/media/<user> as organizer sources without recursively sweeping unrelated top-level folders.
  */
 class FileOrganizerEngine(
     private val cancelled: AtomicBoolean,
@@ -66,17 +66,32 @@ class FileOrganizerEngine(
     fun scan(progress: (Progress) -> Unit): String {
         cancelled.set(false)
         val started = SystemClock.elapsedRealtime()
-        val roots = discoverDownloadRoots(started, progress)
+        val mediaRoots = mediaUserRoots()
+        val downloadRoots = discoverDownloadRoots(started, progress)
         if (cancelled.get()) {
             return JSONObject().put("cancelled", true).put("message", "文件归类扫描已停止").toString()
         }
 
         val items = LinkedHashMap<String, PlannedMove>()
-        for ((index, root) in roots.withIndex()) {
-            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) break
-            progress(Progress("正在读取下载目录", index + 1, roots.size, displayPath(root.path)))
+        val sourceCount = mediaRoots.size + downloadRoots.size
+
+        mediaRoots.forEachIndexed { index, root ->
+            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return@forEachIndexed
+            progress(Progress("正在读取内部存储根目录", index + 1, sourceCount, displayPath(root.path)))
+            collectTopLevelMediaFiles(root, started, items, progress)
+        }
+
+        downloadRoots.forEachIndexed { index, root ->
+            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return@forEachIndexed
+            progress(
+                Progress(
+                    "正在读取下载与接收目录",
+                    mediaRoots.size + index + 1,
+                    sourceCount,
+                    displayPath(root.path)
+                )
+            )
             collectFiles(root, started, items, progress)
-            if (items.size >= MAX_ITEMS) break
         }
 
         val immutable = items.values.sortedWith(
@@ -86,7 +101,7 @@ class FileOrganizerEngine(
         )
         val id = UUID.randomUUID().toString()
         val truncated = immutable.size >= MAX_ITEMS || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS
-        snapshot = Snapshot(id, System.currentTimeMillis(), roots.size, truncated, immutable)
+        snapshot = Snapshot(id, System.currentTimeMillis(), sourceCount, truncated, immutable)
 
         val categoryCounts = JSONObject()
         val sourceCounts = JSONObject()
@@ -103,7 +118,7 @@ class FileOrganizerEngine(
             .put("success", true)
             .put("snapshotId", id)
             .put("expiresInMs", SNAPSHOT_TTL_MS)
-            .put("roots", roots.size)
+            .put("roots", sourceCount)
             .put("total", immutable.size)
             .put("totalBytes", totalBytes)
             .put("truncated", truncated)
@@ -118,12 +133,12 @@ class FileOrganizerEngine(
 
     fun page(snapshotId: String, offset: Int, limit: Int): String {
         val current = validSnapshot(snapshotId)
-            ?: return error("snapshot_expired", "文件归类计划不存在或已过期，请重新扫描")
+            ?: return error("snapshot_expired", "文件归类计划不存在或已过期，请重新执行一键归类")
         val safeOffset = offset.coerceIn(0, current.items.size)
         val safeLimit = limit.coerceIn(1, MAX_PAGE_SIZE)
         val end = (safeOffset + safeLimit).coerceAtMost(current.items.size)
         val array = JSONArray()
-        current.items.subList(safeOffset, end).forEach { item -> array.put(itemJson(item)) }
+        current.items.subList(safeOffset, end).forEach { array.put(itemJson(it)) }
         return JSONObject()
             .put("success", true)
             .put("snapshotId", current.id)
@@ -138,14 +153,14 @@ class FileOrganizerEngine(
 
     fun apply(snapshotId: String, selectionJson: String, progress: (Progress) -> Unit): String {
         val current = validSnapshot(snapshotId)
-            ?: return error("snapshot_expired", "文件归类计划不存在或已过期，请重新扫描")
+            ?: return error("snapshot_expired", "文件归类计划不存在或已过期，请重新执行一键归类")
         val selection = parseSelection(selectionJson)
         val selected = if (selection.all) {
             current.items.filterNot { it.id in selection.excludedIds }
         } else {
             current.items.filter { it.id in selection.ids }
         }
-        if (selected.isEmpty()) return error("empty_selection", "没有选择需要归类的文件")
+        if (selected.isEmpty()) return error("empty_selection", "没有需要归类的文件")
 
         val moves = JSONArray()
         val details = JSONArray()
@@ -156,11 +171,8 @@ class FileOrganizerEngine(
         var bytes = 0L
 
         fun appendDetail(item: PlannedMove, action: String, reason: String) {
-            if (details.length() < MAX_RESULT_DETAILS) {
-                details.put(detail(item, action, reason))
-            } else {
-                detailTruncated = true
-            }
+            if (details.length() < MAX_RESULT_DETAILS) details.put(detail(item, action, reason))
+            else detailTruncated = true
         }
 
         for ((index, item) in selected.withIndex()) {
@@ -253,7 +265,7 @@ class FileOrganizerEngine(
                 !destination.isFile -> "归类后的文件已不存在"
                 isSymlink(destination) -> "符号链接不允许撤销"
                 expected.isBlank() || fingerprint(destination) != expected -> "归类后的文件已发生变化"
-                !allowedDownloadSource(source.path) -> "原路径不再属于允许的下载目录"
+                !allowedOrganizerSource(source.path) -> "原路径不再属于允许的归类来源"
                 else -> null
             }
             if (reason != null) {
@@ -281,9 +293,8 @@ class FileOrganizerEngine(
                     true
                 }
             }.getOrDefault(false)
-            if (ok) {
-                restored += 1
-            } else {
+            if (ok) restored += 1
+            else {
                 failed += 1
                 remaining.put(move)
                 appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "failed").put("reason", "恢复失败"))
@@ -303,13 +314,16 @@ class FileOrganizerEngine(
             .toString()
     }
 
+    private fun mediaUserRoots(): List<File> =
+        File("/data/media").listFiles()
+            ?.filter { it.isDirectory && it.name.all(Char::isDigit) && !isSymlink(it) }
+            ?.sortedBy { it.path }
+            .orEmpty()
+
     private fun discoverDownloadRoots(started: Long, progress: (Progress) -> Unit): List<File> {
         val roots = LinkedHashMap<String, File>()
         val scanBases = mutableListOf<Pair<File, Int>>()
-
-        File("/data/media").listFiles()
-            ?.filter { it.isDirectory && it.name.all(Char::isDigit) }
-            ?.forEach { scanBases += it to 8 }
+        mediaUserRoots().forEach { scanBases += it to 8 }
 
         listOf(File("/data/user"), File("/data/user_de")).forEach { base ->
             base.listFiles()
@@ -346,6 +360,23 @@ class FileOrganizerEngine(
         return roots.values.sortedBy { it.path }
     }
 
+    private fun collectTopLevelMediaFiles(
+        mediaRoot: File,
+        started: Long,
+        out: MutableMap<String, PlannedMove>,
+        progress: (Progress) -> Unit
+    ) {
+        val rootPath = canonical(mediaRoot)
+        val userId = userIdForPath("$rootPath/") ?: return
+        val files = mediaRoot.listFiles()?.filter { it.isFile && !isSymlink(it) }.orEmpty()
+        files.forEachIndexed { index, file ->
+            if (cancelled.get() || out.size >= MAX_ITEMS || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return
+            if (skipFile(file)) return@forEachIndexed
+            if (index % 100 == 0) progress(Progress("正在读取内部存储根目录文件", index + 1, files.size, displayPath(file.path)))
+            addPlannedMove(file, rootPath, "内部存储根目录", userId, out)
+        }
+    }
+
     private fun collectFiles(
         root: File,
         started: Long,
@@ -354,7 +385,6 @@ class FileOrganizerEngine(
     ) {
         val rootPath = canonical(root)
         val userId = userIdForPath(rootPath) ?: return
-        val destinationBase = File("/data/media/$userId/BaiZe归类")
         val sourceGroup = sourceGroup(rootPath)
         val stack = ArrayDeque<Pair<File, Int>>()
         stack.add(root to 0)
@@ -374,29 +404,40 @@ class FileOrganizerEngine(
             if (!file.isFile || skipFile(file)) continue
             visited += 1
             if (visited % 200 == 0) progress(Progress("正在建立不可变归类计划", out.size, MAX_ITEMS, displayPath(path)))
-            val sourceStat = runCatching { Os.lstat(file.path) }.getOrNull() ?: continue
-            val statFingerprint = fingerprint(sourceStat)
-            val category = category(file.name)
-            val destination = File(File(destinationBase, category), file.name)
-            val id = sha256Text("$path\u0000$statFingerprint")
-            out.putIfAbsent(
-                id,
-                PlannedMove(
-                    id = id,
-                    source = path,
-                    sourceRoot = rootPath,
-                    sourceGroup = sourceGroup,
-                    destination = destination.path,
-                    category = category,
-                    name = file.name,
-                    bytes = file.length().coerceAtLeast(0L),
-                    fingerprint = statFingerprint,
-                    sourceUid = sourceStat.st_uid,
-                    sourceGid = sourceStat.st_gid,
-                    sourceMode = sourceStat.st_mode
-                )
-            )
+            addPlannedMove(file, rootPath, sourceGroup, userId, out)
         }
+    }
+
+    private fun addPlannedMove(
+        file: File,
+        sourceRoot: String,
+        sourceGroup: String,
+        userId: Int,
+        out: MutableMap<String, PlannedMove>
+    ) {
+        val path = canonical(file)
+        val sourceStat = runCatching { Os.lstat(file.path) }.getOrNull() ?: return
+        val statFingerprint = fingerprint(sourceStat)
+        val category = category(file.name)
+        val destination = File(File("/data/media/$userId/BaiZe归类"), "$category/${file.name}")
+        val id = sha256Text("$path\u0000$statFingerprint")
+        out.putIfAbsent(
+            id,
+            PlannedMove(
+                id = id,
+                source = path,
+                sourceRoot = sourceRoot,
+                sourceGroup = sourceGroup,
+                destination = destination.path,
+                category = category,
+                name = file.name,
+                bytes = file.length().coerceAtLeast(0L),
+                fingerprint = statFingerprint,
+                sourceUid = sourceStat.st_uid,
+                sourceGid = sourceStat.st_gid,
+                sourceMode = sourceStat.st_mode
+            )
+        )
     }
 
     private fun validatePlannedMove(item: PlannedMove, source: File, destination: File): String? {
@@ -404,7 +445,7 @@ class FileOrganizerEngine(
         if (sourcePath != item.source) return "源路径已变化"
         if (!source.isFile) return "文件已不存在"
         if (isSymlink(source)) return "符号链接受保护"
-        if (!allowedDownloadSource(sourcePath)) return "源文件不再属于下载或接收目录"
+        if (!allowedOrganizerSource(sourcePath)) return "源文件不再属于允许的归类来源"
         if (fingerprint(source) != item.fingerprint) return "文件在扫描后发生变化"
         if (destination.exists()) return "归类目录已有同名文件"
         if (!destination.path.startsWith("/data/media/")) return "目标路径超出公共归类目录"
@@ -533,8 +574,10 @@ class FileOrganizerEngine(
         return path.split('/').any(::isDownloadDirectoryName)
     }
 
-    private fun allowedDownloadSource(path: String): Boolean =
-        allowedDownloadRoot(path.substringBeforeLast('/', path))
+    private fun allowedOrganizerSource(path: String): Boolean {
+        if (MEDIA_ROOT_FILE.matches(path)) return true
+        return allowedDownloadRoot(path.substringBeforeLast('/', path))
+    }
 
     private fun shouldPruneDiscovery(path: String, name: String): Boolean {
         val lower = name.lowercase()
@@ -564,7 +607,8 @@ class FileOrganizerEngine(
             "jpg", "jpeg", "png", "gif", "webp", "bmp", "heic", "heif", "avif", "dng", "raw" -> "图片"
             "mp4", "mkv", "mov", "avi", "webm", "flv", "wmv", "m4v", "3gp", "ts" -> "视频"
             "mp3", "flac", "wav", "m4a", "aac", "ogg", "opus", "ape", "wma", "amr" -> "音频"
-            "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "rtf", "csv", "md", "odt", "ods", "odp" -> "文档"
+            "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "txt", "rtf", "csv", "md",
+            "odt", "ods", "odp", "log", "json", "xml", "yaml", "yml", "conf", "ini" -> "文档"
             "apk", "apks", "xapk", "apkm", "aab" -> "安装包"
             "zip", "rar", "7z", "tar", "gz", "bz2", "xz", "zst", "tgz", "tbz2" -> "压缩包"
             "epub", "mobi", "azw", "azw3", "fb2", "cbz", "cbr", "djvu" -> "电子书"
@@ -573,6 +617,7 @@ class FileOrganizerEngine(
     }
 
     private fun sourceGroup(path: String): String {
+        if (MEDIA_ROOT_FILE.matches(path)) return "内部存储根目录"
         val lower = path.lowercase()
         if (lower.contains("/qqfile_recv/") || lower.endsWith("/qqfile_recv")) return "QQ 接收文件"
         if (lower.contains("/timfile_recv/") || lower.endsWith("/timfile_recv")) return "TIM 接收文件"
@@ -582,9 +627,9 @@ class FileOrganizerEngine(
     }
 
     private fun userIdForPath(path: String): Int? {
-        val media = Regex("^/data/media/(\\d+)/").find("$path/")?.groupValues?.getOrNull(1)?.toIntOrNull()
+        val media = Regex("^/data/media/(\\d+)(?:/|$)").find(path)?.groupValues?.getOrNull(1)?.toIntOrNull()
         if (media != null) return media
-        return Regex("^/data/(?:user|user_de)/(\\d+)/").find("$path/")?.groupValues?.getOrNull(1)?.toIntOrNull()
+        return Regex("^/data/(?:user|user_de)/(\\d+)(?:/|$)").find(path)?.groupValues?.getOrNull(1)?.toIntOrNull()
     }
 
     private fun fingerprint(file: File): String = runCatching {
@@ -648,6 +693,7 @@ class FileOrganizerEngine(
 
     companion object {
         private val ID_PATTERN = Regex("^[a-f0-9]{64}$")
+        private val MEDIA_ROOT_FILE = Regex("^/data/media/\\d+/[^/]+$")
         private val DOWNLOAD_DIRECTORY_NAMES = setOf(
             "download", "downloads", "下载",
             "qqfile_recv", "qqmy_file_recv", "qqfile_receive",

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.1.0-alpha10
-versionCode=22410
+version=v2.1.0-alpha11
+versionCode=22411
 author=惜故里丶
-description=白泽 v2.1.0 Alpha 10：修复大量文件 Binder 崩溃，支持 QQ/TIM 接收目录与服务端完整归类计划。
+description=白泽 v2.1.0 Alpha 11：内部存储根目录散落文件归类，手动操作改为无需确认的一键归类。

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/debug/app-debug.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2.1.0-alpha10-Module.zip"
+OUTPUT="$OUT/BaiZe-v2.1.0-alpha11-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -75,8 +75,8 @@ unzip -p "$OUTPUT" config/default.conf | grep -q '^scan_root_workers=0$'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-scanner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
-unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha10$'
-unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22410$'
+unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha11$'
+unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22411$'
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1
@@ -87,4 +87,4 @@ if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.1.0 Alpha 10 Binder 安全文件归类模块：$OUTPUT"
+echo "已生成白泽 v2.1.0 Alpha 11 根目录一键归类模块：$OUTPUT"


### PR DESCRIPTION
## 真机反馈

- `/storage/emulated/0/` 根目录中直接散落的 ZIP、TXT、LOG 等文件没有进入归类计划。
- 手动操作仍然要求先扫描、再选择、再确认归类，不符合“一键整理”的使用方式。

## Alpha 11 修改

- 新增内部存储根目录直接文件扫描，对应 Root 路径 `/data/media/<user>/`。
- 只处理根目录直接存在的普通文件，不递归搬动 Android、DCIM、Documents、Movies 等正常目录。
- 根目录 ZIP/RAR/7z 进入压缩包，TXT/LOG/JSON/XML 等进入文档，其余按现有分类规则处理。
- 校验与撤销逻辑同步允许根目录来源，仍保留指纹复验、同名跳过和不可覆盖保护。
- 手动入口改成“一键归类全部散落文件”：一次点击完成扫描和完整计划执行，不再展示勾选列表或二次确认按钮。
- QQ/TIM、Download、应用下载目录、Binder 有界响应和真实定时归类全部保留。

## 版本

- App：`2.1.0-alpha11`
- 模块：`v2.1.0-alpha11`
- versionCode：`22411`

## 验证

新增 Alpha 11 独立 CI，验证根目录仅扫描直接文件、一键归类调用、无 Checkbox/确认步骤、Android App、ARM64 引擎、模块 ZIP 与版本一致性。