### PR TITLE
feat(v2): v2.1.0 Alpha 12 通用扫描所有应用下载目录

### DIFF
--- a/.github/workflows/v2.1.0-alpha12-direct-verify.yml
+++ b/.github/workflows/v2.1.0-alpha12-direct-verify.yml
@@ -1,0 +1,114 @@
+name: BaiZe v2.1.0 Alpha 12 Direct Verify
+
+on:
+  pull_request:
+    branches: [feat/v2.1.0-alpha11-root-one-tap]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Alpha 12 source
+        uses: actions/checkout@v4
+        with:
+          ref: feat/v2.1.0-alpha12-generic-app-downloads
+          fetch-depth: 0
+
+      - name: Check source and shell syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          git diff --check origin/feat/v2.1.0-alpha11-root-one-tap...HEAD
+          sh -n v2/module/one-pass-scan.sh
+          sh -n v2/module/native-scan.sh
+          sh -n v2/scripts/build-native.sh
+          sh -n v2/scripts/package-module.sh
+
+      - name: Verify generic app download discovery
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENGINE=v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
+          UI=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+          WORKER=v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+          grep -q 'SourcePolicy.APP_USER_FILES' "$ENGINE"
+          grep -q 'Android/media' "$ENGINE"
+          grep -q 'Android/data' "$ENGINE"
+          grep -q 'APP_MEDIA_FILE' "$ENGINE"
+          grep -q 'APP_EXTERNAL_FILES_FILE' "$ENGINE"
+          grep -q 'isAppUserFile' "$ENGINE"
+          grep -q '应用缓存、数据库、缩略图、贴纸和临时文件会跳过' "$UI"
+          grep -q '一键归类所有应用下载' "$UI"
+          grep -q 'put("all", true)' "$UI"
+          grep -q 'put("all", true)' "$WORKER"
+          ! grep -q 'nu.gpu.nagram' "$ENGINE"
+          ! grep -q 'org.telegram.messenger' "$ENGINE"
+          ! grep -q 'Checkbox' "$UI"
+          ! grep -q 'onApply' "$UI"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build ARM64 scanner
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build Android App
+        working-directory: v2
+        shell: bash
+        run: |
+          set -o pipefail
+          gradle --no-daemon :app:assembleDebug 2>&1 | tee android-build.log
+
+      - name: Upload Android build failure log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-alpha12-build-failure-log
+          path: v2/android-build.log
+          if-no-files-found: ignore
+
+      - name: Package Alpha 12 module
+        working-directory: v2
+        run: sh scripts/package-module.sh
+
+      - name: Verify final package
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIP=v2/dist/BaiZe-v2.1.0-alpha12-Module.zip
+          test -s "$ZIP"
+          unzip -tq "$ZIP"
+          unzip -p "$ZIP" module.prop | grep -qx 'version=v2.1.0-alpha12'
+          unzip -p "$ZIP" module.prop | grep -qx 'versionCode=22412'
+          grep -q 'versionName = "2.1.0-alpha12"' v2/app/build.gradle.kts
+          grep -q 'versionCode = 22412' v2/app/build.gradle.kts
+          ! unzip -Z1 "$ZIP" | grep -Eq '^(webroot|webui|www|ksu-webui)/'
+          sha256sum "$ZIP" | tee "$ZIP.sha256"
+
+      - name: Upload Alpha 12 module
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.1.0-alpha12-Generic-App-Downloads
+          if-no-files-found: error
+          path: |
+            v2/dist/BaiZe-v2.1.0-alpha12-Module.zip
+            v2/dist/BaiZe-v2.1.0-alpha12-Module.zip.sha256

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -12,8 +12,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22411
-        versionName = "2.1.0-alpha11"
+        versionCode = 22412
+        versionName = "2.1.0-alpha12"
     }
 
     buildFeatures {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
@@ -20,8 +20,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.rememberScrollState
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -88,7 +88,11 @@ class FileOrganizerActivity : ComponentActivity() {
         override fun onServiceDisconnected(name: ComponentName?) {
             service = null
             bound = false
-            state = state.copy(connected = false, running = false, status = "Root 服务已断开，请重新进入页面")
+            state = state.copy(
+                connected = false,
+                running = false,
+                status = "Root 服务已断开，请重新进入页面"
+            )
         }
     }
 
@@ -130,20 +134,27 @@ class FileOrganizerActivity : ComponentActivity() {
         state = state.copy(status = "正在连接 Root 文件归类服务…")
         runCatching {
             RootService.bind(
-                Intent(this, BaiZeProfileRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                Intent(this, BaiZeProfileRootService::class.java)
+                    .addCategory(RootService.CATEGORY_DAEMON_MODE),
                 connection
             )
             bound = true
         }.onFailure {
             bound = false
-            state = state.copy(status = "Root 服务启动失败：${it.message ?: it.javaClass.simpleName}")
+            state = state.copy(
+                status = "Root 服务启动失败：${it.message ?: it.javaClass.simpleName}"
+            )
         }
     }
 
     private fun saveSchedule() {
         FileOrganizerWorker.saveAndSchedule(this, schedule)
         schedule = FileOrganizerWorker.loadSettings(this)
-        scheduleSavedText = if (schedule.enabled) "已保存：每 ${schedule.intervalHours} 小时自动归类" else "定时归类已关闭"
+        scheduleSavedText = if (schedule.enabled) {
+            "已保存：每 ${schedule.intervalHours} 小时自动归类"
+        } else {
+            "定时归类已关闭"
+        }
     }
 
     private fun oneTapOrganize() {
@@ -151,18 +162,24 @@ class FileOrganizerActivity : ComponentActivity() {
         if (state.running) return
         state = state.copy(
             running = true,
-            status = "正在扫描内部存储根目录、下载与 QQ/TIM 接收目录…",
+            status = "正在扫描内部存储、公共下载和所有应用用户文件目录…",
             lastTotal = 0,
             lastBytes = 0L
         )
+
         lifecycleScope.launch {
             val scan = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.scanFileOrganizer()) }.getOrElse {
-                    JSONObject().put("error", "scan_failed").put("message", it.message ?: it.javaClass.simpleName)
+                    JSONObject()
+                        .put("error", "scan_failed")
+                        .put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
             if (scan.has("error")) {
-                state = state.copy(running = false, status = scan.optString("message", "文件归类扫描失败"))
+                state = state.copy(
+                    running = false,
+                    status = scan.optString("message", "文件归类扫描失败")
+                )
                 return@launch
             }
             if (scan.optBoolean("cancelled")) {
@@ -176,7 +193,7 @@ class FileOrganizerActivity : ComponentActivity() {
             if (snapshotId.isBlank() || total == 0) {
                 state = state.copy(
                     running = false,
-                    status = "一键归类完成：没有需要移动的散落文件",
+                    status = "一键归类完成：没有需要移动的新文件",
                     lastTotal = 0,
                     lastBytes = 0L
                 )
@@ -190,13 +207,23 @@ class FileOrganizerActivity : ComponentActivity() {
             )
             val result = withContext(Dispatchers.IO) {
                 runCatching {
-                    JSONObject(root.applyFileOrganizer(snapshotId, JSONObject().put("all", true).toString()))
+                    JSONObject(
+                        root.applyFileOrganizer(
+                            snapshotId,
+                            JSONObject().put("all", true).toString()
+                        )
+                    )
                 }.getOrElse {
-                    JSONObject().put("error", "apply_failed").put("message", it.message ?: it.javaClass.simpleName)
+                    JSONObject()
+                        .put("error", "apply_failed")
+                        .put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
             if (result.has("error")) {
-                state = state.copy(running = false, status = result.optString("message", "文件归类失败"))
+                state = state.copy(
+                    running = false,
+                    status = result.optString("message", "文件归类失败")
+                )
                 return@launch
             }
 
@@ -206,7 +233,9 @@ class FileOrganizerActivity : ComponentActivity() {
             val bytes = result.optLong("bytes")
             state = state.copy(
                 running = false,
-                status = "一键归类完成：移动 $moved/$total 个 · 跳过 $skipped 个 · 失败 $failed 个 · ${Formatter.formatFileSize(this@FileOrganizerActivity, bytes)}",
+                status = "一键归类完成：移动 $moved/$total 个 · 跳过 $skipped 个 · 失败 $failed 个 · ${
+                    Formatter.formatFileSize(this@FileOrganizerActivity, bytes)
+                }",
                 undoAvailable = result.optBoolean("undoAvailable"),
                 lastTotal = total,
                 lastBytes = bytes
@@ -221,17 +250,24 @@ class FileOrganizerActivity : ComponentActivity() {
         lifecycleScope.launch {
             val result = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(root.undoFileOrganizer()) }.getOrElse {
-                    JSONObject().put("error", "undo_failed").put("message", it.message ?: it.javaClass.simpleName)
+                    JSONObject()
+                        .put("error", "undo_failed")
+                        .put("message", it.message ?: it.javaClass.simpleName)
                 }
             }
             if (result.has("error")) {
-                state = state.copy(running = false, status = result.optString("message", "撤销失败"))
+                state = state.copy(
+                    running = false,
+                    status = result.optString("message", "撤销失败")
+                )
                 return@launch
             }
             state = state.copy(
                 running = false,
                 undoAvailable = result.optBoolean("undoAvailable"),
-                status = "撤销完成：恢复 ${result.optInt("restored")} 个 · 跳过 ${result.optInt("skipped")} 个 · 失败 ${result.optInt("failed")} 个"
+                status = "撤销完成：恢复 ${result.optInt("restored")} 个 · 跳过 ${
+                    result.optInt("skipped")
+                } 个 · 失败 ${result.optInt("failed")} 个"
             )
         }
     }
@@ -270,7 +306,11 @@ private fun FileOrganizerScreen(
                 title = {
                     Column {
                         Text("文件归类", fontWeight = FontWeight.Black, fontSize = 24.sp)
-                        Text("一键归类与定时归类", fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        Text(
+                            "全应用一键归类与定时归类",
+                            fontSize = 12.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 },
                 navigationIcon = {
@@ -278,21 +318,31 @@ private fun FileOrganizerScreen(
                         Icon(Icons.Rounded.ArrowBack, contentDescription = "返回")
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = MaterialTheme.colorScheme.background)
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background
+                )
             )
         }
     ) { padding ->
         LazyColumn(
-            modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(padding),
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(padding),
             contentPadding = PaddingValues(16.dp, 8.dp, 16.dp, 36.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item {
                 Card(
-                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainer
+                    ),
                     shape = RoundedCornerShape(28.dp)
                 ) {
-                    Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Column(
+                        Modifier.padding(20.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Icon(
                                 Icons.Rounded.FolderCopy,
@@ -302,26 +352,43 @@ private fun FileOrganizerScreen(
                             )
                             Spacer(Modifier.size(12.dp))
                             Column(Modifier.weight(1f)) {
-                                Text(state.status, fontWeight = FontWeight.Black, fontSize = 18.sp)
                                 Text(
-                                    "点一次自动扫描并归类，无需再确认。范围包括内部存储根目录的散落文件、Download、QQ/TIM 接收目录及可读取的应用下载目录。",
+                                    state.status,
+                                    fontWeight = FontWeight.Black,
+                                    fontSize = 18.sp
+                                )
+                                Text(
+                                    "点一次自动扫描并直接归类。Telegram、NagramX、浏览器、网盘等应用不再依赖单独写死路径。",
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     fontSize = 12.sp,
                                     lineHeight = 18.sp
                                 )
                             }
-                            if (state.running) CircularProgressIndicator(Modifier.size(24.dp), strokeWidth = 2.dp)
+                            if (state.running) {
+                                CircularProgressIndicator(
+                                    Modifier.size(24.dp),
+                                    strokeWidth = 2.dp
+                                )
+                            }
                         }
+
                         Button(
                             onClick = if (state.running) onStop else onOneTap,
                             enabled = state.connected,
                             modifier = Modifier.fillMaxWidth().height(56.dp),
                             shape = RoundedCornerShape(18.dp)
                         ) {
-                            Icon(if (state.running) Icons.Rounded.Stop else Icons.Rounded.AutoAwesome, contentDescription = null)
+                            Icon(
+                                if (state.running) Icons.Rounded.Stop else Icons.Rounded.AutoAwesome,
+                                contentDescription = null
+                            )
                             Spacer(Modifier.size(8.dp))
-                            Text(if (state.running) "停止当前任务" else "一键归类全部散落文件", fontWeight = FontWeight.Black)
+                            Text(
+                                if (state.running) "停止当前任务" else "一键归类所有应用下载",
+                                fontWeight = FontWeight.Black
+                            )
                         }
+
                         OutlinedButton(
                             onClick = onUndo,
                             enabled = state.connected && !state.running && state.undoAvailable,
@@ -338,7 +405,14 @@ private fun FileOrganizerScreen(
 
             item { SourceCard() }
             item { DestinationCard() }
-            item { ScheduleCard(schedule, scheduleSavedText, onScheduleChange, onSaveSchedule) }
+            item {
+                ScheduleCard(
+                    schedule,
+                    scheduleSavedText,
+                    onScheduleChange,
+                    onSaveSchedule
+                )
+            }
         }
     }
 }
@@ -346,14 +420,23 @@ private fun FileOrganizerScreen(
 @Composable
 private fun SourceCard() {
     Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        ),
         shape = RoundedCornerShape(24.dp)
     ) {
-        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text("从哪里归类", fontWeight = FontWeight.Black, fontSize = 19.sp)
-            Text("内部存储根目录", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+        Column(
+            Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Text("扫描范围", fontWeight = FontWeight.Black, fontSize = 19.sp)
             Text(
-                "只处理根目录中直接散落的文件，不递归搬动 Android、DCIM、Documents、Movies 等正常文件夹。另会扫描 Download、QQfile_recv、TIMfile_recv 和应用下载目录。",
+                "内部存储 + 全部应用用户文件",
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                "包括根目录散落文件、公共 Download/接收目录，以及每个应用的 Android/media/<包名> 和 Android/data/<包名>/files。应用缓存、数据库、缩略图、贴纸和临时文件会跳过。",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 12.sp,
                 lineHeight = 18.sp
@@ -366,19 +449,38 @@ private fun SourceCard() {
 private fun DestinationCard() {
     val categories = listOf("图片", "视频", "音频", "文档", "安装包", "压缩包", "电子书", "其他")
     Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        ),
         shape = RoundedCornerShape(24.dp)
     ) {
-        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Column(
+            Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
             Text("归类到哪里", fontWeight = FontWeight.Black, fontSize = 19.sp)
-            Text("内部存储 / BaiZe归类", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
-            Text("按类型移动到对应子目录；遇到同名文件直接跳过，不覆盖。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            Text(
+                "内部存储 / BaiZe归类",
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                "按类型移动到对应子目录；遇到同名文件直接跳过，不覆盖。",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp
+            )
             Row(
-                modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 categories.forEach { category ->
-                    FilterChip(selected = false, onClick = {}, label = { Text(category) })
+                    FilterChip(
+                        selected = false,
+                        onClick = {},
+                        label = { Text(category) }
+                    )
                 }
             }
         }
@@ -394,21 +496,40 @@ private fun ScheduleCard(
 ) {
     val intervals = listOf(6, 12, 24, 72, 168)
     Card(
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        ),
         shape = RoundedCornerShape(24.dp)
     ) {
-        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(
+            Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Rounded.Schedule, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Icon(
+                    Icons.Rounded.Schedule,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary
+                )
                 Spacer(Modifier.size(10.dp))
                 Column(Modifier.weight(1f)) {
                     Text("定时归类", fontWeight = FontWeight.Black, fontSize = 19.sp)
-                    Text("定时任务同样自动扫描并直接归类", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                    Text(
+                        "定时任务使用相同的全应用扫描范围",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 11.sp
+                    )
                 }
-                Switch(checked = schedule.enabled, onCheckedChange = { onChange(schedule.copy(enabled = it)) })
+                Switch(
+                    checked = schedule.enabled,
+                    onCheckedChange = { onChange(schedule.copy(enabled = it)) }
+                )
             }
+
             Row(
-                Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState()),
                 horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 intervals.forEach { hours ->
@@ -416,23 +537,48 @@ private fun ScheduleCard(
                         selected = schedule.intervalHours == hours,
                         onClick = { onChange(schedule.copy(intervalHours = hours)) },
                         label = {
-                            Text(when (hours) {
-                                24 -> "每天"
-                                72 -> "每3天"
-                                168 -> "每周"
-                                else -> "${hours}小时"
-                            })
+                            Text(
+                                when (hours) {
+                                    24 -> "每天"
+                                    72 -> "每3天"
+                                    168 -> "每周"
+                                    else -> "${hours}小时"
+                                }
+                            )
                         }
                     )
                 }
             }
+
             HorizontalDivider()
-            SettingSwitch("仅充电时执行", schedule.chargingOnly) { onChange(schedule.copy(chargingOnly = it)) }
-            SettingSwitch("仅息屏时执行", schedule.screenOffOnly) { onChange(schedule.copy(screenOffOnly = it)) }
-            Text("上次执行：${FileOrganizerWorker.lastRunText(LocalContext.current, schedule)}", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            Text(schedule.lastResult, fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            if (savedText.isNotBlank()) Text(savedText, color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
-            Button(onClick = onSave, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(16.dp)) {
+            SettingSwitch("仅充电时执行", schedule.chargingOnly) {
+                onChange(schedule.copy(chargingOnly = it))
+            }
+            SettingSwitch("仅息屏时执行", schedule.screenOffOnly) {
+                onChange(schedule.copy(screenOffOnly = it))
+            }
+            Text(
+                "上次执行：${FileOrganizerWorker.lastRunText(LocalContext.current, schedule)}",
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Text(
+                schedule.lastResult,
+                fontSize = 11.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            if (savedText.isNotBlank()) {
+                Text(
+                    savedText,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+            Button(
+                onClick = onSave,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp)
+            ) {
                 Text("保存定时归类", fontWeight = FontWeight.Black)
             }
         }
@@ -440,7 +586,11 @@ private fun ScheduleCard(
 }
 
 @Composable
-private fun SettingSwitch(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+private fun SettingSwitch(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(label, modifier = Modifier.weight(1f), fontWeight = FontWeight.Bold)
         Switch(checked = checked, onCheckedChange = onCheckedChange)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerActivity.kt
@@ -11,6 +11,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -20,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.rememberScrollState
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/FileOrganizerEngine.kt
@@ -16,9 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * Root-side immutable file organizer plan.
  *
- * Binder responses are bounded. The complete move plan remains inside the Root process, while the
- * App only receives a small summary. Alpha 11 also treats regular files placed directly in
- * /data/media/<user> as organizer sources without recursively sweeping unrelated top-level folders.
+ * Binder responses are bounded. Alpha 12 discovers user files from public downloads plus every
+ * application's external media and external files roots, so Telegram forks, browsers and download
+ * managers do not need package-specific path rules.
  */
 class FileOrganizerEngine(
     private val cancelled: AtomicBoolean,
@@ -29,6 +29,18 @@ class FileOrganizerEngine(
         val current: Int = 0,
         val total: Int = 0,
         val path: String = ""
+    )
+
+    private enum class SourcePolicy {
+        TOP_LEVEL_ONLY,
+        FULL_DOWNLOAD_TREE,
+        APP_USER_FILES
+    }
+
+    private data class SourceRoot(
+        val directory: File,
+        val group: String,
+        val policy: SourcePolicy
     )
 
     private data class PlannedMove(
@@ -66,32 +78,29 @@ class FileOrganizerEngine(
     fun scan(progress: (Progress) -> Unit): String {
         cancelled.set(false)
         val started = SystemClock.elapsedRealtime()
-        val mediaRoots = mediaUserRoots()
-        val downloadRoots = discoverDownloadRoots(started, progress)
+        val sources = discoverSourceRoots(started, progress)
         if (cancelled.get()) {
             return JSONObject().put("cancelled", true).put("message", "文件归类扫描已停止").toString()
         }
 
         val items = LinkedHashMap<String, PlannedMove>()
-        val sourceCount = mediaRoots.size + downloadRoots.size
-
-        mediaRoots.forEachIndexed { index, root ->
-            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return@forEachIndexed
-            progress(Progress("正在读取内部存储根目录", index + 1, sourceCount, displayPath(root.path)))
-            collectTopLevelMediaFiles(root, started, items, progress)
-        }
-
-        downloadRoots.forEachIndexed { index, root ->
-            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return@forEachIndexed
+        sources.forEachIndexed { index, source ->
+            if (cancelled.get() || items.size >= MAX_ITEMS || elapsed(started) >= SCAN_BUDGET_MS) {
+                return@forEachIndexed
+            }
             progress(
                 Progress(
-                    "正在读取下载与接收目录",
-                    mediaRoots.size + index + 1,
-                    sourceCount,
-                    displayPath(root.path)
+                    phase = when (source.policy) {
+                        SourcePolicy.TOP_LEVEL_ONLY -> "正在读取内部存储根目录"
+                        SourcePolicy.FULL_DOWNLOAD_TREE -> "正在读取下载与接收目录"
+                        SourcePolicy.APP_USER_FILES -> "正在读取应用用户文件目录"
+                    },
+                    current = index + 1,
+                    total = sources.size,
+                    path = displayPath(source.directory.path)
                 )
             )
-            collectFiles(root, started, items, progress)
+            collectSource(source, started, items, progress)
         }
 
         val immutable = items.values.sortedWith(
@@ -100,8 +109,8 @@ class FileOrganizerEngine(
                 .thenBy { it.name.lowercase() }
         )
         val id = UUID.randomUUID().toString()
-        val truncated = immutable.size >= MAX_ITEMS || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS
-        snapshot = Snapshot(id, System.currentTimeMillis(), sourceCount, truncated, immutable)
+        val truncated = immutable.size >= MAX_ITEMS || elapsed(started) >= SCAN_BUDGET_MS
+        snapshot = Snapshot(id, System.currentTimeMillis(), sources.size, truncated, immutable)
 
         val categoryCounts = JSONObject()
         val sourceCounts = JSONObject()
@@ -118,11 +127,11 @@ class FileOrganizerEngine(
             .put("success", true)
             .put("snapshotId", id)
             .put("expiresInMs", SNAPSHOT_TTL_MS)
-            .put("roots", sourceCount)
+            .put("roots", sources.size)
             .put("total", immutable.size)
             .put("totalBytes", totalBytes)
             .put("truncated", truncated)
-            .put("elapsedMs", SystemClock.elapsedRealtime() - started)
+            .put("elapsedMs", elapsed(started))
             .put("pageSize", DEFAULT_PAGE_SIZE)
             .put("categoryCounts", categoryCounts)
             .put("sourceCounts", sourceCounts)
@@ -271,7 +280,12 @@ class FileOrganizerEngine(
             if (reason != null) {
                 skipped += 1
                 remaining.put(move)
-                appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "skipped").put("reason", reason))
+                appendDetail(
+                    JSONObject()
+                        .put("destination", displayPath(destination.path))
+                        .put("action", "skipped")
+                        .put("reason", reason)
+                )
                 continue
             }
 
@@ -279,7 +293,12 @@ class FileOrganizerEngine(
             if (sourceParent?.isDirectory != true) {
                 skipped += 1
                 remaining.put(move)
-                appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "skipped").put("reason", "原目录已不存在"))
+                appendDetail(
+                    JSONObject()
+                        .put("destination", displayPath(destination.path))
+                        .put("action", "skipped")
+                        .put("reason", "原目录已不存在")
+                )
                 continue
             }
             val ok = runCatching {
@@ -293,11 +312,17 @@ class FileOrganizerEngine(
                     true
                 }
             }.getOrDefault(false)
-            if (ok) restored += 1
-            else {
+            if (ok) {
+                restored += 1
+            } else {
                 failed += 1
                 remaining.put(move)
-                appendDetail(JSONObject().put("destination", displayPath(destination.path)).put("action", "failed").put("reason", "恢复失败"))
+                appendDetail(
+                    JSONObject()
+                        .put("destination", displayPath(destination.path))
+                        .put("action", "failed")
+                        .put("reason", "恢复失败")
+                )
             }
         }
 
@@ -314,13 +339,60 @@ class FileOrganizerEngine(
             .toString()
     }
 
-    private fun mediaUserRoots(): List<File> =
-        File("/data/media").listFiles()
-            ?.filter { it.isDirectory && it.name.all(Char::isDigit) && !isSymlink(it) }
-            ?.sortedBy { it.path }
-            .orEmpty()
+    private fun discoverSourceRoots(started: Long, progress: (Progress) -> Unit): List<SourceRoot> {
+        val roots = LinkedHashMap<String, SourceRoot>()
 
-    private fun discoverDownloadRoots(started: Long, progress: (Progress) -> Unit): List<File> {
+        fun add(directory: File, group: String, policy: SourcePolicy) {
+            if (!directory.isDirectory || isSymlink(directory)) return
+            val path = canonical(directory)
+            if (path.contains("/BaiZe归类/") || path.endsWith("/BaiZe归类")) return
+            val existing = roots[path]
+            if (existing == null || policyPriority(policy) > policyPriority(existing.policy)) {
+                roots[path] = SourceRoot(directory, group, policy)
+            }
+        }
+
+        val mediaRoots = mediaUserRoots()
+        mediaRoots.forEach { mediaRoot ->
+            add(mediaRoot, "内部存储根目录", SourcePolicy.TOP_LEVEL_ONLY)
+
+            val androidMedia = File(mediaRoot, "Android/media")
+            androidMedia.listFiles()
+                ?.filter { it.isDirectory && !isSymlink(it) }
+                ?.forEach { packageRoot ->
+                    add(
+                        packageRoot,
+                        "${packageRoot.name} · 应用媒体",
+                        SourcePolicy.APP_USER_FILES
+                    )
+                }
+
+            val androidData = File(mediaRoot, "Android/data")
+            androidData.listFiles()
+                ?.filter { it.isDirectory && !isSymlink(it) }
+                ?.forEach { packageRoot ->
+                    val filesRoot = File(packageRoot, "files")
+                    if (filesRoot.isDirectory) {
+                        add(
+                            filesRoot,
+                            "${packageRoot.name} · 应用文件",
+                            SourcePolicy.APP_USER_FILES
+                        )
+                    }
+                }
+        }
+
+        discoverNamedDownloadRoots(started, progress).forEach { root ->
+            add(root, sourceGroup(root.path), SourcePolicy.FULL_DOWNLOAD_TREE)
+        }
+
+        return roots.values.sortedWith(
+            compareBy<SourceRoot> { policyPriority(it.policy) }
+                .thenBy { canonical(it.directory) }
+        )
+    }
+
+    private fun discoverNamedDownloadRoots(started: Long, progress: (Progress) -> Unit): List<File> {
         val roots = LinkedHashMap<String, File>()
         val scanBases = mutableListOf<Pair<File, Int>>()
         mediaUserRoots().forEach { scanBases += it to 8 }
@@ -337,74 +409,99 @@ class FileOrganizerEngine(
 
         var visited = 0
         for ((base, depthLimit) in scanBases) {
-            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= DISCOVERY_BUDGET_MS) break
+            if (cancelled.get() || elapsed(started) >= DISCOVERY_BUDGET_MS) break
             val stack = ArrayDeque<Pair<File, Int>>()
             stack.add(base to 0)
             while (stack.isNotEmpty()) {
-                if (cancelled.get() || SystemClock.elapsedRealtime() - started >= DISCOVERY_BUDGET_MS) break
+                if (cancelled.get() || elapsed(started) >= DISCOVERY_BUDGET_MS) break
                 val (dir, depth) = stack.removeLast()
                 if (!dir.isDirectory || isSymlink(dir)) continue
                 val path = canonical(dir)
                 if (path.contains("/BaiZe归类/") || path.endsWith("/BaiZe归类")) continue
                 visited += 1
-                if (visited % 500 == 0) progress(Progress("正在发现下载与接收目录", visited, 0, displayPath(path)))
+                if (visited % 500 == 0) {
+                    progress(Progress("正在发现下载与接收目录", visited, 0, displayPath(path)))
+                }
                 if (isDownloadDirectoryName(dir.name) && allowedDownloadRoot(path)) {
                     roots.putIfAbsent(path, dir)
                     continue
                 }
                 if (depth >= depthLimit || shouldPruneDiscovery(path, dir.name)) continue
-                dir.listFiles()?.filter { it.isDirectory && !isSymlink(it) }
+                dir.listFiles()
+                    ?.filter { it.isDirectory && !isSymlink(it) }
                     ?.forEach { stack.add(it to depth + 1) }
             }
         }
         return roots.values.sortedBy { it.path }
     }
 
-    private fun collectTopLevelMediaFiles(
-        mediaRoot: File,
+    private fun collectSource(
+        source: SourceRoot,
         started: Long,
         out: MutableMap<String, PlannedMove>,
         progress: (Progress) -> Unit
     ) {
-        val rootPath = canonical(mediaRoot)
-        val userId = userIdForPath("$rootPath/") ?: return
-        val files = mediaRoot.listFiles()?.filter { it.isFile && !isSymlink(it) }.orEmpty()
-        files.forEachIndexed { index, file ->
-            if (cancelled.get() || out.size >= MAX_ITEMS || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return
-            if (skipFile(file)) return@forEachIndexed
-            if (index % 100 == 0) progress(Progress("正在读取内部存储根目录文件", index + 1, files.size, displayPath(file.path)))
-            addPlannedMove(file, rootPath, "内部存储根目录", userId, out)
+        when (source.policy) {
+            SourcePolicy.TOP_LEVEL_ONLY -> collectTopLevelFiles(source, started, out, progress)
+            SourcePolicy.FULL_DOWNLOAD_TREE,
+            SourcePolicy.APP_USER_FILES -> collectTreeFiles(source, started, out, progress)
         }
     }
 
-    private fun collectFiles(
-        root: File,
+    private fun collectTopLevelFiles(
+        source: SourceRoot,
         started: Long,
         out: MutableMap<String, PlannedMove>,
         progress: (Progress) -> Unit
     ) {
-        val rootPath = canonical(root)
+        val rootPath = canonical(source.directory)
+        val userId = userIdForPath("$rootPath/") ?: return
+        val files = source.directory.listFiles()
+            ?.filter { it.isFile && !isSymlink(it) }
+            .orEmpty()
+
+        files.forEachIndexed { index, file ->
+            if (cancelled.get() || out.size >= MAX_ITEMS || elapsed(started) >= SCAN_BUDGET_MS) return
+            if (skipFile(file)) return@forEachIndexed
+            if (index % 100 == 0) {
+                progress(Progress("正在读取内部存储根目录文件", index + 1, files.size, displayPath(file.path)))
+            }
+            addPlannedMove(file, rootPath, source.group, userId, out)
+        }
+    }
+
+    private fun collectTreeFiles(
+        source: SourceRoot,
+        started: Long,
+        out: MutableMap<String, PlannedMove>,
+        progress: (Progress) -> Unit
+    ) {
+        val rootPath = canonical(source.directory)
         val userId = userIdForPath(rootPath) ?: return
-        val sourceGroup = sourceGroup(rootPath)
         val stack = ArrayDeque<Pair<File, Int>>()
-        stack.add(root to 0)
+        stack.add(source.directory to 0)
         var visited = 0
 
         while (stack.isNotEmpty() && out.size < MAX_ITEMS) {
-            if (cancelled.get() || SystemClock.elapsedRealtime() - started >= SCAN_BUDGET_MS) return
+            if (cancelled.get() || elapsed(started) >= SCAN_BUDGET_MS) return
             val (file, depth) = stack.removeLast()
             if (!file.exists() || isSymlink(file)) continue
             val path = canonical(file)
             if (!path.startsWith("$rootPath/") && path != rootPath) continue
+
             if (file.isDirectory) {
-                if (depth >= MAX_FILE_DEPTH) continue
-                file.listFiles()?.forEach { stack.add(it to depth + 1) }
+                if (depth >= MAX_FILE_DEPTH || shouldPruneSourceDirectory(path, file.name)) continue
+                file.listFiles()?.forEach { child -> stack.add(child to depth + 1) }
                 continue
             }
             if (!file.isFile || skipFile(file)) continue
+            if (source.policy == SourcePolicy.APP_USER_FILES && !isAppUserFile(file, path)) continue
+
             visited += 1
-            if (visited % 200 == 0) progress(Progress("正在建立不可变归类计划", out.size, MAX_ITEMS, displayPath(path)))
-            addPlannedMove(file, rootPath, sourceGroup, userId, out)
+            if (visited % 200 == 0) {
+                progress(Progress("正在建立应用文件归类计划", out.size, MAX_ITEMS, displayPath(path)))
+            }
+            addPlannedMove(file, rootPath, source.group, userId, out)
         }
     }
 
@@ -443,6 +540,7 @@ class FileOrganizerEngine(
     private fun validatePlannedMove(item: PlannedMove, source: File, destination: File): String? {
         val sourcePath = canonical(source)
         if (sourcePath != item.source) return "源路径已变化"
+        if (!sourcePath.startsWith("${item.sourceRoot}/") && sourcePath != item.sourceRoot) return "源目录已变化"
         if (!source.isFile) return "文件已不存在"
         if (isSymlink(source)) return "符号链接受保护"
         if (!allowedOrganizerSource(sourcePath)) return "源文件不再属于允许的归类来源"
@@ -563,33 +661,62 @@ class FileOrganizerEngine(
         true
     }.getOrDefault(false)
 
+    private fun mediaUserRoots(): List<File> =
+        File("/data/media").listFiles()
+            ?.filter { it.isDirectory && it.name.all(Char::isDigit) && !isSymlink(it) }
+            ?.sortedBy { it.path }
+            .orEmpty()
+
     private fun mediaUserRoot(path: String): File? {
         val user = Regex("^/data/media/(\\d+)(?:/|$)").find(path)?.groupValues?.getOrNull(1) ?: return null
         return File("/data/media/$user").takeIf { it.isDirectory }
     }
 
     private fun allowedDownloadRoot(path: String): Boolean {
-        if (!path.startsWith("/data/media/") && !path.startsWith("/data/user/") && !path.startsWith("/data/user_de/")) return false
+        if (!path.startsWith("/data/media/") && !path.startsWith("/data/user/") && !path.startsWith("/data/user_de/")) {
+            return false
+        }
         if (path.contains("/BaiZe归类/") || path.endsWith("/BaiZe归类")) return false
         return path.split('/').any(::isDownloadDirectoryName)
     }
 
     private fun allowedOrganizerSource(path: String): Boolean {
         if (MEDIA_ROOT_FILE.matches(path)) return true
+        if (APP_MEDIA_FILE.matches(path)) return true
+        if (APP_EXTERNAL_FILES_FILE.matches(path)) return true
         return allowedDownloadRoot(path.substringBeforeLast('/', path))
     }
 
+    private fun isAppUserFile(file: File, path: String): Boolean {
+        if (category(file.name) != "其他") return true
+        if (file.extension.isBlank()) return false
+        return path.split('/').any { segment ->
+            normalizeDirectoryName(segment) in USER_DIRECTORY_NAMES
+        }
+    }
+
     private fun shouldPruneDiscovery(path: String, name: String): Boolean {
-        val lower = name.lowercase()
-        if (lower in setOf("cache", "code_cache", "databases", "shared_prefs", "lib", "oat", "no_backup")) return true
+        val normalized = normalizeDirectoryName(name)
+        if (normalized in DISCOVERY_PRUNE_NAMES) return true
         if (path.contains("/Android/obb/")) return true
         return false
     }
 
-    private fun isDownloadDirectoryName(name: String): Boolean {
-        val normalized = name.trim().lowercase().replace('-', '_').replace(' ', '_')
-        return normalized in DOWNLOAD_DIRECTORY_NAMES
+    private fun shouldPruneSourceDirectory(path: String, name: String): Boolean {
+        if (path.contains("/BaiZe归类/") || path.endsWith("/BaiZe归类")) return true
+        val normalized = normalizeDirectoryName(name)
+        if (normalized in SOURCE_PRUNE_NAMES) return true
+        return false
     }
+
+    private fun isDownloadDirectoryName(name: String): Boolean =
+        normalizeDirectoryName(name) in DOWNLOAD_DIRECTORY_NAMES
+
+    private fun normalizeDirectoryName(name: String): String =
+        name.trim().lowercase()
+            .replace('-', '_')
+            .replace(' ', '_')
+            .replace('.', '_')
 
     private fun skipFile(file: File): Boolean {
         val name = file.name.lowercase()
@@ -629,8 +756,20 @@ class FileOrganizerEngine(
     private fun userIdForPath(path: String): Int? {
         val media = Regex("^/data/media/(\\d+)(?:/|$)").find(path)?.groupValues?.getOrNull(1)?.toIntOrNull()
         if (media != null) return media
-        return Regex("^/data/(?:user|user_de)/(\\d+)(?:/|$)").find(path)?.groupValues?.getOrNull(1)?.toIntOrNull()
+        return Regex("^/data/(?:user|user_de)/(\\d+)(?:/|$)")
+            .find(path)
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toIntOrNull()
     }
+
+    private fun policyPriority(policy: SourcePolicy): Int = when (policy) {
+        SourcePolicy.TOP_LEVEL_ONLY -> 1
+        SourcePolicy.APP_USER_FILES -> 2
+        SourcePolicy.FULL_DOWNLOAD_TREE -> 3
+    }
+
+    private fun elapsed(started: Long): Long = SystemClock.elapsedRealtime() - started
 
     private fun fingerprint(file: File): String = runCatching {
         fingerprint(Os.lstat(file.path))
@@ -694,22 +833,40 @@ class FileOrganizerEngine(
     companion object {
         private val ID_PATTERN = Regex("^[a-f0-9]{64}$")
         private val MEDIA_ROOT_FILE = Regex("^/data/media/\\d+/[^/]+$")
+        private val APP_MEDIA_FILE = Regex("^/data/media/\\d+/Android/media/[^/]+/.+")
+        private val APP_EXTERNAL_FILES_FILE = Regex("^/data/media/\\d+/Android/data/[^/]+/files/.+")
         private val DOWNLOAD_DIRECTORY_NAMES = setOf(
             "download", "downloads", "下载",
+            "received", "receive", "recv", "file_recv",
             "qqfile_recv", "qqmy_file_recv", "qqfile_receive",
             "timfile_recv", "tim_file_recv"
         )
+        private val USER_DIRECTORY_NAMES = setOf(
+            "download", "downloads", "下载",
+            "document", "documents", "file", "files",
+            "received", "receive", "recv", "export", "exports",
+            "telegram", "telegram_documents", "telegram_files",
+            "nagram", "nagramx", "saved", "shared"
+        )
+        private val DISCOVERY_PRUNE_NAMES = setOf(
+            "cache", "code_cache", "databases", "shared_prefs", "lib", "oat", "no_backup",
+            "tmp", "temp", "thumbnail", "thumbnails", "_thumbnails"
+        )
+        private val SOURCE_PRUNE_NAMES = DISCOVERY_PRUNE_NAMES + setOf(
+            "stickers", "emoji", "emojis", "crash", "crashes", "crashlytics",
+            "logs", "log", "sessions", "accounts"
+        )
         private const val SNAPSHOT_TTL_MS = 30L * 60_000L
-        private const val DISCOVERY_BUDGET_MS = 60_000L
-        private const val SCAN_BUDGET_MS = 3L * 60_000L
-        private const val MAX_ITEMS = 20_000
-        private const val MAX_FILE_DEPTH = 12
+        private const val DISCOVERY_BUDGET_MS = 75_000L
+        private const val SCAN_BUDGET_MS = 4L * 60_000L
+        private const val MAX_ITEMS = 30_000
+        private const val MAX_FILE_DEPTH = 14
         private const val DEFAULT_PAGE_SIZE = 60
         private const val MAX_PAGE_SIZE = 100
-        private const val MAX_SELECTION_IDS = 20_000
+        private const val MAX_SELECTION_IDS = 30_000
         private const val MAX_RESULT_DETAILS = 40
         private const val MAX_PATH_CHARS = 360
         private const val MAX_NAME_CHARS = 160
-        private const val MAX_GROUP_CHARS = 80
+        private const val MAX_GROUP_CHARS = 100
     }
 }

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.1.0-alpha11
-versionCode=22411
+version=v2.1.0-alpha12
+versionCode=22412
 author=惜故里丶
-description=白泽 v2.1.0 Alpha 11：内部存储根目录散落文件归类，手动操作改为无需确认的一键归类。
+description=白泽 v2.1.0 Alpha 12：通用扫描 Android/media 与 Android/data 应用用户文件目录，覆盖 Telegram、NagramX 等应用下载。

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/debug/app-debug.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2.1.0-alpha11-Module.zip"
+OUTPUT="$OUT/BaiZe-v2.1.0-alpha12-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -75,8 +75,8 @@ unzip -p "$OUTPUT" config/default.conf | grep -q '^scan_root_workers=0$'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-scanner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
-unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha11$'
-unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22411$'
+unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.1.0-alpha12$'
+unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22412$'
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1
@@ -87,4 +87,4 @@ if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.1.0 Alpha 11 根目录一键归类模块：$OUTPUT"
+echo "已生成白泽 v2.1.0 Alpha 12 全应用下载归类模块：$OUTPUT"


### PR DESCRIPTION
## 真机反馈

Alpha 11 仍依赖 Download、QQ/TIM 等目录名，Telegram、NagramX、浏览器、网盘和其他应用的下载路径仍会漏掉。

## Alpha 12 修改

- 不再按应用包名逐个硬编码下载路径。
- 自动枚举每个用户存储中的 `Android/media/<包名>`。
- 自动枚举每个应用的 `Android/data/<包名>/files`。
- Telegram 官方版及各类分支、NagramX、浏览器、网盘和下载器只要使用 Android 标准应用外部目录即可被覆盖。
- 应用目录仅收集图片、视频、音频、文档、安装包、压缩包和电子书等用户文件；未知类型只在 Download/Documents/Telegram/Received 等用户目录中接纳。
- 跳过 cache、数据库、缩略图、贴纸、Emoji、崩溃日志、临时文件和未完成下载。
- 保留内部存储根目录、公共下载目录、QQ/TIM、Binder 有界返回、一键直接归类、撤销和定时归类。
- 扫描上限提高到 30000 个文件，扫描预算提高到 4 分钟。

## 版本

- App：`2.1.0-alpha12`
- 模块：`v2.1.0-alpha12`
- versionCode：`22412`

## 验证

新增 Alpha 12 独立 CI，验证通用应用目录发现、无 Telegram/NagramX 包名硬编码、Android App、ARM64 引擎、模块 ZIP 与版本一致性。