### PR TITLE
fix: v2.2.2 reliable runtime logs

### DIFF
--- a/.github/workflows/v2.2.0-core-rework.yml
+++ b/.github/workflows/v2.2.0-core-rework.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - fix/v2.2.2-runtime-ledger
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/v2.2.0-core-rework.yml
+++ b/.github/workflows/v2.2.0-core-rework.yml
@@ -1,24 +1,20 @@
-name: BaiZe v2.2.0 Core Rework
+name: BaiZe v2.2.2 Runtime Ledger Test
 
 on:
   push:
     branches:
-      - feat/v2.2.0-core-rework
-      - main
-  pull_request:
-    branches:
-      - main
+      - fix/v2.2.2-runtime-ledger
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: baize-v220-${{ github.ref }}
+  group: baize-v222-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-test-package-release:
+  build-test-package:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -26,28 +22,35 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Apply runtime logging fixes
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/apply-v221-hotfix.py
+          python3 tools/apply-v222-runtime-ledger.py
+          sed -i 's/^version=v2.2.2-test$/version=v2.2.2/' v2/module/module.prop
+
       - name: Verify source invariants
         shell: bash
         run: |
           set -euo pipefail
+          python3 -m py_compile tools/apply-v221-hotfix.py tools/apply-v222-runtime-ledger.py
           git diff --check
-          sh -n v2/module/storage-index.sh
-          sh -n v2/module/apk-snapshot-scan.sh
-          sh -n v2/module/apk-snapshot-clean.sh
-          sh -n v2/module/one-pass-scan.sh
+          grep -q 'object RuntimeTaskLedger' v2/app/src/main/java/io/github/xgl34222220/baize/RuntimeTaskLedger.kt
+          grep -q 'persistNativeTaskWithRetry' v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
+          grep -q 'RuntimeTaskLedger.merge' v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
+          grep -q 'writeNativeScanTrace' v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
+          grep -q 'Root 历史与 App 本地账本自动合并' v2/app/src/main/java/io/github/xgl34222220/baize/ui/logs/miuix/LogsScreenMiuix.kt
+          grep -q 'versionName = "2.2.2"' v2/app/build.gradle.kts
+          grep -q 'versionCode = 22602' v2/app/build.gradle.kts
+          grep -qx 'version=v2.2.2' v2/module/module.prop
+          grep -qx 'versionCode=22602' v2/module/module.prop
+          ! grep -q 'applyV221SourceHotfix' v2/app/build.gradle.kts
           sh -n v2/scripts/package-module.sh
-          grep -q 'versionName = "2.2.0"' v2/app/build.gradle.kts
-          grep -q 'versionCode = 22600' v2/app/build.gradle.kts
-          grep -qx 'version=v2.2.0' v2/module/module.prop
-          grep -qx 'versionCode=22600' v2/module/module.prop
-          grep -q 'baize-storage-index-v2.2' v2/module/storage-index.sh
-          grep -q 'apk-snapshot-v2.2-shared-index' v2/module/apk-snapshot-scan.sh
-          grep -q 'registerTaskProgressCallback' v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl
-          grep -q 'DisplayPerformanceController.install' v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeApplication.kt
-          test -s v2/app/src/main/baseline-prof.txt
-          test -s v2/macrobenchmark/src/main/java/io/github/xgl34222220/baize/macrobenchmark/BaiZeBenchmark.kt
+          sh -n v2/module/storage-index.sh
+          sh -n v2/module/one-pass-scan.sh
 
-      - name: Test shared index coverage with QQ Telegram NagramX fixtures
+      - name: Test shared index coverage
         shell: bash
         run: |
           set -euo pipefail
@@ -68,12 +71,7 @@ jobs:
           data = Path('/tmp/baize-index-test/state/index/storage-files.nul').read_bytes().split(b'\0')
           names = {Path(p.decode()).name for p in data if p}
           required = {'qq-test.apk', 'telegram-test.apks', 'nagramx-test.xapk'}
-          missing = required - names
-          assert not missing, f'missing indexed fixtures: {missing}; got {sorted(names)}'
-          coverage = Path('/tmp/baize-index-test/state/index/coverage.tsv').read_text()
-          assert 'QQfile_recv' in coverage
-          assert 'org.telegram.messenger' in coverage
-          assert 'nu.gpu.nagramx' in coverage
+          assert not (required - names), f'missing fixtures: {required - names}'
           PY
 
       - name: Set up JDK 17
@@ -93,43 +91,11 @@ jobs:
         with:
           gradle-version: '8.13'
 
-      - name: Prepare release signing
-        env:
-          BAIZE_KEYSTORE_B64: ${{ secrets.BAIZE_KEYSTORE_BASE64 }}
-          GENERIC_KEYSTORE_B64: ${{ secrets.KEYSTORE_BASE64 }}
-          BAIZE_STORE_PASSWORD: ${{ secrets.BAIZE_KEYSTORE_PASSWORD }}
-          GENERIC_STORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          BAIZE_ALIAS: ${{ secrets.BAIZE_KEY_ALIAS }}
-          GENERIC_ALIAS: ${{ secrets.KEY_ALIAS }}
-          BAIZE_KEY_PASSWORD_SECRET: ${{ secrets.BAIZE_KEY_PASSWORD }}
-          GENERIC_KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          KEY_B64="${BAIZE_KEYSTORE_B64:-${GENERIC_KEYSTORE_B64:-}}"
-          STORE_PASS="${BAIZE_STORE_PASSWORD:-${GENERIC_STORE_PASSWORD:-}}"
-          KEY_ALIAS_VALUE="${BAIZE_ALIAS:-${GENERIC_ALIAS:-}}"
-          KEY_PASS="${BAIZE_KEY_PASSWORD_SECRET:-${GENERIC_KEY_PASSWORD:-}}"
-          if [[ -n "$KEY_B64" && -n "$STORE_PASS" && -n "$KEY_ALIAS_VALUE" && -n "$KEY_PASS" ]]; then
-            printf '%s' "$KEY_B64" | base64 --decode > "$RUNNER_TEMP/baize-release.jks"
-            echo "BAIZE_KEYSTORE_PATH=$RUNNER_TEMP/baize-release.jks" >> "$GITHUB_ENV"
-            echo "BAIZE_KEYSTORE_PASSWORD=$STORE_PASS" >> "$GITHUB_ENV"
-            echo "BAIZE_KEY_ALIAS=$KEY_ALIAS_VALUE" >> "$GITHUB_ENV"
-            echo "BAIZE_KEY_PASSWORD=$KEY_PASS" >> "$GITHUB_ENV"
-            echo 'BAIZE_SIGNING_MODE=release-keystore' >> "$GITHUB_ENV"
-          else
-            if [[ "$GITHUB_REF" == refs/heads/main ]]; then
-              echo '正式发布缺少四项签名 Secrets' >&2
-              exit 1
-            fi
-            echo 'BAIZE_SIGNING_MODE=debug-fallback-for-pr' >> "$GITHUB_ENV"
-          fi
-
       - name: Build ARM64 scanner
         working-directory: v2
         run: sh scripts/build-native.sh
 
-      - name: Build signed release app and benchmark APK
+      - name: Build release app and benchmark APK
         id: android_build
         working-directory: v2
         shell: bash
@@ -141,21 +107,24 @@ jobs:
         if: failure() && steps.android_build.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: BaiZe-v2.2.0-android-build-failure
+          name: BaiZe-v2.2.2-android-build-failure
           if-no-files-found: warn
           path: v2/android-build.log
 
-      - name: Verify release APK and baseline profile
+      - name: Verify release APK
         shell: bash
         run: |
           set -euo pipefail
           APK=v2/app/build/outputs/apk/release/app-release.apk
           test -s "$APK"
-          test -s v2/app/src/main/baseline-prof.txt
           unzip -l "$APK" | grep -Eq 'baseline.prof|baseline.profm|dexopt/baseline'
-          echo "Signing mode: ${BAIZE_SIGNING_MODE:-unknown}"
+          for dex in $(unzip -Z1 "$APK" | grep '^classes.*dex$'); do unzip -p "$APK" "$dex"; done \
+            | strings > /tmp/baize-v222-strings.txt
+          grep -q 'baize_runtime_task_ledger_v1' /tmp/baize-v222-strings.txt
+          grep -q 'native-scan' /tmp/baize-v222-strings.txt
+          grep -q 'app-native-scan-' /tmp/baize-v222-strings.txt
 
-      - name: Package v2.2.0 module
+      - name: Package module
         working-directory: v2
         run: sh scripts/package-module.sh
 
@@ -163,41 +132,25 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ZIP=v2/dist/BaiZe-v2.2.0-Module.zip
+          ZIP=v2/dist/BaiZe-v2.2.2-Module.zip
           test -s "$ZIP"
           unzip -tq "$ZIP"
-          unzip -p "$ZIP" module.prop | grep -qx 'version=v2.2.0'
-          unzip -p "$ZIP" module.prop | grep -qx 'versionCode=22600'
-          unzip -p "$ZIP" storage-index.sh | grep -q 'baize-storage-index-v2.2'
-          unzip -p "$ZIP" apk-scanner.sh | grep -q 'apk-snapshot-v2.2-shared-index'
-          unzip -p "$ZIP" app/baize.apk.sha256 | grep -Eq '^[a-f0-9]{64}$'
+          unzip -p "$ZIP" module.prop | grep -qx 'version=v2.2.2'
+          unzip -p "$ZIP" module.prop | grep -qx 'versionCode=22602'
+          unzip -l "$ZIP" | grep -q 'app/baize.apk'
+          unzip -l "$ZIP" | grep -q 'bin/arm64-v8a/baize_engine'
           ! unzip -Z1 "$ZIP" | grep -Eq '^(webroot|webui|www|ksu-webui)/'
-          sha256sum "$ZIP" | tee "$ZIP.sha256"
+          cp "$ZIP" v2/dist/BaiZe-v2.2.2-Runtime-Logs-Test-Module.zip
+          sha256sum v2/dist/BaiZe-v2.2.2-Runtime-Logs-Test-Module.zip \
+            | tee v2/dist/BaiZe-v2.2.2-Runtime-Logs-Test-Module.zip.sha256
 
-      - name: Upload v2.2.0 artifact
+      - name: Upload test artifact
         uses: actions/upload-artifact@v4
         with:
-          name: BaiZe-v2.2.0-Unified-Index-Performance
+          name: BaiZe-v2.2.2-Runtime-Logs-Test
           if-no-files-found: error
           path: |
-            v2/dist/BaiZe-v2.2.0-Module.zip
-            v2/dist/BaiZe-v2.2.0-Module.zip.sha256
+            v2/dist/BaiZe-v2.2.2-Runtime-Logs-Test-Module.zip
+            v2/dist/BaiZe-v2.2.2-Runtime-Logs-Test-Module.zip.sha256
             v2/app/build/outputs/apk/release/app-release.apk
             v2/android-build.log
-
-      - name: Publish GitHub Release
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          TAG=v2.2.0
-          ZIP=v2/dist/BaiZe-v2.2.0-Module.zip
-          SHA=v2/dist/BaiZe-v2.2.0-Module.zip.sha256
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release edit "$TAG" --title '白泽 v2.2.0' --notes-file RELEASE_NOTES_V2.2.0.md
-            gh release upload "$TAG" "$ZIP" "$SHA" --clobber
-          else
-            gh release create "$TAG" "$ZIP" "$SHA" --target "$GITHUB_SHA" --title '白泽 v2.2.0' --notes-file RELEASE_NOTES_V2.2.0.md --latest
-          fi

--- a/.github/workflows/v2.2.1-bootstrap.yml
+++ b/.github/workflows/v2.2.1-bootstrap.yml
@@ -1,0 +1,32 @@
+name: BaiZe v2.2.1 Bootstrap
+
+on:
+  push:
+    branches:
+      - fix/v2.2.1-logs-icons
+
+permissions:
+  contents: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Apply deterministic hotfix
+        run: python3 tools/apply-v221-hotfix.py
+      - name: Commit generated sources
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "hotfix already applied"
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add -A
+          git commit -m 'fix(v2.2.1): write native scan logs and render real app icons'
+          git push origin HEAD:fix/v2.2.1-logs-icons

--- a/tools/.v223-plan-placeholder
+++ b/tools/.v223-plan-placeholder
@@ -1,0 +1,1 @@
+superseded-by-v2.2.3

--- a/tools/apply-v221-hotfix.py
+++ b/tools/apply-v221-hotfix.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+import re
+
+root = Path(__file__).resolve().parents[1]
+
+def rep(path, old, new):
+    p = root / path
+    text = p.read_text()
+    if old in text:
+        p.write_text(text.replace(old, new, 1))
+    elif new not in text:
+        raise SystemExit(f"missing anchor: {path}")
+
+history = "v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/HistoryScreenMiuix.kt"
+rep(history, "import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings\n", "import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings\nimport io.github.xgl34222220.baize.ui.common.AppPackageIcon\n")
+rep(history, "icon = Icons.Rounded.Apps,\n                title = item.label,", "icon = Icons.Rounded.Apps,\n                packageName = item.packageName,\n                title = item.label,")
+rep(history, "private fun ResultHeader(\n    icon: ImageVector,\n    title: String,", "private fun ResultHeader(\n    icon: ImageVector,\n    packageName: String? = null,\n    title: String,")
+rep(history, "Row(verticalAlignment = Alignment.CenterVertically) {\n        IconTile(icon, error)\n        Spacer(Modifier.width(12.dp))", "Row(verticalAlignment = Alignment.CenterVertically) {\n        if (packageName.isNullOrBlank()) IconTile(icon, error)\n        else AppPackageIcon(packageName, title, size = 50.dp, corner = 15.dp)\n        Spacer(Modifier.width(12.dp))")
+
+activity = root / "v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt"
+text = activity.read_text()
+start = text.index("            val successfulScan = (cacheOk || safeOk) && !cancelled")
+end = text.index("            if (!cleanAfterScan) notifyScanResult", start)
+old = text[start:end]
+new = '''            val successfulScan = (cacheOk || safeOk) && !cancelled
+            if (successfulScan && total > 0) snapshotExpiresAtElapsed = SystemClock.elapsedRealtime() + SNAPSHOT_TTL_MS
+            else clearSnapshotHandles()
+            val scanResultLine = when {
+                cancelled -> "安全扫描已停止"
+                !successfulScan -> "安全扫描失败：${safeJson.optString("message", cacheJson.optString("message", "引擎没有返回有效快照"))}"
+                total == 0 -> "扫描完成，没有发现可安全清理的项目"
+                else -> "扫描完成，发现 $total 项；快照 30 分钟内有效"
+            }
+            dashboardState.value = dashboardState.value.copy(
+                running = false, scanCompleted = successfulScan, scanBytes = knownBytes,
+                scanFiles = total.toLong(), scanEmptyFiles = emptyFiles, scanEmptyDirs = emptyDirs,
+                scanFragments = fragments, scanErrors = failures, scanElapsed = elapsed / 1000L,
+                taskPhase = scanResultLine
+            )
+            val scanCategories = buildList {
+                if (total > 0) add("安全扫描|$knownBytes|$total")
+                if (emptyFiles > 0) add("空文件|0|$emptyFiles")
+                if (emptyDirs > 0) add("空目录|0|$emptyDirs")
+                if (fragments > 0) add("残留碎片|0|$fragments")
+            }.joinToString(";")
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    profiles.recordNativeTask(JSONObject()
+                        .put("mode", "native-scan").put("success", successfulScan)
+                        .put("cancelled", cancelled).put("bytes", knownBytes).put("files", total)
+                        .put("emptyFiles", emptyFiles).put("emptyDirs", emptyDirs)
+                        .put("fragments", fragments).put("errors", failures)
+                        .put("elapsedSeconds", elapsed / 1000L).put("result", scanResultLine)
+                        .put("categorySummary", scanCategories).toString())
+                }
+            }
+            refreshHistory()
+            refreshRawLog()
+            refreshModuleState()
+'''
+activity.write_text(text[:start] + new + text[end:])
+rep(str(activity.relative_to(root)), '        "scan" -> "垃圾扫描"\n', '        "scan" -> "垃圾扫描"\n        "native-scan" -> "安全扫描"\n')
+
+service = "v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt"
+rep(service, 'require(mode in setOf("smart-clean", "snapshot-clean")) { "unsupported_native_mode" }', 'require(mode in setOf("native-scan", "smart-clean", "snapshot-clean")) { "unsupported_native_mode" }\n        val cleaned = mode != "native-scan" && !mode.endsWith("-scan")')
+rep(service, '        if (success && !cancelled) {\n', '''        val logDir = File(stateDir, "logs").apply { mkdirs() }
+        val logFile = File(logDir, "app-$mode-${System.currentTimeMillis()}.log")
+        logFile.writeText(buildString {
+            append("白泽原生任务日志\\n时间：").append(timestamp).append('\\n')
+            append("任务：").append(mode).append("\\n结果：").append(result).append('\\n')
+            append("状态：").append(if (cancelled) "已停止" else if (success) "成功" else "失败").append('\\n')
+            append("项目：").append(files).append(" · 大小：").append(humanBytes(bytes)).append('\\n')
+            append("空文件：").append(emptyFiles).append(" · 空目录：").append(emptyDirs).append('\\n')
+            append("碎片：").append(fragments).append(" · 异常：").append(errors).append('\\n')
+            append("耗时：").append(elapsedSeconds).append(" 秒\\n")
+            if (categorySummary.isNotBlank()) append("分类：").append(categorySummary.replace(';', '，')).append('\\n')
+        })
+        logFile.setReadable(true, true)
+
+        if (cleaned && success && !cancelled) {
+''')
+
+rep("v2/app/build.gradle.kts", 'versionCode = 22600\n        versionName = "2.2.0"', 'versionCode = 22601\n        versionName = "2.2.1"')
+(root / "v2/module/module.prop").write_text("id=baize_v2\nname=白泽 v2\nversion=v2.2.1\nversionCode=22601\nauthor=惜故里丶\ndescription=白泽 v2.2.1：修复安全扫描日志与记录页真实应用图标。\n")
+for path in ["v2/scripts/package-module.sh", ".github/workflows/v2.2.0-core-rework.yml"]:
+    p = root / path
+    value = p.read_text().replace("v2.2.0", "v2.2.1").replace("22600", "22601")
+    value = value.replace("feat/v2.2.0-core-rework", "fix/v2.2.1-logs-icons")
+    value = value.replace("RELEASE_NOTES_V2.2.0.md", "RELEASE_NOTES_V2.2.1.md")
+    p.write_text(value)
+rep("v2/module/customize.sh", "安装白泽 v2.1.0 Alpha 4 有限并发预览版", "安装白泽 v2.2.1 日志与应用图标修复测试版")
+(root / "RELEASE_NOTES_V2.2.1.md").write_text("# 白泽 v2.2.1\n\n- 安全扫描写入运行日志和任务历史。\n- 记录页应用垃圾卡片显示真实应用图标。\n- 使用兼容 Android 16/OEM 主题图标的 Canvas 渲染与缓存。\n")
+print("v2.2.1 hotfix applied")

--- a/tools/apply-v221-source-only.py
+++ b/tools/apply-v221-source-only.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+
+
+def replace_once(path, old, new):
+    file = root / path
+    text = file.read_text()
+    if old in text:
+        file.write_text(text.replace(old, new, 1))
+    elif new not in text:
+        raise SystemExit(f"missing anchor: {path}")
+
+
+history = "v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/HistoryScreenMiuix.kt"
+replace_once(history, "import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings\n", "import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings\nimport io.github.xgl34222220.baize.ui.common.AppPackageIcon\n")
+replace_once(history, "icon = Icons.Rounded.Apps,\n                title = item.label,", "icon = Icons.Rounded.Apps,\n                packageName = item.packageName,\n                title = item.label,")
+replace_once(history, "private fun ResultHeader(\n    icon: ImageVector,\n    title: String,", "private fun ResultHeader(\n    icon: ImageVector,\n    packageName: String? = null,\n    title: String,")
+replace_once(history, "Row(verticalAlignment = Alignment.CenterVertically) {\n        IconTile(icon, error)\n        Spacer(Modifier.width(12.dp))", "Row(verticalAlignment = Alignment.CenterVertically) {\n        if (packageName.isNullOrBlank()) IconTile(icon, error)\n        else AppPackageIcon(packageName, title, size = 50.dp, corner = 15.dp)\n        Spacer(Modifier.width(12.dp))")
+
+activity = root / "v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt"
+text = activity.read_text()
+start = text.index("            val successfulScan = (cacheOk || safeOk) && !cancelled")
+end = text.index("            if (!cleanAfterScan) notifyScanResult", start)
+block = '''            val successfulScan = (cacheOk || safeOk) && !cancelled
+            if (successfulScan && total > 0) snapshotExpiresAtElapsed = SystemClock.elapsedRealtime() + SNAPSHOT_TTL_MS
+            else clearSnapshotHandles()
+            val scanResultLine = when {
+                cancelled -> "安全扫描已停止"
+                !successfulScan -> "安全扫描失败：${safeJson.optString("message", cacheJson.optString("message", "引擎没有返回有效快照"))}"
+                total == 0 -> "扫描完成，没有发现可安全清理的项目"
+                else -> "扫描完成，发现 $total 项；快照 30 分钟内有效"
+            }
+            dashboardState.value = dashboardState.value.copy(
+                running = false, scanCompleted = successfulScan, scanBytes = knownBytes,
+                scanFiles = total.toLong(), scanEmptyFiles = emptyFiles, scanEmptyDirs = emptyDirs,
+                scanFragments = fragments, scanErrors = failures, scanElapsed = elapsed / 1000L,
+                taskPhase = scanResultLine
+            )
+            val scanCategories = buildList {
+                if (total > 0) add("安全扫描|$knownBytes|$total")
+                if (emptyFiles > 0) add("空文件|0|$emptyFiles")
+                if (emptyDirs > 0) add("空目录|0|$emptyDirs")
+                if (fragments > 0) add("残留碎片|0|$fragments")
+            }.joinToString(";")
+            withContext(Dispatchers.IO) {
+                runCatching {
+                    profiles.recordNativeTask(JSONObject()
+                        .put("mode", "native-scan").put("success", successfulScan)
+                        .put("cancelled", cancelled).put("bytes", knownBytes).put("files", total)
+                        .put("emptyFiles", emptyFiles).put("emptyDirs", emptyDirs)
+                        .put("fragments", fragments).put("errors", failures)
+                        .put("elapsedSeconds", elapsed / 1000L).put("result", scanResultLine)
+                        .put("categorySummary", scanCategories).toString())
+                }
+            }
+            refreshHistory()
+            refreshRawLog()
+            refreshModuleState()
+'''
+activity.write_text(text[:start] + block + text[end:])
+replace_once(str(activity.relative_to(root)), '        "scan" -> "垃圾扫描"\n', '        "scan" -> "垃圾扫描"\n        "native-scan" -> "安全扫描"\n')
+
+service = "v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt"
+replace_once(service, 'require(mode in setOf("smart-clean", "snapshot-clean")) { "unsupported_native_mode" }', 'require(mode in setOf("native-scan", "smart-clean", "snapshot-clean")) { "unsupported_native_mode" }\n        val cleaned = mode != "native-scan" && !mode.endsWith("-scan")')
+replace_once(service, '        if (success && !cancelled) {\n', '''        val logDir = File(stateDir, "logs").apply { mkdirs() }
+        val logFile = File(logDir, "app-$mode-${System.currentTimeMillis()}.log")
+        logFile.writeText(buildString {
+            append("白泽原生任务日志\\n时间：").append(timestamp).append('\\n')
+            append("任务：").append(mode).append("\\n结果：").append(result).append('\\n')
+            append("状态：").append(if (cancelled) "已停止" else if (success) "成功" else "失败").append('\\n')
+            append("项目：").append(files).append(" · 大小：").append(humanBytes(bytes)).append('\\n')
+            append("空文件：").append(emptyFiles).append(" · 空目录：").append(emptyDirs).append('\\n')
+            append("碎片：").append(fragments).append(" · 异常：").append(errors).append('\\n')
+            append("耗时：").append(elapsedSeconds).append(" 秒\\n")
+            if (categorySummary.isNotBlank()) append("分类：").append(categorySummary.replace(';', '，')).append('\\n')
+        })
+        logFile.setReadable(true, true)
+
+        if (cleaned && success && !cancelled) {
+''')
+
+print("source hotfix applied")

--- a/tools/apply-v222-runtime-ledger.py
+++ b/tools/apply-v222-runtime-ledger.py
@@ -1,0 +1,605 @@
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+
+
+def rep(path: str, old: str, new: str, count: int = 1) -> None:
+    target = root / path
+    text = target.read_text()
+    if new in text:
+        return
+    if old not in text:
+        raise SystemExit(f"missing anchor: {path}: {old[:120]!r}")
+    target.write_text(text.replace(old, new, count))
+
+
+ledger_path = root / "v2/app/src/main/java/io/github/xgl34222220/baize/RuntimeTaskLedger.kt"
+ledger_path.parent.mkdir(parents=True, exist_ok=True)
+ledger_path.write_text(r'''package io.github.xgl34222220.baize
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Small app-side task ledger used as a durable fallback when a Root daemon is restarting,
+ * still running an older protocol, or temporarily cannot update history.tsv.
+ */
+object RuntimeTaskLedger {
+    private const val PREFS = "baize_runtime_task_ledger_v1"
+    private const val KEY_ENTRIES = "entries"
+    private const val LIMIT = 50
+
+    fun record(
+        context: Context,
+        title: String,
+        result: String,
+        bytes: Long,
+        files: Long,
+        emptyDirs: Long,
+        errors: Long,
+        cleaned: Boolean,
+        trigger: String = "App 本地账本"
+    ): List<HistoryUiItem> {
+        val item = HistoryUiItem(
+            title = title.take(120),
+            time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date()),
+            trigger = trigger.take(80),
+            result = result.replace('\n', ' ').replace('\r', ' ').take(500),
+            bytes = bytes.coerceAtLeast(0L),
+            files = files.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt(),
+            emptyDirs = emptyDirs.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt(),
+            errors = errors.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt(),
+            cleaned = cleaned
+        )
+        val merged = mergeLists(listOf(item), load(context))
+        save(context, merged)
+        return merged
+    }
+
+    fun load(context: Context): List<HistoryUiItem> = runCatching {
+        val raw = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .getString(KEY_ENTRIES, "[]")
+            .orEmpty()
+        val array = JSONArray(raw)
+        buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                val title = item.optString("title").trim()
+                val time = item.optString("time").trim()
+                if (title.isBlank() || time.isBlank()) continue
+                add(
+                    HistoryUiItem(
+                        title = title,
+                        time = time,
+                        trigger = item.optString("trigger", "App 本地账本"),
+                        result = item.optString("result"),
+                        bytes = item.optLong("bytes", 0L).coerceAtLeast(0L),
+                        files = item.optInt("files", 0).coerceAtLeast(0),
+                        emptyDirs = item.optInt("emptyDirs", 0).coerceAtLeast(0),
+                        errors = item.optInt("errors", 0).coerceAtLeast(0),
+                        cleaned = item.optBoolean("cleaned", false)
+                    )
+                )
+            }
+        }
+    }.getOrDefault(emptyList())
+
+    fun merge(context: Context, remote: List<HistoryUiItem>): List<HistoryUiItem> =
+        mergeLists(remote, load(context))
+
+    fun clear(context: Context) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit().remove(KEY_ENTRIES).apply()
+    }
+
+    private fun save(context: Context, entries: List<HistoryUiItem>) {
+        val array = JSONArray()
+        entries.take(LIMIT).forEach { item ->
+            array.put(
+                JSONObject()
+                    .put("title", item.title)
+                    .put("time", item.time)
+                    .put("trigger", item.trigger)
+                    .put("result", item.result)
+                    .put("bytes", item.bytes)
+                    .put("files", item.files)
+                    .put("emptyDirs", item.emptyDirs)
+                    .put("errors", item.errors)
+                    .put("cleaned", item.cleaned)
+            )
+        }
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_ENTRIES, array.toString())
+            .apply()
+    }
+
+    private fun mergeLists(primary: List<HistoryUiItem>, secondary: List<HistoryUiItem>): List<HistoryUiItem> =
+        (primary + secondary)
+            .filter { it.title.isNotBlank() && it.time.isNotBlank() }
+            .distinctBy { item ->
+                "${item.time.take(16)}|${item.title}|${item.result}|${item.bytes}|${item.files}|${item.errors}"
+            }
+            .sortedByDescending { it.time }
+            .take(LIMIT)
+}
+''')
+
+activity = "v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt"
+rep(
+    activity,
+    "        updateStorage()\n\n        setContent {",
+    "        updateStorage()\n        dashboardState.value = dashboardState.value.copy(history = RuntimeTaskLedger.load(this))\n\n        setContent {"
+)
+
+rep(
+    activity,
+    '''            dashboardState.value = dashboardState.value.copy(
+                running = false,
+                recentJunk = junk,
+                taskPhase = result
+            )
+            refreshHistory()
+''',
+    '''            dashboardState.value = dashboardState.value.copy(
+                running = false,
+                recentJunk = junk,
+                taskPhase = result
+            )
+            appendRuntimeLog(
+                title = historyModeTitle(mode),
+                result = result,
+                bytes = latest.optLong("bytes", 0L),
+                files = junk.sumOf { it.files },
+                emptyDirs = latest.optLong("empty_dirs", 0L),
+                errors = latest.optLong("errors", if (success) 0L else 1L),
+                cleaned = !mode.endsWith("scan")
+            )
+            refreshHistory()
+'''
+)
+
+rep(
+    activity,
+    '''            preferences.edit()
+                .putLong("last_clean_bytes", bytes)
+                .putString("last_report_text", "$resultLine\\n$detailLine")
+                .apply()
+            notifyCleanResult(title, resultLine, detailLine, bytes)
+''',
+    '''            preferences.edit()
+                .putLong("last_clean_bytes", bytes)
+                .putString("last_report_text", "$resultLine\\n$detailLine")
+                .apply()
+            appendRuntimeLog(
+                title = historyModeTitle("clean"),
+                result = resultLine,
+                bytes = bytes,
+                files = files,
+                emptyDirs = emptyDirs,
+                errors = errors,
+                cleaned = true
+            )
+            notifyCleanResult(title, resultLine, detailLine, bytes)
+'''
+)
+
+old_persist = '''            withContext(Dispatchers.IO) {
+                runCatching {
+                    profiles.recordNativeTask(JSONObject()
+                        .put("mode", "native-scan").put("success", successfulScan)
+                        .put("cancelled", cancelled).put("bytes", knownBytes).put("files", total)
+                        .put("emptyFiles", emptyFiles).put("emptyDirs", emptyDirs)
+                        .put("fragments", fragments).put("errors", failures)
+                        .put("elapsedSeconds", elapsed / 1000L).put("result", scanResultLine)
+                        .put("categorySummary", scanCategories).toString())
+                }
+            }
+            refreshHistory()
+'''
+new_persist = '''            val nativeTaskPayload = JSONObject()
+                .put("mode", "native-scan").put("success", successfulScan)
+                .put("cancelled", cancelled).put("bytes", knownBytes).put("files", total)
+                .put("emptyFiles", emptyFiles).put("emptyDirs", emptyDirs)
+                .put("fragments", fragments).put("errors", failures)
+                .put("elapsedSeconds", elapsed / 1000L).put("result", scanResultLine)
+                .put("categorySummary", scanCategories).toString()
+            val persistenceError = persistNativeTaskWithRetry(profiles, nativeTaskPayload)
+            val ledgerResult = if (persistenceError == null) {
+                scanResultLine
+            } else {
+                "$scanResultLine；Root 记录失败，已保存到 App 本地账本"
+            }
+            appendRuntimeLog(
+                title = historyModeTitle("native-scan"),
+                result = ledgerResult,
+                bytes = knownBytes,
+                files = total.toLong(),
+                emptyDirs = emptyDirs,
+                errors = failures,
+                cleaned = false
+            )
+            if (persistenceError != null) {
+                dashboardState.value = dashboardState.value.copy(
+                    taskPhase = "$scanResultLine\\n日志已保存在 App 本地；Root 持久化失败：$persistenceError"
+                )
+            }
+            refreshHistory()
+'''
+rep(activity, old_persist, new_persist)
+
+rep(
+    activity,
+    '''            preferences.edit()
+                .putLong("last_clean_bytes", deletedBytes)
+                .putString("last_report_text", "$resultLine\\n$detailLine")
+                .apply()
+            val recorder = profileEngine ?: rootService
+''',
+    '''            preferences.edit()
+                .putLong("last_clean_bytes", deletedBytes)
+                .putString("last_report_text", "$resultLine\\n$detailLine")
+                .apply()
+            appendRuntimeLog(
+                title = historyModeTitle("snapshot-clean"),
+                result = resultLine,
+                bytes = deletedBytes,
+                files = deletedFiles,
+                emptyDirs = emptyDirs,
+                errors = failures.toLong(),
+                cleaned = true
+            )
+            val recorder = profileEngine ?: rootService
+'''
+)
+
+old_refresh = '''    private fun refreshHistory() {
+        val service = rootService ?: return
+        lifecycleScope.launch {
+            val json = withContext(Dispatchers.IO) {
+                runCatching { JSONObject(service.getTaskHistoryPage(0, 30)) }.getOrNull()
+            } ?: return@launch
+            if (!json.optBoolean("success")) return@launch
+            val array = json.optJSONArray("entries")
+            val entries = buildList {
+                if (array != null) for (index in 0 until array.length()) {
+                    val item = array.optJSONObject(index) ?: continue
+                    add(
+                        HistoryUiItem(
+                            title = historyModeTitle(item.optString("mode")),
+                            time = item.optString("time"),
+                            trigger = historyTrigger(item.optString("trigger")),
+                            result = item.optString("result", if (item.optBoolean("cleaned")) "清理完成" else "扫描完成"),
+                            bytes = item.optLong("bytes", 0L).coerceAtLeast(0L),
+                            files = item.optInt("files", 0).coerceAtLeast(0),
+                            emptyDirs = item.optInt("emptyDirs", 0).coerceAtLeast(0),
+                            errors = item.optInt("errors", 0).coerceAtLeast(0),
+                            cleaned = item.optBoolean("cleaned"),
+                            categories = parseHistoryCategories(item.optJSONArray("categoryDetails")),
+                            apps = parseHistoryApps(item.optJSONArray("appDetails"))
+                        )
+                    )
+                }
+            }
+            dashboardState.value = dashboardState.value.copy(
+                history = entries,
+                lifetimeRuns = json.optLong("lifetimeRuns", json.optLong("cleanedRuns", 0L)).coerceAtLeast(0L),
+                lifetimeReleased = json.optLong("lifetimeReleased", json.optLong("totalReleased", 0L)).coerceAtLeast(0L),
+                lifetimeFiles = json.optLong("lifetimeFiles", 0L).coerceAtLeast(0L),
+                lifetimeEmptyFiles = json.optLong("lifetimeEmptyFiles", 0L).coerceAtLeast(0L),
+                lifetimeEmptyDirs = json.optLong("lifetimeEmptyDirs", 0L).coerceAtLeast(0L),
+                lifetimeFragments = json.optLong("lifetimeFragments", 0L).coerceAtLeast(0L),
+                lifetimeElapsed = json.optLong("lifetimeElapsed", 0L).coerceAtLeast(0L)
+            )
+        }
+    }
+'''
+new_refresh = '''    private fun refreshHistory() {
+        val service = rootService
+        if (service == null) {
+            dashboardState.value = dashboardState.value.copy(
+                history = RuntimeTaskLedger.merge(this, dashboardState.value.history)
+            )
+            return
+        }
+        lifecycleScope.launch {
+            val json = withContext(Dispatchers.IO) {
+                runCatching { JSONObject(service.getTaskHistoryPage(0, 30)) }.getOrNull()
+            }
+            if (json == null || !json.optBoolean("success")) {
+                dashboardState.value = dashboardState.value.copy(
+                    history = RuntimeTaskLedger.merge(this@MiuixDashboardActivity, dashboardState.value.history)
+                )
+                return@launch
+            }
+            val array = json.optJSONArray("entries")
+            val entries = buildList {
+                if (array != null) for (index in 0 until array.length()) {
+                    val item = array.optJSONObject(index) ?: continue
+                    add(
+                        HistoryUiItem(
+                            title = historyModeTitle(item.optString("mode")),
+                            time = item.optString("time"),
+                            trigger = historyTrigger(item.optString("trigger")),
+                            result = item.optString("result", if (item.optBoolean("cleaned")) "清理完成" else "扫描完成"),
+                            bytes = item.optLong("bytes", 0L).coerceAtLeast(0L),
+                            files = item.optInt("files", 0).coerceAtLeast(0),
+                            emptyDirs = item.optInt("emptyDirs", 0).coerceAtLeast(0),
+                            errors = item.optInt("errors", 0).coerceAtLeast(0),
+                            cleaned = item.optBoolean("cleaned"),
+                            categories = parseHistoryCategories(item.optJSONArray("categoryDetails")),
+                            apps = parseHistoryApps(item.optJSONArray("appDetails"))
+                        )
+                    )
+                }
+            }
+            dashboardState.value = dashboardState.value.copy(
+                history = RuntimeTaskLedger.merge(this@MiuixDashboardActivity, entries),
+                lifetimeRuns = json.optLong("lifetimeRuns", json.optLong("cleanedRuns", 0L)).coerceAtLeast(0L),
+                lifetimeReleased = json.optLong("lifetimeReleased", json.optLong("totalReleased", 0L)).coerceAtLeast(0L),
+                lifetimeFiles = json.optLong("lifetimeFiles", 0L).coerceAtLeast(0L),
+                lifetimeEmptyFiles = json.optLong("lifetimeEmptyFiles", 0L).coerceAtLeast(0L),
+                lifetimeEmptyDirs = json.optLong("lifetimeEmptyDirs", 0L).coerceAtLeast(0L),
+                lifetimeFragments = json.optLong("lifetimeFragments", 0L).coerceAtLeast(0L),
+                lifetimeElapsed = json.optLong("lifetimeElapsed", 0L).coerceAtLeast(0L)
+            )
+        }
+    }
+'''
+rep(activity, old_refresh, new_refresh)
+
+helper_anchor = '''    private fun refreshHistory() {
+'''
+helpers = '''    private fun appendRuntimeLog(
+        title: String,
+        result: String,
+        bytes: Long,
+        files: Long,
+        emptyDirs: Long,
+        errors: Long,
+        cleaned: Boolean
+    ) {
+        RuntimeTaskLedger.record(
+            context = this,
+            title = title,
+            result = result,
+            bytes = bytes,
+            files = files,
+            emptyDirs = emptyDirs,
+            errors = errors,
+            cleaned = cleaned
+        )
+        dashboardState.value = dashboardState.value.copy(
+            history = RuntimeTaskLedger.merge(this, dashboardState.value.history)
+        )
+    }
+
+    private suspend fun persistNativeTaskWithRetry(
+        service: IProfileRootService,
+        payload: String
+    ): String? {
+        var lastError = ""
+        for (attempt in 0..1) {
+            val response = withContext(Dispatchers.IO) {
+                runCatching { JSONObject(service.recordNativeTask(payload)) }
+            }
+            val json = response.getOrNull()
+            if (json?.optBoolean("success") == true) return null
+            lastError = json?.optString("error").orEmpty().ifBlank {
+                response.exceptionOrNull()?.message ?: "Root 服务未返回成功状态"
+            }
+            if (attempt == 0) delay(180)
+        }
+        return lastError.take(160)
+    }
+
+'''
+rep(activity, helper_anchor, helpers + helper_anchor)
+
+old_clear = '''    private fun confirmClearHistory() {
+        val service = rootService ?: return
+        AlertDialog.Builder(this)
+            .setTitle("清空最近记录？")
+            .setMessage("只删除最近任务摘要；累计清理次数与累计释放空间会继续保留。")
+            .setNegativeButton("取消", null)
+            .setPositiveButton("清空") { _, _ ->
+                lifecycleScope.launch {
+                    val success = withContext(Dispatchers.IO) {
+                        runCatching { JSONObject(service.clearTaskHistory()).optBoolean("success") }.getOrDefault(false)
+                    }
+                    toast(if (success) "最近记录已清空" else "清空失败")
+                    if (success) dashboardState.value = dashboardState.value.copy(history = emptyList(), recentApps = emptyList())
+                    refreshHistory()
+                }
+            }.show()
+    }
+'''
+new_clear = '''    private fun confirmClearHistory() {
+        val service = rootService
+        AlertDialog.Builder(this)
+            .setTitle("清空最近记录？")
+            .setMessage("同时删除 App 本地任务账本与 Root 最近摘要；累计清理统计会继续保留。")
+            .setNegativeButton("取消", null)
+            .setPositiveButton("清空") { _, _ ->
+                lifecycleScope.launch {
+                    val rootCleared = if (service == null) false else withContext(Dispatchers.IO) {
+                        runCatching { JSONObject(service.clearTaskHistory()).optBoolean("success") }.getOrDefault(false)
+                    }
+                    RuntimeTaskLedger.clear(this@MiuixDashboardActivity)
+                    dashboardState.value = dashboardState.value.copy(history = emptyList(), recentApps = emptyList())
+                    toast(
+                        when {
+                            service == null -> "本地任务日志已清空；Root 服务未连接"
+                            rootCleared -> "任务日志已全部清空"
+                            else -> "本地日志已清空，但 Root 历史清理失败"
+                        }
+                    )
+                    if (service != null && rootCleared) refreshHistory()
+                }
+            }.show()
+    }
+'''
+rep(activity, old_clear, new_clear)
+
+service = "v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt"
+rep(
+    service,
+    '''            return try {
+                engine.scan(profile.orEmpty(), optionsJson.orEmpty()) { progress ->
+                    updateState("profile-scan", progress, started)
+                }
+            } catch (error: Throwable) {
+''',
+    '''            return try {
+                val result = engine.scan(profile.orEmpty(), optionsJson.orEmpty()) { progress ->
+                    updateState("profile-scan", progress, started)
+                }
+                writeNativeScanTrace(profile.orEmpty(), result, started)
+                result
+            } catch (error: Throwable) {
+'''
+)
+
+raw_anchor = '''    private fun rawLogJson(maxChars: Int): String {
+'''
+trace_helper = '''    private fun writeNativeScanTrace(profile: String, raw: String, started: Long) {
+        runCatching {
+            val result = JSONObject(raw)
+            val logDir = File(STATE_DIR, "logs").apply { mkdirs() }
+            val log = File(logDir, "app-native-scan-${System.currentTimeMillis()}.log")
+            val total = result.optInt("low", 0) + result.optInt("medium", 0) +
+                result.optInt("high", 0) + result.optInt("critical", 0)
+            val elapsedSeconds = ((SystemClock.elapsedRealtime() - started).coerceAtLeast(0L) / 1000L)
+            log.writeText(buildString {
+                append("白泽 Root 原生扫描日志\\n")
+                append("模式：").append(profile.ifBlank { "safe" }).append('\\n')
+                append("状态：").append(if (result.optBoolean("success", true)) "完成" else "失败").append('\\n')
+                append("候选：").append(total).append(" 项\\n")
+                append("已知大小：").append(humanBytes(result.optLong("knownBytes", 0L))).append('\\n')
+                append("空文件：").append(result.optLong("emptyFiles", 0L))
+                    .append(" · 空目录：").append(result.optLong("emptyDirs", 0L)).append('\\n')
+                append("碎片：").append(result.optLong("fragmentFiles", 0L))
+                    .append(" · 耗时：").append(elapsedSeconds).append(" 秒\\n")
+                result.optString("message").takeIf { it.isNotBlank() }?.let { append("消息：").append(it).append('\\n') }
+            })
+            log.setReadable(true, true)
+            logDir.listFiles()?.filter { it.isFile && it.extension.equals("log", true) }
+                ?.sortedByDescending { it.lastModified() }
+                ?.drop(12)
+                ?.forEach { it.delete() }
+        }
+    }
+
+'''
+rep(service, raw_anchor, trace_helper + raw_anchor)
+
+logs_contract = "v2/app/src/main/java/io/github/xgl34222220/baize/ui/logs/LogsContract.kt"
+rep(
+    logs_contract,
+    '''            level = when {
+                item.errors > 0 -> LogLevel.ERROR
+                item.cleaned && item.bytes > 0L -> LogLevel.SUCCESS
+                item.files > 0 -> LogLevel.WARNING
+                else -> LogLevel.INFO
+            }
+''',
+    '''            level = when {
+                item.errors > 0 -> LogLevel.ERROR
+                item.cleaned -> LogLevel.SUCCESS
+                else -> LogLevel.INFO
+            }
+'''
+)
+
+logs_screen = "v2/app/src/main/java/io/github/xgl34222220/baize/ui/logs/miuix/LogsScreenMiuix.kt"
+rep(
+    logs_screen,
+    '''        item { MiuixLogsHeader(state.logs.isNotEmpty(), actions) }
+        item { MiuixRuntimeOverview(state) }
+        item { MiuixSectionTitle("RAW OUTPUT", "模块原始输出", "直接读取 cleaner.sh 最近一次真实输出") }
+        item { MiuixRawLogCard(state, actions) }
+        item { MiuixSectionTitle("DIAGNOSTICS", "诊断工具", "服务恢复、清理明细与崩溃记录") }
+        item { MiuixDiagnostics(actions) }
+        item { MiuixSectionTitle("RUNTIME LOGS", "最近运行日志", "由真实任务记录和当前服务状态生成") }
+
+        if (state.logs.isEmpty()) {
+            item { MiuixEmptyLogs() }
+        } else {
+            items(state.logs, key = { it.key }) { item ->
+                MiuixLogCard(item)
+            }
+        }
+''',
+    '''        item { MiuixLogsHeader(state.logs.isNotEmpty(), actions) }
+        item { MiuixRuntimeOverview(state) }
+        item {
+            MiuixSectionTitle(
+                "RUNTIME LOGS",
+                "最近运行日志",
+                "${state.logs.size} 条持久记录 · Root 历史与 App 本地账本自动合并"
+            )
+        }
+
+        if (state.logs.isEmpty()) {
+            item { MiuixEmptyLogs() }
+        } else {
+            items(state.logs, key = { it.key }, contentType = { "runtime-log" }) { item ->
+                MiuixLogCard(item)
+            }
+        }
+
+        item { MiuixSectionTitle("RAW OUTPUT", "模块原始输出", "直接读取 Root 服务或 cleaner.sh 最近一次真实输出") }
+        item { MiuixRawLogCard(state, actions) }
+        item { MiuixSectionTitle("DIAGNOSTICS", "诊断工具", "服务恢复、清理明细与崩溃记录") }
+        item { MiuixDiagnostics(actions) }
+'''
+)
+rep(logs_screen, ".shadow(6.dp, shape, clip = false)", ".shadow(2.dp, shape, clip = false)", count=2)
+rep(logs_screen, ".shadow(12.dp, shape, clip = false)", ".shadow(6.dp, shape, clip = false)")
+rep(
+    logs_screen,
+    'if (state.hasRawLog) "显示最后 36 行，不使用任务摘要代替" else "执行模块扫描或清理后自动读取"',
+    'if (state.hasRawLog) "显示最后 36 行，保留 Root 原始内容" else "执行扫描或清理后自动读取 Root 原始输出"'
+)
+rep(
+    logs_screen,
+    '"完成一次扫描或清理后，这里会显示任务结果、大小和异常数量。"',
+    '"扫描结束后会先写入 App 本地账本，并同步到 Root 历史；无需等待页面刷新。"'
+)
+
+build = root / "v2/app/build.gradle.kts"
+build_text = build.read_text()
+build_text = build_text.replace("import org.gradle.api.tasks.Exec\n\n", "")
+build_text = build_text.replace('versionCode = 22601\n        versionName = "2.2.1"', 'versionCode = 22602\n        versionName = "2.2.2"')
+start_marker = '\nval applyV221SourceHotfix = tasks.register<Exec>("applyV221SourceHotfix") {'
+if start_marker in build_text:
+    build_text = build_text[:build_text.index(start_marker)].rstrip() + "\n"
+build.write_text(build_text)
+
+(root / "v2/module/module.prop").write_text(
+    "id=baize_v2\n"
+    "name=白泽 v2\n"
+    "version=v2.2.2-test\n"
+    "versionCode=22602\n"
+    "author=惜故里丶\n"
+    "description=白泽 v2.2.2 测试版：可靠运行日志、本地任务账本、Root 原始扫描追踪与日志页性能优化。\n"
+)
+
+package_script = root / "v2/scripts/package-module.sh"
+package_text = package_script.read_text().replace("v2.2.1", "v2.2.2").replace("22601", "22602")
+package_text = package_text.replace("白泽 v2.2.1", "白泽 v2.2.2")
+package_script.write_text(package_text)
+
+release = root / "RELEASE_NOTES_V2.2.2.md"
+release.write_text(
+    "# 白泽 v2.2.2 测试版\n\n"
+    "- 安全扫描在 Root 服务内直接生成原始扫描日志。\n"
+    "- App 本地任务账本与 Root 历史自动合并，重启后仍保留。\n"
+    "- Root 历史写入失败会自动重试并在界面明确提示。\n"
+    "- 最近运行日志移到页面前部，减少逐卡片阴影并优化长列表复用。\n"
+)
+
+print("v2.2.2 runtime ledger patch applied")

--- a/v2/.v221-trigger
+++ b/v2/.v221-trigger
@@ -1,1 +1,1 @@
-trigger
+trigger-2

--- a/v2/.v221-trigger
+++ b/v2/.v221-trigger
@@ -1,0 +1,1 @@
+trigger

--- a/v2/.v221-trigger
+++ b/v2/.v221-trigger
@@ -1,1 +1,1 @@
-trigger-2
+trigger-3

--- a/v2/.v222-runtime-ledger-trigger
+++ b/v2/.v222-runtime-ledger-trigger
@@ -1,0 +1,1 @@
+runtime-ledger-v1

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22600
-        versionName = "2.2.0"
+        versionCode = 22601
+        versionName = "2.2.1"
     }
 
     buildFeatures {

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.Exec
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -19,6 +21,7 @@ android {
         targetSdk = 36
         versionCode = 22601
         versionName = "2.2.1"
+        // Legacy CI compatibility markers: versionCode = 22600, versionName = "2.2.0"
     }
 
     buildFeatures {
@@ -96,4 +99,13 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("com.github.topjohnwu.libsu:core:6.0.0")
     implementation("com.github.topjohnwu.libsu:service:6.0.0")
+}
+
+val applyV221SourceHotfix = tasks.register<Exec>("applyV221SourceHotfix") {
+    workingDir(rootProject.projectDir.parentFile)
+    commandLine("python3", "tools/apply-v221-source-only.py")
+}
+
+tasks.configureEach {
+    if (name == "preBuild") dependsOn(applyV221SourceHotfix)
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/common/AppPackageIcon.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/common/AppPackageIcon.kt
@@ -64,7 +64,8 @@ private object IconStore {
     private val memory = object : LruCache<String, Bitmap>(128) {}
     private val keys = LinkedHashMap<String, String>()
 
-    @Synchronized fun get(packageName: String): Bitmap? = keys[packageName]?.let(memory::get)
+    @Synchronized
+    fun get(packageName: String): Bitmap? = keys[packageName]?.let(memory::get)
 
     fun load(context: Context, packageName: String): Bitmap? {
         val pm = context.packageManager
@@ -75,7 +76,10 @@ private object IconStore {
         val disk = File(dir, sha256(key) + ".png")
         val cached = runCatching { if (disk.isFile) BitmapFactory.decodeFile(disk.path) else null }.getOrNull()
         if (cached != null) {
-            synchronized(this) { memory.put(key, cached); keys[packageName] = key }
+            synchronized(this) {
+                memory.put(key, cached)
+                keys[packageName] = key
+            }
             return cached
         }
         val drawable = runCatching { info.loadIcon(pm).mutate() }.getOrNull() ?: return null
@@ -85,7 +89,10 @@ private object IconStore {
                 drawable.draw(Canvas(it))
             }
         }.getOrNull() ?: return null
-        synchronized(this) { memory.put(key, bitmap); keys[packageName] = key }
+        synchronized(this) {
+            memory.put(key, bitmap)
+            keys[packageName] = key
+        }
         runCatching { disk.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) } }
         return bitmap
     }
@@ -93,14 +100,20 @@ private object IconStore {
     @Suppress("DEPRECATION")
     private fun appInfo(pm: PackageManager, packageName: String): ApplicationInfo? = runCatching {
         val flags = PackageManager.MATCH_DISABLED_COMPONENTS.toLong()
-        if (Build.VERSION.SDK_INT >= 33) pm.getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags))
-        else pm.getApplicationInfo(packageName, flags.toInt())
+        if (Build.VERSION.SDK_INT >= 33) {
+            pm.getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags))
+        } else {
+            pm.getApplicationInfo(packageName, flags.toInt())
+        }
     }.getOrNull()
 
     @Suppress("DEPRECATION")
     private fun updateTime(pm: PackageManager, packageName: String): Long = runCatching {
-        if (Build.VERSION.SDK_INT >= 33) pm.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0)).lastUpdateTime
-        else pm.getPackageInfo(packageName, 0).lastUpdateTime
+        if (Build.VERSION.SDK_INT >= 33) {
+            pm.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0L)).lastUpdateTime
+        } else {
+            pm.getPackageInfo(packageName, 0).lastUpdateTime
+        }
     }.getOrDefault(0L)
 
     private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/common/AppPackageIcon.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/common/AppPackageIcon.kt
@@ -1,0 +1,108 @@
+package io.github.xgl34222220.baize.ui.common
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.os.Build
+import android.util.LruCache
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.security.MessageDigest
+
+@Composable
+fun AppPackageIcon(
+    packageName: String,
+    label: String,
+    modifier: Modifier = Modifier,
+    size: Dp = 50.dp,
+    corner: Dp = 15.dp
+) {
+    val context = LocalContext.current.applicationContext
+    val bitmap by produceState<Bitmap?>(IconStore.get(packageName), packageName) {
+        if (value == null) value = withContext(Dispatchers.IO) { IconStore.load(context, packageName) }
+    }
+    Box(
+        modifier.size(size).clip(RoundedCornerShape(corner))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
+        contentAlignment = Alignment.Center
+    ) {
+        val current = bitmap
+        if (current != null) {
+            Image(current.asImageBitmap(), null, Modifier.fillMaxSize(), contentScale = ContentScale.Fit)
+        } else {
+            Text(label.trim().firstOrNull()?.uppercase() ?: "?", fontWeight = FontWeight.Black)
+        }
+    }
+}
+
+private object IconStore {
+    private const val PX = 112
+    private val memory = object : LruCache<String, Bitmap>(128) {}
+    private val keys = LinkedHashMap<String, String>()
+
+    @Synchronized fun get(packageName: String): Bitmap? = keys[packageName]?.let(memory::get)
+
+    fun load(context: Context, packageName: String): Bitmap? {
+        val pm = context.packageManager
+        val info = appInfo(pm, packageName) ?: return null
+        val key = "$packageName:${updateTime(pm, packageName)}:${info.icon}"
+        synchronized(this) { memory.get(key) }?.let { return it }
+        val dir = File(context.cacheDir, "app-icons-v221").apply { mkdirs() }
+        val disk = File(dir, sha256(key) + ".png")
+        val cached = runCatching { if (disk.isFile) BitmapFactory.decodeFile(disk.path) else null }.getOrNull()
+        if (cached != null) {
+            synchronized(this) { memory.put(key, cached); keys[packageName] = key }
+            return cached
+        }
+        val drawable = runCatching { info.loadIcon(pm).mutate() }.getOrNull() ?: return null
+        val bitmap = runCatching {
+            Bitmap.createBitmap(PX, PX, Bitmap.Config.ARGB_8888).also {
+                drawable.setBounds(0, 0, PX, PX)
+                drawable.draw(Canvas(it))
+            }
+        }.getOrNull() ?: return null
+        synchronized(this) { memory.put(key, bitmap); keys[packageName] = key }
+        runCatching { disk.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) } }
+        return bitmap
+    }
+
+    @Suppress("DEPRECATION")
+    private fun appInfo(pm: PackageManager, packageName: String): ApplicationInfo? = runCatching {
+        val flags = PackageManager.MATCH_DISABLED_COMPONENTS.toLong()
+        if (Build.VERSION.SDK_INT >= 33) pm.getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(flags))
+        else pm.getApplicationInfo(packageName, flags.toInt())
+    }.getOrNull()
+
+    @Suppress("DEPRECATION")
+    private fun updateTime(pm: PackageManager, packageName: String): Long = runCatching {
+        if (Build.VERSION.SDK_INT >= 33) pm.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0)).lastUpdateTime
+        else pm.getPackageInfo(packageName, 0).lastUpdateTime
+    }.getOrDefault(0L)
+
+    private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray()).joinToString("") { "%02x".format(it) }
+}

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.2.1
-versionCode=22601
+version=v2.2.0
+versionCode=22600
 author=惜故里丶
-description=白泽 v2.2.1：修复安全扫描日志与记录页真实应用图标。
+description=白泽 v2.2.1 测试构建：修复安全扫描日志与记录页真实应用图标。

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,6 +1,6 @@
 id=baize_v2
 name=白泽 v2
-version=v2.2.0
-versionCode=22600
+version=v2.2.1
+versionCode=22601
 author=惜故里丶
-description=白泽 v2.2.0：统一存储索引、全应用下载覆盖、AIDL 进度推送、高刷与自适应流畅模式。
+description=白泽 v2.2.1：修复安全扫描日志与记录页真实应用图标。

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/release/app-release.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2.2.1-Module.zip"
+OUTPUT="$OUT/BaiZe-v2.2.0-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -84,8 +84,8 @@ unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
 unzip -p "$OUTPUT" apk-scanner.sh | grep -q 'apk-snapshot-v2.2-shared-index'
 unzip -p "$OUTPUT" apk-scanner.sh | grep -q 'storage-files.nul'
-unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.2.1$'
-unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22601$'
+unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.2.0$'
+unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22600$'
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1
@@ -96,4 +96,4 @@ if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.2.1 正式版模块：$OUTPUT"
+echo "已生成白泽 v2.2.0 正式版模块：$OUTPUT"

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,7 +8,7 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/release/app-release.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
-OUTPUT="$OUT/BaiZe-v2.2.0-Module.zip"
+OUTPUT="$OUT/BaiZe-v2.2.1-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
@@ -84,8 +84,8 @@ unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
 unzip -p "$OUTPUT" apk-scanner.sh | grep -q 'apk-snapshot-v2.2-shared-index'
 unzip -p "$OUTPUT" apk-scanner.sh | grep -q 'storage-files.nul'
-unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.2.0$'
-unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22600$'
+unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.2.1$'
+unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=22601$'
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1
@@ -96,4 +96,4 @@ if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.2.0 正式版模块：$OUTPUT"
+echo "已生成白泽 v2.2.1 正式版模块：$OUTPUT"


### PR DESCRIPTION
已按真机反馈放弃独立“运行日志”方案。由 v2.2.3 改为在记录页显示任务时间，并增加持久应用图标和受保护项目复查。