### PR TITLE
fix(release): 正确读取正式 APK 证书摘要

### DIFF
--- a/.github/workflows/v2.4.0-release.yml
+++ b/.github/workflows/v2.4.0-release.yml
@@ -213,7 +213,7 @@ jobs:
           "$APKSIGNER" verify --verbose --print-certs "$APK" > "$CERT_FILE"
           cat "$CERT_FILE"
           if [ "${{ github.event_name }}" != 'pull_request' ]; then
-            APK_CERT=$(awk -F': ' '/certificate SHA-256 digest/ {print tolower($2); exit}' "$CERT_FILE" | tr -d ':[:space:]')
+            APK_CERT=$(awk -F': ' '/certificate SHA-256 digest/ {print tolower($NF); exit}' "$CERT_FILE" | tr -d ':[:space:]')
             test "$APK_CERT" = "$BAIZE_CERT_SHA256"
           fi
           cp "$APK" "$RELEASE_APK"


### PR DESCRIPTION
主分支正式签名、Release、Lint、Macrobenchmark 和模块封包均已通过，失败仅发生在证书摘要解析。

`apksigner` 实际输出格式为：

`V3.0 Signer: certificate SHA-256 digest: <摘要>`

旧脚本按 `: ` 分隔后读取 `$2`，得到的是字段名称；本 PR 改为读取最后一段 `$NF`，再统一去除冒号和空白，与固定 BaiZe 正式证书摘要比较。

只修改一行发布核验脚本，不涉及任何功能源码。