### PR TITLE
fix(release): 修正证书摘要读取

### DIFF
--- a/.github/workflows/v2.4.0-release.yml
+++ b/.github/workflows/v2.4.0-release.yml
@@ -213,7 +213,7 @@ jobs:
           "$APKSIGNER" verify --verbose --print-certs "$APK" > "$CERT_FILE"
           cat "$CERT_FILE"
           if [ "${{ github.event_name }}" != 'pull_request' ]; then
-            APK_CERT=$(awk -F': ' '/certificate SHA-256 digest/ {print tolower($2); exit}' "$CERT_FILE" | tr -d ':[:space:]')
+            APK_CERT=$(awk -F': ' '/certificate SHA-256 digest/ {print tolower($NF); exit}' "$CERT_FILE" | tr -d ':[:space:]')
             test "$APK_CERT" = "$BAIZE_CERT_SHA256"
           fi
           cp "$APK" "$RELEASE_APK"


### PR DESCRIPTION
修复 v2.4.0 发布工作流读取 apksigner SHA-256 摘要字段的问题。仅修改发布脚本一行。