### PR TITLE
fix(v2.4.0): 修正模块安装页版本号

### DIFF
--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -15,7 +15,7 @@ for base in "$MODPATH" "/data/adb/modules/baize_v2" "/data/adb/modules_update/ba
   rm -rf "$base/webroot" "$base/webui" "$base/www" "$base/ksu-webui" 2>/dev/null || true
 done
 
-ui_print "- 正在安装白泽 v2.3.0"
+ui_print "- 正在安装白泽 v2.4.0"
 ui_print "- 白泽是 Android Root 垃圾清理与文件归类模块"
 ui_print "- 用于扫描清理缓存、安装包、卸载残留和深度垃圾"
 ui_print "- 可整理应用下载、接收、附件与导出文件"

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -102,6 +102,11 @@ unzip -p "$OUTPUT" apk-scanner.sh | grep -q 'apk-snapshot-v2.2-shared-index'
 unzip -p "$OUTPUT" apk-scanner.sh | grep -q 'storage-files.nul'
 unzip -p "$OUTPUT" module.prop | grep -q '^version=v2.4.0$'
 unzip -p "$OUTPUT" module.prop | grep -q '^versionCode=24000$'
+unzip -p "$OUTPUT" customize.sh | grep -Fqx 'ui_print "- 正在安装白泽 v2.4.0"'
+if unzip -p "$OUTPUT" customize.sh | grep -Eq 'v2\.3\.0|versionCode=23000'; then
+  echo "安装脚本仍包含旧版 v2.3.0 标识，禁止发布" >&2
+  exit 1
+fi
 if unzip -Z1 "$OUTPUT" | grep -Eq '^(webroot|webui|www|ksu-webui)/'; then
   echo "模块包中不允许包含 WebUI 资源" >&2
   exit 1


### PR DESCRIPTION
修复模块安装脚本仍显示 `v2.3.0` 的问题：

- `customize.sh` 安装提示统一为 `v2.4.0`。
- 模块封包阶段强制校验安装提示必须为 `v2.4.0`。
- 检测到 `v2.3.0` 或 `23000` 残留时直接禁止发布。

不修改清理、调度、归类或 App 功能。通过后重新构建并覆盖 v2.4.0 正式资产。