### PR TITLE
feat(clean): resume interrupted clean plans

### DIFF
--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -29,10 +29,11 @@
             android:exported="false" />
         <activity android:name=".CacheActivity" android:exported="false" />
         <activity android:name=".PersistentSmartScanActivity" android:exported="false" />
+        <activity android:name=".ResumableSmartScanActivity" android:exported="false" />
         <activity-alias
             android:name=".SmartScanActivity"
             android:exported="false"
-            android:targetActivity=".PersistentSmartScanActivity" />
+            android:targetActivity=".ResumableSmartScanActivity" />
         <activity android:name=".ApkScanActivity" android:exported="false" />
         <activity android:name=".InstantCacheActivity" android:exported="false" />
         <activity android:name=".FileOrganizerActivity" android:exported="false" />
@@ -60,6 +61,10 @@
             tools:ignore="Instantiatable" />
         <service
             android:name=".root.PersistentCleanPlanRootService"
+            android:exported="false"
+            tools:ignore="Instantiatable" />
+        <service
+            android:name=".root.CleanPlanResumeRootService"
             android:exported="false"
             tools:ignore="Instantiatable" />
     </application>

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanPlanResumeService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanPlanResumeService.aidl
@@ -1,0 +1,10 @@
+package io.github.xgl34222220.baize.root;
+
+interface ICleanPlanResumeService {
+    String ping();
+    String begin(String planId, String cacheSnapshotId, String safeSnapshotId, int cacheCount, int safeCount);
+    String checkpointCache(String planId, String resultJson);
+    String checkpointSafe(String planId, String resultJson);
+    String recover(String planId);
+    String finish(String planId);
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt
@@ -1,0 +1,989 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.IBinder
+import android.os.SystemClock
+import android.text.format.Formatter
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.DeleteSweep
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Stop
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.BaiZeRootService
+import io.github.xgl34222220.baize.root.CleanPlanResumeRootService
+import io.github.xgl34222220.baize.root.IBaiZeRootService
+import io.github.xgl34222220.baize.root.ICleanPlanResumeService
+import io.github.xgl34222220.baize.root.IPersistentCleanPlanService
+import io.github.xgl34222220.baize.root.PersistentCleanPlanRootService
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.util.UUID
+
+/** Smart clean with stage checkpoints and crash-safe resume. */
+class ResumableSmartScanActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private val preferences by lazy { getSharedPreferences("baize_v2", MODE_PRIVATE) }
+
+    private var cacheService: IBaiZeRootService? = null
+    private var planService: IPersistentCleanPlanService? = null
+    private var resumeService: ICleanPlanResumeService? = null
+    private var cacheBindingRequested = false
+    private var planBindingRequested = false
+    private var resumeBindingRequested = false
+    private var pollJob: Job? = null
+
+    private var cacheSnapshotId = ""
+    private var safeSnapshotId = ""
+    private var cacheCount = 0
+    private var safeCount = 0
+    private var originalCacheCount = 0
+    private var originalSafeCount = 0
+    private var cleanPlanId = ""
+    private var cleanPlanCreatedAt = 0L
+    private var runCount = 0
+    private var deletedBytes = 0L
+    private var deletedFiles = 0L
+    private var deletedDirectories = 0L
+    private var cleanedCandidates = 0
+    private var cumulativeFailures = 0
+    private var resumable = false
+    private var restoredPlanNeedsValidation = false
+    private var validationRunning = false
+
+    private var showCleanConfirm by mutableStateOf(false)
+    private var screenState by mutableStateOf(ResumeSmartUiState())
+
+    private val cacheConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            cacheService = IBaiZeRootService.Stub.asInterface(binder)
+            cacheBindingRequested = true
+            updateConnectionState()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            cacheService = null
+            cacheBindingRequested = false
+            updateConnectionState()
+        }
+    }
+
+    private val planConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            planService = IPersistentCleanPlanService.Stub.asInterface(binder)
+            planBindingRequested = true
+            updateConnectionState()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            planService = null
+            planBindingRequested = false
+            updateConnectionState()
+        }
+    }
+
+    private val resumeConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            resumeService = ICleanPlanResumeService.Stub.asInterface(binder)
+            resumeBindingRequested = true
+            updateConnectionState()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            resumeService = null
+            resumeBindingRequested = false
+            updateConnectionState()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        restoreCleanPlan()
+        setContent {
+            val appearance by appearanceViewModel.settings.collectAsState()
+            BaiZeTheme(appearance) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    ResumeSmartScreen(
+                        state = screenState,
+                        onBack = ::finish,
+                        onScan = ::startSmartScan,
+                        onClean = { showCleanConfirm = true },
+                        onStop = ::stopTask,
+                        onReconnect = ::bindServices
+                    )
+                    if (showCleanConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showCleanConfirm = false },
+                            title = {
+                                Text(
+                                    if (resumable) "继续清理 ${cacheCount + safeCount} 项？"
+                                    else "执行清理计划 ${cleanPlanId.take(8)}？"
+                                )
+                            },
+                            text = {
+                                Text(
+                                    if (resumable) {
+                                        "只继续处理事务日志中剩余的候选。已完成项目不会重复删除，也不会重新扫描。"
+                                    } else {
+                                        "只处理本次扫描保存的候选。清理前会再次校验路径、白名单和文件状态。"
+                                    }
+                                )
+                            },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    showCleanConfirm = false
+                                    cleanSnapshots()
+                                }) { Text(if (resumable) "继续清理" else "立即清理") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showCleanConfirm = false }) { Text("取消") }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        bindServices()
+    }
+
+    private fun bindServices() {
+        if (cacheService == null && !cacheBindingRequested) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, BaiZeRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    cacheConnection
+                )
+                cacheBindingRequested = true
+            }.onFailure {
+                cacheBindingRequested = false
+                screenState = screenState.copy(phase = "缓存 Root 服务启动失败：${it.message}")
+            }
+        }
+        if (planService == null && !planBindingRequested) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, PersistentCleanPlanRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    planConnection
+                )
+                planBindingRequested = true
+            }.onFailure {
+                planBindingRequested = false
+                screenState = screenState.copy(phase = "安全项目 Root 服务启动失败：${it.message}")
+            }
+        }
+        if (resumeService == null && !resumeBindingRequested) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, CleanPlanResumeRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    resumeConnection
+                )
+                resumeBindingRequested = true
+            }.onFailure {
+                resumeBindingRequested = false
+                screenState = screenState.copy(phase = "断点事务 Root 服务启动失败：${it.message}")
+            }
+        }
+        updateConnectionState()
+    }
+
+    private fun updateConnectionState() {
+        val readyCount = listOf(cacheService, planService, resumeService).count { it != null }
+        screenState = screenState.copy(
+            connected = readyCount == 3,
+            status = if (readyCount == 3) "扫描、快照与断点事务引擎已连接" else "正在连接 Root 引擎 · $readyCount/3"
+        )
+        if (readyCount == 3 && restoredPlanNeedsValidation && !validationRunning) validateRestoredPlan()
+    }
+
+    private fun startSmartScan() {
+        if (screenState.running) return
+        val cache = cacheService
+        val plans = planService
+        val transactions = resumeService
+        if (cache == null || plans == null || transactions == null) {
+            screenState = screenState.copy(phase = "Root 引擎尚未全部连接，正在重新连接…")
+            bindServices()
+            return
+        }
+
+        val oldPlan = cleanPlanId
+        resetPlanFields()
+        if (oldPlan.isNotBlank()) lifecycleScope.launch(Dispatchers.IO) { runCatching { transactions.finish(oldPlan) } }
+        screenState = ResumeSmartUiState(
+            connected = true,
+            running = true,
+            operation = "scan",
+            status = "扫描、快照与断点事务引擎已连接",
+            phase = "正在并行生成应用缓存与安全项目清理计划…",
+            progressCurrent = 0,
+            progressTotal = 2,
+            cacheSummary = "正在扫描",
+            safeSummary = "正在扫描"
+        )
+        startPolling()
+        val started = SystemClock.elapsedRealtime()
+
+        lifecycleScope.launch {
+            try {
+                val whitelist = preferences.getStringSet("package_whitelist", emptySet()).orEmpty()
+                val options = optionsJson()
+                val (cacheJson, safeJson) = withContext(Dispatchers.IO) {
+                    coroutineScope {
+                        val cacheJob = async {
+                            JSONObject(cache.scanCandidates(JSONArray(whitelist.toList().sorted()).toString()))
+                        }
+                        val safeJob = async { JSONObject(plans.scanSafe(options)) }
+                        cacheJob.await() to safeJob.await()
+                    }
+                }
+                if (cacheJson.optString("error") == "busy" || safeJson.optString("error") == "busy") {
+                    screenState = screenState.copy(phase = "当前已有扫描或清理任务正在运行")
+                    return@launch
+                }
+
+                cacheSnapshotId = if (cacheJson.has("error")) "" else cacheJson.optString("snapshotId")
+                cacheCount = if (cacheSnapshotId.isBlank()) 0 else (
+                    cacheJson.optInt("totalCandidates") - cacheJson.optInt("whitelisted")
+                ).coerceAtLeast(0)
+                safeSnapshotId = if (safeJson.has("error")) "" else safeJson.optString("snapshotId")
+                safeCount = if (safeSnapshotId.isBlank()) 0 else (
+                    safeJson.optInt("low") + safeJson.optInt("medium")
+                ).coerceAtLeast(0)
+                originalCacheCount = cacheCount
+                originalSafeCount = safeCount
+                cleanPlanId = UUID.randomUUID().toString()
+                cleanPlanCreatedAt = System.currentTimeMillis()
+
+                val total = cacheCount + safeCount
+                val cancelled = cacheJson.optBoolean("cancelled") || safeJson.optBoolean("cancelled")
+                val ready = !cancelled && total > 0 && (cacheSnapshotId.isNotBlank() || safeSnapshotId.isNotBlank())
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    phase = buildString {
+                        append(if (cancelled) "智能扫描已停止" else "可恢复清理计划生成完成")
+                        append(" · ${SystemClock.elapsedRealtime() - started}ms")
+                        if (!cancelled) append("\n保存 $total 项；停止或异常中断后可继续，不会重新扫描")
+                    },
+                    totalSafe = total,
+                    cleanReady = ready,
+                    scanCompleted = !cancelled,
+                    resumable = false,
+                    progressCurrent = 2,
+                    progressTotal = 2,
+                    cacheSummary = if (cacheJson.has("error")) {
+                        cacheJson.optString("message", "缓存扫描失败")
+                    } else "$cacheCount 项 · ${cacheJson.optLong("elapsedMs")}ms",
+                    safeSummary = if (safeJson.has("error")) {
+                        safeJson.optString("message", "安全项目扫描失败")
+                    } else {
+                        "$safeCount 项 · 空项目 ${safeJson.optInt("emptyFiles") + safeJson.optInt("emptyDirs")} · " +
+                            "规则 ${safeJson.optInt("ruleTargets")} · 碎片 ${safeJson.optInt("fragmentFiles")}"
+                    }
+                )
+                if (ready) persistCleanPlan() else clearLocalPlan()
+            } catch (error: Throwable) {
+                screenState = screenState.copy(phase = "智能扫描失败：${error.message ?: error.javaClass.simpleName}")
+            } finally {
+                pollJob?.cancel()
+                if (screenState.running) screenState = screenState.copy(running = false, operation = "")
+                updateConnectionState()
+            }
+        }
+    }
+
+    private fun cleanSnapshots() {
+        if (screenState.running) return
+        val totalBefore = cacheCount + safeCount
+        if (!screenState.cleanReady || totalBefore <= 0 || !cleanPlanCurrent()) {
+            screenState = screenState.copy(phase = "清理计划已过期、失效或设置已变化，请重新扫描")
+            return
+        }
+        val cache = cacheService
+        val plans = planService
+        val transactions = resumeService
+        if (cache == null || plans == null || transactions == null) {
+            screenState = screenState.copy(phase = "Root 引擎尚未全部连接")
+            bindServices()
+            return
+        }
+
+        screenState = screenState.copy(
+            running = true,
+            operation = "clean",
+            phase = if (resumable) "正在继续清理剩余候选…" else "正在启动可恢复清理事务…",
+            progressCurrent = 0,
+            progressTotal = totalBefore.coerceAtLeast(1)
+        )
+        startPolling()
+        val started = SystemClock.elapsedRealtime()
+
+        lifecycleScope.launch {
+            var interrupted = false
+            try {
+                val begin = JSONObject(withContext(Dispatchers.IO) {
+                    transactions.begin(cleanPlanId, cacheSnapshotId, safeSnapshotId, cacheCount, safeCount)
+                })
+                if (begin.has("error")) throw IllegalStateException(begin.optString("message", "无法启动清理事务"))
+                applyTransaction(begin)
+                persistCleanPlan()
+
+                val selection = JSONObject().put("__all_safe__", true).toString()
+                val whitelist = preferences.getStringSet("package_whitelist", emptySet()).orEmpty()
+
+                if (cacheSnapshotId.isNotBlank() && cacheCount > 0) {
+                    screenState = screenState.copy(phase = "正在清理应用缓存 · 已建立事务检查点")
+                    val result = withContext(Dispatchers.IO) {
+                        runCatching {
+                            JSONObject(cache.cleanSelected(
+                                cacheSnapshotId,
+                                selection,
+                                JSONArray(whitelist.toList().sorted()).toString()
+                            ))
+                        }.getOrElse { throwableJson(it) }
+                    }
+                    val checkpoint = JSONObject(withContext(Dispatchers.IO) {
+                        transactions.checkpointCache(cleanPlanId, result.toString())
+                    })
+                    if (checkpoint.has("error")) throw IllegalStateException(checkpoint.optString("message"))
+                    applyTransaction(checkpoint)
+                    if (checkpoint.optBoolean("cacheComplete")) cacheSnapshotId = ""
+                    persistCleanPlan()
+                    interrupted = result.has("error") || result.optBoolean("cancelled") || result.optBoolean("timedOut")
+                }
+
+                if (!interrupted && safeSnapshotId.isNotBlank() && safeCount > 0) {
+                    screenState = screenState.copy(phase = "正在清理安全项目 · 逐候选写入事务日志")
+                    val result = withContext(Dispatchers.IO) {
+                        runCatching {
+                            JSONObject(plans.cleanSafe(safeSnapshotId, selection, optionsJson()))
+                        }.getOrElse { throwableJson(it) }
+                    }
+                    val checkpoint = JSONObject(withContext(Dispatchers.IO) {
+                        transactions.checkpointSafe(cleanPlanId, result.toString())
+                    })
+                    if (checkpoint.has("error")) throw IllegalStateException(checkpoint.optString("message"))
+                    applyTransaction(checkpoint)
+                    if (checkpoint.optBoolean("safeComplete")) safeSnapshotId = ""
+                    persistCleanPlan()
+                    interrupted = result.has("error") || result.optBoolean("cancelled") || result.optBoolean("timedOut")
+                }
+
+                val remaining = cacheCount + safeCount
+                val elapsed = SystemClock.elapsedRealtime() - started
+                val report = buildString {
+                    append(if (remaining > 0) {
+                        if (interrupted) "清理已安全停止" else "清理部分完成"
+                    } else "清理计划执行完成")
+                    append(" · ${elapsed}ms")
+                    append("\n累计释放 ${Formatter.formatFileSize(this@ResumableSmartScanActivity, deletedBytes)}")
+                    append(" · 已完成 $cleanedCandidates 项 · 剩余 $remaining 项")
+                    if (cumulativeFailures > 0) append(" · 失败记录 $cumulativeFailures")
+                    if (remaining > 0) append("\n可直接点击继续清理，不会重新扫描或重复处理已完成项目")
+                }
+                preferences.edit()
+                    .putString("last_report_text", report)
+                    .putLong("last_clean_bytes", deletedBytes)
+                    .apply()
+
+                if (remaining <= 0) {
+                    withContext(Dispatchers.IO) { runCatching { transactions.finish(cleanPlanId) } }
+                    clearLocalPlan()
+                } else {
+                    resumable = true
+                    persistCleanPlan()
+                }
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    phase = report,
+                    totalSafe = remaining,
+                    cleanReady = remaining > 0,
+                    scanCompleted = remaining > 0,
+                    resumable = remaining > 0,
+                    runCount = runCount,
+                    deletedBytes = deletedBytes,
+                    cleanedCandidates = cleanedCandidates,
+                    failures = cumulativeFailures,
+                    progressCurrent = (originalCacheCount + originalSafeCount - remaining).coerceAtLeast(0),
+                    progressTotal = (originalCacheCount + originalSafeCount).coerceAtLeast(1),
+                    cacheSummary = if (remaining > 0) "应用缓存剩余 $cacheCount 项" else "应用缓存清理完成",
+                    safeSummary = if (remaining > 0) "安全项目剩余 $safeCount 项" else "安全项目清理完成"
+                )
+                NativeNotifier.showTaskResult(
+                    this@ResumableSmartScanActivity,
+                    if (remaining > 0) "白泽清理已保存断点" else "白泽清理计划完成",
+                    if (remaining > 0) "剩余 $remaining 项，可继续清理" else "释放 ${Formatter.formatFileSize(this@ResumableSmartScanActivity, deletedBytes)}",
+                    report
+                )
+            } catch (error: Throwable) {
+                val recovered = withContext(Dispatchers.IO) {
+                    runCatching { JSONObject(transactions.recover(cleanPlanId)) }.getOrNull()
+                }
+                if (recovered != null && !recovered.has("error")) applyTransaction(recovered)
+                val remaining = cacheCount + safeCount
+                resumable = remaining > 0
+                if (remaining > 0) persistCleanPlan()
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    phase = "清理事务中断：${error.message ?: error.javaClass.simpleName}\n已保存剩余 $remaining 项，可直接继续清理",
+                    totalSafe = remaining,
+                    cleanReady = remaining > 0,
+                    scanCompleted = remaining > 0,
+                    resumable = remaining > 0,
+                    runCount = runCount,
+                    deletedBytes = deletedBytes,
+                    cleanedCandidates = cleanedCandidates,
+                    failures = cumulativeFailures,
+                    cacheSummary = "应用缓存剩余 $cacheCount 项",
+                    safeSummary = "安全项目剩余 $safeCount 项"
+                )
+            } finally {
+                pollJob?.cancel()
+                if (screenState.running) screenState = screenState.copy(running = false, operation = "")
+                updateConnectionState()
+            }
+        }
+    }
+
+    private fun stopTask() {
+        if (!screenState.running) return
+        cacheService?.cancelCurrentTask()
+        planService?.cancelCurrentTask()
+        screenState = screenState.copy(phase = "已发送停止请求；完成当前项目后写入断点…")
+    }
+
+    private fun startPolling() {
+        pollJob?.cancel()
+        pollJob = lifecycleScope.launch {
+            while (isActive && screenState.running) {
+                val states = withContext(Dispatchers.IO) {
+                    coroutineScope {
+                        val cacheState = async {
+                            cacheService?.getTaskState()?.takeIf { it.isNotBlank() }
+                                ?.let { runCatching { JSONObject(it) }.getOrNull() }
+                        }
+                        val safeState = async {
+                            planService?.getTaskState()?.takeIf { it.isNotBlank() }
+                                ?.let { runCatching { JSONObject(it) }.getOrNull() }
+                        }
+                        listOfNotNull(cacheState.await(), safeState.await())
+                    }
+                }.filter { it.optBoolean("running") }
+                if (states.isNotEmpty()) renderProgress(states)
+                delay(350L)
+            }
+        }
+    }
+
+    private fun renderProgress(states: List<JSONObject>) {
+        val preferred = states.firstOrNull {
+            it.optString("operation", it.optString("mode")).contains(screenState.operation, ignoreCase = true)
+        } ?: states.first()
+        val current = preferred.optInt("current", preferred.optInt("progress_current", screenState.progressCurrent))
+        val total = preferred.optInt("total", preferred.optInt("progress_total", screenState.progressTotal))
+        val path = preferred.optString("currentPath", preferred.optString("current_path")).trim()
+        val phase = preferred.optString("phase").ifBlank {
+            if (screenState.operation == "clean") "正在执行可恢复清理" else "正在生成清理计划"
+        }
+        screenState = screenState.copy(
+            phase = buildString {
+                append(phase)
+                if (total > 0) append(" · $current/$total")
+                if (path.isNotBlank()) append("\n").append(path.takeLast(96))
+                if (preferred.optBoolean("cancelRequested")) append("\n正在安全停止并保存断点…")
+            },
+            progressCurrent = current.coerceAtLeast(0),
+            progressTotal = total.coerceAtLeast(1)
+        )
+    }
+
+    private fun restoreCleanPlan() {
+        val rawV2 = preferences.getString(CLEAN_PLAN_KEY, null).orEmpty()
+        val raw = if (rawV2.isNotBlank()) rawV2 else preferences.getString(LEGACY_PLAN_KEY, null).orEmpty()
+        if (raw.isBlank()) return
+        val plan = runCatching { JSONObject(raw) }.getOrNull() ?: run {
+            clearLocalPlan()
+            return
+        }
+        val createdAt = plan.optLong("createdAt", 0L)
+        val age = System.currentTimeMillis() - createdAt
+        if (createdAt <= 0L || age !in 0..CLEAN_PLAN_TTL_MS || plan.optString("optionsSha") != sha256(optionsJson())) {
+            clearLocalPlan()
+            screenState = screenState.copy(phase = "旧清理计划已过期或设置已变化，请重新扫描")
+            return
+        }
+
+        cleanPlanId = plan.optString("planId")
+        cleanPlanCreatedAt = createdAt
+        cacheSnapshotId = plan.optString("cacheSnapshotId")
+        safeSnapshotId = plan.optString("safeSnapshotId")
+        cacheCount = plan.optInt("cacheCount").coerceAtLeast(0)
+        safeCount = plan.optInt("safeCount").coerceAtLeast(0)
+        originalCacheCount = plan.optInt("originalCacheCount", cacheCount).coerceAtLeast(cacheCount)
+        originalSafeCount = plan.optInt("originalSafeCount", safeCount).coerceAtLeast(safeCount)
+        runCount = plan.optInt("runCount", 0).coerceAtLeast(0)
+        deletedBytes = plan.optLong("deletedBytes", 0L).coerceAtLeast(0L)
+        deletedFiles = plan.optLong("deletedFiles", 0L).coerceAtLeast(0L)
+        deletedDirectories = plan.optLong("deletedDirectories", 0L).coerceAtLeast(0L)
+        cleanedCandidates = plan.optInt("cleanedCandidates", 0).coerceAtLeast(0)
+        cumulativeFailures = plan.optInt("failures", 0).coerceAtLeast(0)
+        resumable = plan.optBoolean("resumable", runCount > 0)
+        val total = cacheCount + safeCount
+        if (cleanPlanId.isBlank() || total <= 0 || (cacheSnapshotId.isBlank() && safeSnapshotId.isBlank())) {
+            clearLocalPlan()
+            return
+        }
+        if (rawV2.isBlank()) persistCleanPlan()
+        restoredPlanNeedsValidation = true
+        screenState = screenState.copy(
+            phase = "已恢复清理计划 ${cleanPlanId.take(8)}，连接 Root 引擎后恢复事务断点",
+            totalSafe = total,
+            cleanReady = true,
+            scanCompleted = true,
+            resumable = resumable,
+            runCount = runCount,
+            deletedBytes = deletedBytes,
+            cleanedCandidates = cleanedCandidates,
+            failures = cumulativeFailures,
+            cacheSummary = plan.optString("cacheSummary", "剩余 $cacheCount 项"),
+            safeSummary = plan.optString("safeSummary", "剩余 $safeCount 项")
+        )
+    }
+
+    private fun validateRestoredPlan() {
+        val cache = cacheService ?: return
+        val plans = planService ?: return
+        val transactions = resumeService ?: return
+        if (!restoredPlanNeedsValidation || validationRunning) return
+        validationRunning = true
+        lifecycleScope.launch {
+            try {
+                if (runCount > 0) {
+                    val recovered = withContext(Dispatchers.IO) {
+                        runCatching { JSONObject(transactions.recover(cleanPlanId)) }.getOrNull()
+                    }
+                    if (recovered != null && !recovered.has("error")) applyTransaction(recovered)
+                }
+                val (cachePage, safePage) = withContext(Dispatchers.IO) {
+                    coroutineScope {
+                        val cacheJob = async {
+                            if (cacheSnapshotId.isBlank()) null else runCatching {
+                                JSONObject(cache.getResultPage(cacheSnapshotId, 0, 1))
+                            }.getOrNull()
+                        }
+                        val safeJob = async {
+                            if (safeSnapshotId.isBlank()) null else runCatching {
+                                JSONObject(plans.getPage(safeSnapshotId, 0, 1))
+                            }.getOrNull()
+                        }
+                        cacheJob.await() to safeJob.await()
+                    }
+                }
+                cacheCount = cachePage?.takeIf { !it.has("error") }?.optInt("total", 0)?.coerceAtLeast(0) ?: 0
+                safeCount = safePage?.takeIf { !it.has("error") }?.optInt("total", 0)?.coerceAtLeast(0) ?: 0
+                if (cacheCount <= 0) cacheSnapshotId = ""
+                if (safeCount <= 0) safeSnapshotId = ""
+                val remaining = cacheCount + safeCount
+                resumable = runCount > 0 && remaining > 0
+                if (remaining <= 0) {
+                    withContext(Dispatchers.IO) { runCatching { transactions.finish(cleanPlanId) } }
+                    clearLocalPlan()
+                    screenState = screenState.copy(
+                        phase = "已保存的清理计划已经全部完成或失效，请重新扫描",
+                        totalSafe = 0,
+                        cleanReady = false,
+                        scanCompleted = false,
+                        resumable = false
+                    )
+                } else {
+                    persistCleanPlan()
+                    screenState = screenState.copy(
+                        phase = if (resumable) {
+                            "事务断点恢复完成 · 剩余 $remaining 项，可直接继续清理"
+                        } else "清理计划 ${cleanPlanId.take(8)} 已恢复 · $remaining 项可直接清理",
+                        totalSafe = remaining,
+                        cleanReady = true,
+                        scanCompleted = true,
+                        resumable = resumable,
+                        runCount = runCount,
+                        deletedBytes = deletedBytes,
+                        cleanedCandidates = cleanedCandidates,
+                        failures = cumulativeFailures,
+                        cacheSummary = "应用缓存剩余 $cacheCount 项",
+                        safeSummary = "安全项目剩余 $safeCount 项"
+                    )
+                }
+            } finally {
+                validationRunning = false
+                restoredPlanNeedsValidation = false
+            }
+        }
+    }
+
+    private fun applyTransaction(json: JSONObject) {
+        cacheCount = json.optInt("cacheRemaining", cacheCount).coerceAtLeast(0)
+        safeCount = json.optInt("safeRemaining", safeCount).coerceAtLeast(0)
+        runCount = json.optInt("runCount", runCount).coerceAtLeast(0)
+        deletedBytes = json.optLong("deletedBytes", deletedBytes).coerceAtLeast(0L)
+        deletedFiles = json.optLong("deletedFiles", deletedFiles).coerceAtLeast(0L)
+        deletedDirectories = json.optLong("deletedDirectories", deletedDirectories).coerceAtLeast(0L)
+        cleanedCandidates = json.optInt("cleanedCandidates", cleanedCandidates).coerceAtLeast(0)
+        cumulativeFailures = json.optInt("failures", cumulativeFailures).coerceAtLeast(0)
+        resumable = json.optBoolean("resumable", cacheCount + safeCount > 0 && runCount > 0)
+        screenState = screenState.copy(
+            totalSafe = cacheCount + safeCount,
+            resumable = resumable,
+            runCount = runCount,
+            deletedBytes = deletedBytes,
+            cleanedCandidates = cleanedCandidates,
+            failures = cumulativeFailures,
+            cacheSummary = "应用缓存剩余 $cacheCount 项",
+            safeSummary = "安全项目剩余 $safeCount 项"
+        )
+    }
+
+    private fun persistCleanPlan() {
+        val total = cacheCount + safeCount
+        if (cleanPlanId.isBlank() || total <= 0 || (cacheSnapshotId.isBlank() && safeSnapshotId.isBlank())) return
+        val plan = JSONObject()
+            .put("version", CLEAN_PLAN_VERSION)
+            .put("planId", cleanPlanId)
+            .put("createdAt", cleanPlanCreatedAt)
+            .put("optionsSha", sha256(optionsJson()))
+            .put("cacheSnapshotId", cacheSnapshotId)
+            .put("safeSnapshotId", safeSnapshotId)
+            .put("cacheCount", cacheCount)
+            .put("safeCount", safeCount)
+            .put("originalCacheCount", originalCacheCount)
+            .put("originalSafeCount", originalSafeCount)
+            .put("runCount", runCount)
+            .put("deletedBytes", deletedBytes)
+            .put("deletedFiles", deletedFiles)
+            .put("deletedDirectories", deletedDirectories)
+            .put("cleanedCandidates", cleanedCandidates)
+            .put("failures", cumulativeFailures)
+            .put("resumable", resumable)
+            .put("cacheSummary", screenState.cacheSummary)
+            .put("safeSummary", screenState.safeSummary)
+        preferences.edit()
+            .putString(CLEAN_PLAN_KEY, plan.toString())
+            .remove(LEGACY_PLAN_KEY)
+            .apply()
+    }
+
+    private fun cleanPlanCurrent(): Boolean {
+        val age = System.currentTimeMillis() - cleanPlanCreatedAt
+        if (cleanPlanId.isBlank() || cleanPlanCreatedAt <= 0L || age !in 0..CLEAN_PLAN_TTL_MS) return false
+        val plan = runCatching { JSONObject(preferences.getString(CLEAN_PLAN_KEY, null).orEmpty()) }.getOrNull()
+            ?: return false
+        return plan.optString("planId") == cleanPlanId && plan.optString("optionsSha") == sha256(optionsJson())
+    }
+
+    private fun optionsJson(): String {
+        val packages = preferences.getStringSet("package_whitelist", emptySet()).orEmpty().toList().sorted()
+        val paths = preferences.getStringSet("path_whitelist", emptySet()).orEmpty().toList().sorted()
+        val maxMb = preferences.getFloat("large_file_mb", 512f).toLong().coerceIn(64L, 16_384L)
+        return JSONObject()
+            .put("whitelistPackages", JSONArray(packages))
+            .put("whitelistPaths", JSONArray(paths))
+            .put("maxFileBytes", maxMb * 1024L * 1024L)
+            .put("fragmentDays", preferences.getInt("fragment_days", 7).coerceIn(0, 365))
+            .put("allowHighRisk", false)
+            .toString()
+    }
+
+    private fun throwableJson(error: Throwable): JSONObject = JSONObject()
+        .put("error", "binder_failed")
+        .put("message", error.message ?: error.javaClass.simpleName)
+        .put("cancelled", false)
+        .put("timedOut", false)
+
+    private fun clearLocalPlan() {
+        preferences.edit().remove(CLEAN_PLAN_KEY).remove(LEGACY_PLAN_KEY).apply()
+        cacheSnapshotId = ""
+        safeSnapshotId = ""
+        cacheCount = 0
+        safeCount = 0
+        cleanPlanId = ""
+        cleanPlanCreatedAt = 0L
+        resumable = false
+        restoredPlanNeedsValidation = false
+        validationRunning = false
+    }
+
+    private fun resetPlanFields() {
+        cacheSnapshotId = ""
+        safeSnapshotId = ""
+        cacheCount = 0
+        safeCount = 0
+        originalCacheCount = 0
+        originalSafeCount = 0
+        cleanPlanId = ""
+        cleanPlanCreatedAt = 0L
+        runCount = 0
+        deletedBytes = 0L
+        deletedFiles = 0L
+        deletedDirectories = 0L
+        cleanedCandidates = 0
+        cumulativeFailures = 0
+        resumable = false
+        restoredPlanNeedsValidation = false
+        validationRunning = false
+    }
+
+    private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    override fun onDestroy() {
+        pollJob?.cancel()
+        if (cacheBindingRequested) runCatching { RootService.unbind(cacheConnection) }
+        if (planBindingRequested) runCatching { RootService.unbind(planConnection) }
+        if (resumeBindingRequested) runCatching { RootService.unbind(resumeConnection) }
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val CLEAN_PLAN_KEY = "smart_clean_plan_v2"
+        private const val LEGACY_PLAN_KEY = "smart_clean_plan_v1"
+        private const val CLEAN_PLAN_VERSION = 2
+        private const val CLEAN_PLAN_TTL_MS = 30L * 60_000L
+    }
+}
+
+private data class ResumeSmartUiState(
+    val connected: Boolean = false,
+    val running: Boolean = false,
+    val operation: String = "",
+    val status: String = "正在连接 Root 引擎…",
+    val phase: String = "连接完成后可开始智能扫描",
+    val totalSafe: Int = 0,
+    val cleanReady: Boolean = false,
+    val scanCompleted: Boolean = false,
+    val resumable: Boolean = false,
+    val runCount: Int = 0,
+    val deletedBytes: Long = 0L,
+    val cleanedCandidates: Int = 0,
+    val failures: Int = 0,
+    val progressCurrent: Int = 0,
+    val progressTotal: Int = 0,
+    val cacheSummary: String = "等待扫描",
+    val safeSummary: String = "等待扫描"
+)
+
+@Composable
+private fun ResumeSmartScreen(
+    state: ResumeSmartUiState,
+    onBack: () -> Unit,
+    onScan: () -> Unit,
+    onClean: () -> Unit,
+    onStop: () -> Unit,
+    onReconnect: () -> Unit
+) {
+    val context = LocalContext.current
+    val progress = if (state.progressTotal > 0) {
+        (state.progressCurrent.toFloat() / state.progressTotal.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 30.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("RESUME CLEAN", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+                    Text("智能扫描", fontSize = 30.sp, fontWeight = FontWeight.Black)
+                    Text("扫描一次 · 清理中断后从剩余项目继续", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(30.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+            ) {
+                Column(modifier = Modifier.padding(22.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier.size(58.dp).background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(20.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                if (state.cleanReady) Icons.Rounded.CheckCircle else Icons.Rounded.CleaningServices,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(30.dp)
+                            )
+                        }
+                        Spacer(Modifier.size(14.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(state.status, fontWeight = FontWeight.Bold)
+                            Text(
+                                state.phase,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 7,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+
+                    if (state.running) {
+                        if (state.progressTotal > 0) {
+                            LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+                        } else LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        OutlinedButton(onClick = onStop, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Stop, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("停止并保存断点")
+                        }
+                    } else if (state.cleanReady) {
+                        Button(onClick = onClean, enabled = state.connected, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.DeleteSweep, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text(if (state.resumable) "继续清理 ${state.totalSafe} 项" else "一键清理 ${state.totalSafe} 项")
+                        }
+                        OutlinedButton(onClick = onScan, enabled = state.connected, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("放弃当前计划并重新扫描")
+                        }
+                    } else if (!state.connected) {
+                        OutlinedButton(onClick = onReconnect, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("重新连接 Root 引擎")
+                        }
+                    } else {
+                        Button(onClick = onScan, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("开始智能扫描")
+                        }
+                    }
+                }
+            }
+        }
+
+        if (state.scanCompleted || state.runCount > 0) {
+            item {
+                Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+                    Text("TRANSACTION", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+                    Text("清理事务", fontSize = 26.sp, fontWeight = FontWeight.Black)
+                    Text(
+                        "执行 ${state.runCount} 次 · 累计释放 ${Formatter.formatFileSize(context, state.deletedBytes)} · 完成 ${state.cleanedCandidates} 项",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (state.failures > 0) {
+                        Text("累计失败记录 ${state.failures} 项，失败项目会保留在剩余计划中", color = MaterialTheme.colorScheme.error)
+                    }
+                }
+            }
+            item { ResumeInfoCard("应用缓存", state.cacheSummary) }
+            item { ResumeInfoCard("安全项目", state.safeSummary) }
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding(),
+                    shape = RoundedCornerShape(24.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+                ) {
+                    Text(
+                        "已完成或确认失效的候选会从事务快照中移除；部分删除、失败和未执行候选继续保留。应用或 Root 服务异常退出后，会先恢复快照检查点，再允许继续清理。",
+                        modifier = Modifier.padding(18.dp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                        lineHeight = 18.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResumeInfoCard(title: String, summary: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 18.dp, vertical = 17.dp)) {
+            Text(title, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            Spacer(Modifier.height(3.dp))
+            Text(summary, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, maxLines = 3, overflow = TextOverflow.Ellipsis)
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt
@@ -1,0 +1,479 @@
+package io.github.xgl34222220.baize.root
+
+import android.content.Intent
+import android.os.IBinder
+import android.os.Process
+import com.topjohnwu.superuser.ipc.RootService
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+import java.util.UUID
+
+/**
+ * Transaction coordinator for smart-clean resume support.
+ *
+ * It never discovers deletion targets. It only backs up the immutable cache/profile snapshots,
+ * consumes the result of an already-authorized clean call, removes terminal candidates from the
+ * remaining snapshot, and restores a snapshot if the client or Root process dies mid-run.
+ */
+class CleanPlanResumeRootService : RootService() {
+    private val binder = object : ICleanPlanResumeService.Stub() {
+        override fun ping(): String {
+            pruneTransactions()
+            return JSONObject()
+                .put("uid", Process.myUid())
+                .put("root", Process.myUid() == 0)
+                .put("engine", "clean-plan-resume-v1")
+                .put("transactions", transactionRoot().listFiles()?.count { it.isDirectory } ?: 0)
+                .toString()
+        }
+
+        override fun begin(
+            planId: String?,
+            cacheSnapshotId: String?,
+            safeSnapshotId: String?,
+            cacheCount: Int,
+            safeCount: Int
+        ): String = guarded(planId) { id, directory ->
+            pruneTransactions()
+            val state = readState(directory) ?: newState(
+                id = id,
+                cacheSnapshotId = cacheSnapshotId.orEmpty(),
+                safeSnapshotId = safeSnapshotId.orEmpty(),
+                cacheCount = cacheCount,
+                safeCount = safeCount
+            )
+            recoverFiles(state, directory)
+            state.put("cacheSnapshotId", cacheSnapshotId.orEmpty())
+                .put("safeSnapshotId", safeSnapshotId.orEmpty())
+                .put("cacheRemaining", cacheCount.coerceAtLeast(0))
+                .put("safeRemaining", safeCount.coerceAtLeast(0))
+                .put("cacheComplete", cacheSnapshotId.isNullOrBlank() || cacheCount <= 0)
+                .put("safeComplete", safeSnapshotId.isNullOrBlank() || safeCount <= 0)
+                .put("runCount", state.optInt("runCount", 0) + 1)
+                .put("runStartedAt", System.currentTimeMillis())
+                .put("status", "running")
+                .put("updatedAt", System.currentTimeMillis())
+            backupCurrentSnapshots(state, directory)
+            writeState(directory, state)
+            response(state)
+        }
+
+        override fun checkpointCache(planId: String?, resultJson: String?): String = guarded(planId) { _, directory ->
+            val state = readState(directory) ?: return@guarded error("transaction_missing", "清理事务不存在")
+            val result = parseJson(resultJson)
+            accumulate(state, result)
+            restoreCacheIfMissing(state, directory)
+
+            val terminal = cacheTerminalPaths(state)
+            val hasFailure = result.has("error") || result.optInt("failures", 0) > 0
+            val interrupted = result.optBoolean("cancelled") || result.optBoolean("timedOut")
+            val cleanFinished = result.optBoolean("success") && !hasFailure && !interrupted
+
+            val remaining = if (cleanFinished) {
+                deleteCacheSnapshot()
+                clearCacheBackup(directory)
+                0
+            } else {
+                filterCacheSnapshot(terminal)
+            }
+            state.put("cacheRemaining", remaining)
+                .put("cacheComplete", remaining <= 0)
+                .put("cacheLastError", result.optString("message", result.optString("error")))
+                .put("status", if (remaining > 0 || state.optInt("safeRemaining", 0) > 0) "partial" else "complete")
+                .put("updatedAt", System.currentTimeMillis())
+            if (remaining > 0) backupCacheSnapshot(directory) else clearCacheBackup(directory)
+            writeState(directory, state)
+            response(state)
+        }
+
+        override fun checkpointSafe(planId: String?, resultJson: String?): String = guarded(planId) { _, directory ->
+            val state = readState(directory) ?: return@guarded error("transaction_missing", "清理事务不存在")
+            val result = parseJson(resultJson)
+            accumulate(state, result)
+            restoreSafeIfMissing(state, directory)
+
+            val remaining = filterSafeSnapshot(state, result, directory)
+            state.put("safeRemaining", remaining)
+                .put("safeComplete", remaining <= 0)
+                .put("safeLastError", result.optString("message", result.optString("error")))
+                .put("status", if (remaining > 0 || state.optInt("cacheRemaining", 0) > 0) "partial" else "complete")
+                .put("updatedAt", System.currentTimeMillis())
+            if (remaining > 0) backupSafeSnapshot(state, directory) else clearSafeBackup(directory)
+            writeState(directory, state)
+            response(state)
+        }
+
+        override fun recover(planId: String?): String = guarded(planId) { _, directory ->
+            val state = readState(directory) ?: return@guarded error("transaction_missing", "没有需要恢复的清理事务")
+            recoverFiles(state, directory)
+            val cacheRemaining = countCacheCandidates().takeIf { !state.optBoolean("cacheComplete") } ?: 0
+            val safeRemaining = countSafeCandidates(state.optString("safeSnapshotId"))
+                .takeIf { !state.optBoolean("safeComplete") } ?: 0
+            state.put("cacheRemaining", cacheRemaining)
+                .put("safeRemaining", safeRemaining)
+                .put("cacheComplete", cacheRemaining <= 0)
+                .put("safeComplete", safeRemaining <= 0)
+                .put("status", if (cacheRemaining + safeRemaining > 0) "partial" else "complete")
+                .put("recoveredAt", System.currentTimeMillis())
+                .put("updatedAt", System.currentTimeMillis())
+            writeState(directory, state)
+            JSONObject(response(state)).put("recovered", true).toString()
+        }
+
+        override fun finish(planId: String?): String = guarded(planId) { _, directory ->
+            val removed = deleteTree(directory)
+            JSONObject().put("success", removed).put("finished", true).toString()
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+
+    private inline fun guarded(
+        rawPlanId: String?,
+        block: (String, File) -> String
+    ): String {
+        val id = validPlanId(rawPlanId.orEmpty())
+            ?: return error("invalid_plan", "清理计划编号无效")
+        return runCatching { block(id, File(transactionRoot(), id).apply { mkdirs() }) }
+            .getOrElse { error("resume_transaction_failed", it.message ?: it.javaClass.simpleName) }
+    }
+
+    private fun newState(
+        id: String,
+        cacheSnapshotId: String,
+        safeSnapshotId: String,
+        cacheCount: Int,
+        safeCount: Int
+    ): JSONObject = JSONObject()
+        .put("version", TRANSACTION_VERSION)
+        .put("planId", id)
+        .put("createdAt", System.currentTimeMillis())
+        .put("updatedAt", System.currentTimeMillis())
+        .put("status", "ready")
+        .put("runCount", 0)
+        .put("cacheSnapshotId", cacheSnapshotId)
+        .put("safeSnapshotId", safeSnapshotId)
+        .put("cacheOriginal", cacheCount.coerceAtLeast(0))
+        .put("safeOriginal", safeCount.coerceAtLeast(0))
+        .put("cacheRemaining", cacheCount.coerceAtLeast(0))
+        .put("safeRemaining", safeCount.coerceAtLeast(0))
+        .put("cacheComplete", cacheSnapshotId.isBlank() || cacheCount <= 0)
+        .put("safeComplete", safeSnapshotId.isBlank() || safeCount <= 0)
+        .put("deletedBytes", 0L)
+        .put("deletedFiles", 0L)
+        .put("deletedDirectories", 0L)
+        .put("cleanedCandidates", 0)
+        .put("failures", 0)
+
+    private fun response(state: JSONObject): String = JSONObject(state.toString())
+        .put("success", true)
+        .put("remainingCandidates", state.optInt("cacheRemaining") + state.optInt("safeRemaining"))
+        .put("resumable", state.optInt("cacheRemaining") + state.optInt("safeRemaining") > 0)
+        .toString()
+
+    private fun accumulate(state: JSONObject, result: JSONObject) {
+        state.put("deletedBytes", state.optLong("deletedBytes") + result.optLong("deletedBytes"))
+            .put("deletedFiles", state.optLong("deletedFiles") + result.optLong("deletedFiles"))
+            .put("deletedDirectories", state.optLong("deletedDirectories") + result.optLong("deletedDirectories"))
+            .put("cleanedCandidates", state.optInt("cleanedCandidates") + result.optInt("cleanedCandidates"))
+            .put("failures", state.optInt("failures") + result.optInt("failures"))
+    }
+
+    private fun backupCurrentSnapshots(state: JSONObject, directory: File) {
+        if (!state.optBoolean("cacheComplete")) backupCacheSnapshot(directory)
+        if (!state.optBoolean("safeComplete")) backupSafeSnapshot(state, directory)
+    }
+
+    private fun recoverFiles(state: JSONObject, directory: File) {
+        if (!state.optBoolean("cacheComplete")) restoreCacheIfMissing(state, directory)
+        if (!state.optBoolean("safeComplete")) restoreSafeIfMissing(state, directory)
+    }
+
+    private fun backupCacheSnapshot(directory: File) {
+        val backup = File(directory, "cache").apply { mkdirs() }
+        CACHE_FILES.forEach { name ->
+            val source = File(RootPaths.STATE_DIR, name)
+            if (source.isFile) atomicCopy(source, File(backup, name.substringAfterLast('/')))
+        }
+    }
+
+    private fun restoreCacheIfMissing(state: JSONObject, directory: File) {
+        if (state.optString("cacheSnapshotId").isBlank()) return
+        val backup = File(directory, "cache")
+        CACHE_FILES.forEach { name ->
+            val target = File(RootPaths.STATE_DIR, name)
+            val source = File(backup, name.substringAfterLast('/'))
+            if (!target.isFile && source.isFile) atomicCopy(source, target)
+        }
+    }
+
+    private fun clearCacheBackup(directory: File) {
+        deleteTree(File(directory, "cache"))
+    }
+
+    private fun backupSafeSnapshot(state: JSONObject, directory: File) {
+        val source = safeSnapshotFile(state.optString("safeSnapshotId")) ?: return
+        if (source.isFile) atomicCopy(source, File(directory, "safe.json"))
+    }
+
+    private fun restoreSafeIfMissing(state: JSONObject, directory: File) {
+        val target = safeSnapshotFile(state.optString("safeSnapshotId")) ?: return
+        val backup = File(directory, "safe.json")
+        if (!target.isFile && backup.isFile) atomicCopy(backup, target)
+    }
+
+    private fun clearSafeBackup(directory: File) {
+        File(directory, "safe.json").delete()
+    }
+
+    private fun cacheTerminalPaths(state: JSONObject): Set<String> {
+        val report = File(RootPaths.STATE_DIR, "reports/latest.tsv")
+        val runStarted = state.optLong("runStartedAt", 0L)
+        if (!report.isFile || report.lastModified() + REPORT_CLOCK_SLOP_MS < runStarted) return emptySet()
+        val terminal = LinkedHashSet<String>()
+        val failed = LinkedHashSet<String>()
+        report.useLines { lines ->
+            lines.drop(1).forEach { line ->
+                val fields = line.split('\t')
+                if (fields.size < 6) return@forEach
+                val action = fields[0].trim().lowercase()
+                val path = fields[5].trim()
+                if (!path.startsWith("/")) return@forEach
+                when (action) {
+                    "failed", "partial" -> failed += path
+                    "cleaned", "protected", "skipped" -> terminal += path
+                }
+            }
+        }
+        terminal.removeAll(failed)
+        return terminal
+    }
+
+    private fun filterCacheSnapshot(terminal: Set<String>): Int {
+        val targetFile = File(RootPaths.STATE_DIR, "cache_scan.targets")
+        val itemFile = File(RootPaths.STATE_DIR, "cache_scan.items.tsv")
+        val stateFile = File(RootPaths.STATE_DIR, "cache_scan.env")
+        if (!targetFile.isFile || !itemFile.isFile || !stateFile.isFile) return 0
+
+        if (terminal.isNotEmpty()) {
+            val remainingTargets = targetFile.readLines().filter { it.isNotBlank() && it !in terminal }
+            atomicWrite(targetFile, remainingTargets.joinToString("\n", postfix = if (remainingTargets.isEmpty()) "" else "\n"))
+
+            val lines = itemFile.readLines()
+            val header = lines.firstOrNull().orEmpty()
+            val remainingItems = lines.drop(1).filter { line ->
+                val fields = line.split('\t')
+                fields.size < 6 || fields[5].trim() !in terminal
+            }
+            atomicWrite(itemFile, buildString {
+                if (header.isNotBlank()) append(header).append('\n')
+                remainingItems.forEach { append(it).append('\n') }
+            })
+        }
+
+        val rows = itemFile.readLines().drop(1).filter { it.isNotBlank() }
+        val targets = targetFile.readLines().count { it.isNotBlank() }
+        var files = 0L
+        var bytes = 0L
+        rows.forEach { row ->
+            val fields = row.split('\t')
+            files += fields.getOrNull(2)?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+            bytes += fields.getOrNull(3)?.toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+        }
+        val env = readEnv(stateFile)
+        env["targets_sha"] = sha256(targetFile)
+        env["items"] = rows.size.toString()
+        env["targets"] = targets.toString()
+        env["files"] = files.toString()
+        env["bytes"] = bytes.toString()
+        atomicWrite(stateFile, env.entries.joinToString("\n", postfix = "\n") { "${it.key}=${it.value}" })
+        if (rows.isEmpty() || targets <= 0) {
+            deleteCacheSnapshot()
+            return 0
+        }
+        return rows.size
+    }
+
+    private fun filterSafeSnapshot(state: JSONObject, result: JSONObject, directory: File): Int {
+        val snapshotId = state.optString("safeSnapshotId")
+        val file = safeSnapshotFile(snapshotId) ?: return 0
+        if (!file.isFile) {
+            restoreSafeIfMissing(state, directory)
+            if (!file.isFile) return 0
+        }
+        val snapshot = parseJson(file.readText())
+        val items = snapshot.optJSONArray("items") ?: JSONArray()
+        val details = result.optJSONArray("details") ?: JSONArray()
+        val terminalIds = LinkedHashSet<String>()
+        val terminalPaths = LinkedHashSet<String>()
+        var hasRetryable = result.has("error") || result.optBoolean("cancelled") || result.optBoolean("timedOut")
+        for (index in 0 until details.length()) {
+            val detail = details.optJSONObject(index) ?: continue
+            when (detail.optString("action").lowercase()) {
+                "cleaned", "protected", "skipped" -> {
+                    detail.optString("id").takeIf { it.isNotBlank() }?.let { terminalIds += it }
+                    detail.optString("path").takeIf { it.isNotBlank() }?.let { terminalPaths += it }
+                }
+                "partial", "failed" -> hasRetryable = true
+            }
+        }
+
+        val remaining = JSONArray()
+        for (index in 0 until items.length()) {
+            val item = items.optJSONObject(index) ?: continue
+            if (item.optString("id") !in terminalIds && item.optString("path") !in terminalPaths) {
+                remaining.put(item)
+            }
+        }
+
+        if (!hasRetryable && result.optBoolean("success") && remaining.length() == 0) {
+            file.delete()
+            return 0
+        }
+        if (!hasRetryable && result.optBoolean("success") && details.length() == 0) {
+            file.delete()
+            return 0
+        }
+        if (remaining.length() <= 0) {
+            file.delete()
+            return 0
+        }
+        snapshot.put("items", remaining)
+            .put("resumeUpdatedAt", System.currentTimeMillis())
+            .put("remainingCandidates", remaining.length())
+        atomicWrite(file, snapshot.toString())
+        return remaining.length()
+    }
+
+    private fun countCacheCandidates(): Int {
+        val file = File(RootPaths.STATE_DIR, "cache_scan.items.tsv")
+        if (!file.isFile) return 0
+        return file.useLines { lines -> lines.drop(1).count { it.isNotBlank() } }
+    }
+
+    private fun countSafeCandidates(snapshotId: String): Int {
+        val file = safeSnapshotFile(snapshotId) ?: return 0
+        if (!file.isFile) return 0
+        return parseJson(file.readText()).optJSONArray("items")?.length() ?: 0
+    }
+
+    private fun deleteCacheSnapshot() {
+        CACHE_FILES.forEach { File(RootPaths.STATE_DIR, it).delete() }
+    }
+
+    private fun safeSnapshotFile(snapshotId: String): File? {
+        val id = runCatching { UUID.fromString(snapshotId).toString() }.getOrNull() ?: return null
+        return File(RootPaths.STATE_DIR, "profile-snapshots/$id.json")
+    }
+
+    private fun transactionRoot(): File = File(RootPaths.STATE_DIR, "clean-plan-transactions").apply { mkdirs() }
+
+    private fun stateFile(directory: File): File = File(directory, "state.json")
+
+    private fun readState(directory: File): JSONObject? {
+        val file = stateFile(directory)
+        if (!file.isFile) return null
+        val state = runCatching { JSONObject(file.readText()) }.getOrNull() ?: return null
+        if (state.optInt("version") != TRANSACTION_VERSION) return null
+        return state
+    }
+
+    private fun writeState(directory: File, state: JSONObject) {
+        atomicWrite(stateFile(directory), state.toString())
+    }
+
+    private fun readEnv(file: File): LinkedHashMap<String, String> {
+        val result = LinkedHashMap<String, String>()
+        if (!file.isFile) return result
+        file.forEachLine { line ->
+            val index = line.indexOf('=')
+            if (index > 0) result[line.substring(0, index)] = line.substring(index + 1)
+        }
+        return result
+    }
+
+    private fun atomicCopy(source: File, target: File): Boolean = runCatching {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        source.copyTo(temporary, overwrite = true)
+        if (!temporary.renameTo(target)) {
+            temporary.copyTo(target, overwrite = true)
+            temporary.delete()
+        }
+        restrict(target)
+        true
+    }.getOrDefault(false)
+
+    private fun atomicWrite(target: File, content: String): Boolean = runCatching {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        temporary.writeText(content)
+        if (!temporary.renameTo(target)) {
+            temporary.copyTo(target, overwrite = true)
+            temporary.delete()
+        }
+        restrict(target)
+        true
+    }.getOrDefault(false)
+
+    private fun restrict(file: File) {
+        file.setReadable(false, false)
+        file.setWritable(false, false)
+        file.setExecutable(false, false)
+        file.setReadable(true, true)
+        file.setWritable(true, true)
+    }
+
+    private fun deleteTree(file: File): Boolean = runCatching {
+        if (!file.exists()) return@runCatching true
+        file.walkBottomUp().forEach { it.delete() }
+        !file.exists()
+    }.getOrDefault(false)
+
+    private fun pruneTransactions() {
+        val now = System.currentTimeMillis()
+        transactionRoot().listFiles()?.filter { it.isDirectory }?.forEach { directory ->
+            val state = readState(directory)
+            val updated = state?.optLong("updatedAt", directory.lastModified()) ?: directory.lastModified()
+            if (updated <= 0L || now - updated > TRANSACTION_TTL_MS) deleteTree(directory)
+        }
+    }
+
+    private fun validPlanId(raw: String): String? = runCatching { UUID.fromString(raw).toString() }.getOrNull()
+
+    private fun parseJson(raw: String?): JSONObject = runCatching { JSONObject(raw.orEmpty()) }.getOrDefault(JSONObject())
+
+    private fun sha256(file: File): String {
+        if (!file.isFile) return "missing"
+        return runCatching {
+            val digest = MessageDigest.getInstance("SHA-256")
+            file.inputStream().use { input ->
+                val buffer = ByteArray(64 * 1024)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read <= 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            digest.digest().joinToString("") { "%02x".format(it) }
+        }.getOrDefault("missing")
+    }
+
+    private fun error(code: String, message: String): String = JSONObject()
+        .put("error", code)
+        .put("message", message)
+        .toString()
+
+    companion object {
+        private const val TRANSACTION_VERSION = 1
+        private const val TRANSACTION_TTL_MS = 2L * 60L * 60_000L
+        private const val REPORT_CLOCK_SLOP_MS = 5_000L
+        private val CACHE_FILES = listOf(
+            "cache_scan.env",
+            "cache_scan.targets",
+            "cache_scan.items.tsv"
+        )
+    }
+}

--- a/v2/tests/test-clean-plan-resume.py
+++ b/v2/tests/test-clean-plan-resume.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
+ACTIVITY = (APP / "ResumableSmartScanActivity.kt").read_text(encoding="utf-8")
+SERVICE = (APP / "root/CleanPlanResumeRootService.kt").read_text(encoding="utf-8")
+MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
+AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanPlanResumeService.aidl").read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+clean_start = ACTIVITY.index("private fun cleanSnapshots()")
+clean_end = ACTIVITY.index("private fun stopTask()", clean_start)
+clean_path = ACTIVITY[clean_start:clean_end]
+require("scanCandidates(" not in clean_path, "resume path must not start cache discovery")
+require("scanSafe(" not in clean_path, "resume path must not start safe discovery")
+require("transactions.begin(" in clean_path, "cleaning must begin a transaction")
+require("checkpointCache" in clean_path, "cache stage must checkpoint")
+require("checkpointSafe" in clean_path, "safe stage must checkpoint")
+require("transactions.recover(" in clean_path, "failure path must recover transaction state")
+require("继续清理" in ACTIVITY, "resume action is not visible to the user")
+require("smart_clean_plan_v2" in ACTIVITY, "resume plan schema is missing")
+require("LEGACY_PLAN_KEY" in ACTIVITY, "v1 clean plans must migrate")
+
+clear_start = ACTIVITY.index("private fun clearLocalPlan()")
+clear_end = ACTIVITY.index("private fun resetPlanFields()", clear_start)
+clear_path = ACTIVITY[clear_start:clear_end]
+require("resetPlanFields()" not in clear_path, "completed cleanup must preserve final metrics")
+require('cacheSummary = "应用缓存剩余 $cacheCount 项"' in ACTIVITY,
+        "transaction checkpoints must refresh cache remaining summary")
+require('safeSummary = "安全项目剩余 $safeCount 项"' in ACTIVITY,
+        "transaction checkpoints must refresh safe remaining summary")
+
+for marker in (
+    "clean-plan-transactions",
+    "backupCacheSnapshot",
+    "restoreCacheIfMissing",
+    "filterCacheSnapshot",
+    "filterSafeSnapshot",
+    "atomicWrite",
+    "remainingCandidates",
+):
+    require(marker in SERVICE, f"missing transaction primitive: {marker}")
+
+require('JSONObject(response(state)).put("recovered", true)' in SERVICE,
+        "recover must return the transaction payload with its recovered flag")
+require('android:name=".ResumableSmartScanActivity"' in MANIFEST, "resume activity is not registered")
+require('android:targetActivity=".ResumableSmartScanActivity"' in MANIFEST, "smart scan alias does not use resume flow")
+require('android:name=".root.CleanPlanResumeRootService"' in MANIFEST, "resume Root service is not registered")
+
+for method in ("begin", "checkpointCache", "checkpointSafe", "recover", "finish"):
+    require(method in AIDL, f"resume binder method missing: {method}")
+
+print("clean plan resume contract: ok")


### PR DESCRIPTION
## 第二阶段：可恢复清理事务

- 清理前为缓存快照和安全项目快照建立 Root 事务检查点。
- 清理停止、超时、Binder 异常、App 被回收或 Root 服务重启后，恢复剩余快照，不重新扫描。
- 根据真实清理报告裁剪缓存目标；安全项目根据逐候选明细移除已完成和终止跳过项目。
- 部分删除、删除失败和未执行项目继续保留，页面按钮切换为“继续清理”。
- 记录累计释放空间、完成候选、执行次数和失败记录；全部完成后仍保留本次结果展示。
- 自动迁移第一阶段 `smart_clean_plan_v1` 计划。
- 新增静态回归测试，禁止继续清理路径调用扫描接口，并约束完成态统计不得被清零。

## 验证结果

- Android Release 与 Debug Kotlin 编译：通过
- Lint：通过
- Macrobenchmark 构建：通过
- ARM64 原生扫描器：通过
- Root 脚本与回归测试：通过
- 模块封包、PR 签名和正式产物结构校验：通过

完整验证运行：BaiZe v2.4.0 Verify and Release #26。