### PR TITLE
feat(clean): add truthful classified result model

### DIFF
--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt
@@ -106,7 +106,16 @@ class ResumableSmartScanActivity : ComponentActivity() {
     private var deletedBytes = 0L
     private var deletedFiles = 0L
     private var deletedDirectories = 0L
+    private var processedCandidates = 0
     private var cleanedCandidates = 0
+    private var changedCandidates = 0
+    private var protectedCandidates = 0
+    private var partialCandidates = 0
+    private var failedCandidates = 0
+    private var classifiedDeletedBytes = 0L
+    private var unattributedDeletedBytes = 0L
+    private var categoryStats = JSONObject()
+    private var riskStats = JSONObject()
     private var cumulativeFailures = 0
     private var resumable = false
     private var restoredPlanNeedsValidation = false
@@ -441,8 +450,12 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     } else "清理计划执行完成")
                     append(" · ${elapsed}ms")
                     append("\n累计释放 ${Formatter.formatFileSize(this@ResumableSmartScanActivity, deletedBytes)}")
-                    append(" · 已完成 $cleanedCandidates 项 · 剩余 $remaining 项")
-                    if (cumulativeFailures > 0) append(" · 失败记录 $cumulativeFailures")
+                    append(" · 已处理 $processedCandidates 项 · 实际清理 $cleanedCandidates 项 · 剩余 $remaining 项")
+                    if (changedCandidates > 0) append(" · 已变化 $changedCandidates")
+                    if (protectedCandidates > 0) append(" · 受保护 $protectedCandidates")
+                    if (partialCandidates > 0) append(" · 部分 $partialCandidates")
+                    if (failedCandidates > 0) append(" · 失败候选 $failedCandidates")
+                    if (cumulativeFailures > 0) append(" · 删除错误 $cumulativeFailures")
                     if (remaining > 0) append("\n可直接点击继续清理，不会重新扫描或重复处理已完成项目")
                 }
                 preferences.edit()
@@ -467,7 +480,16 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     resumable = remaining > 0,
                     runCount = runCount,
                     deletedBytes = deletedBytes,
+                    processedCandidates = processedCandidates,
                     cleanedCandidates = cleanedCandidates,
+                    changedCandidates = changedCandidates,
+                    protectedCandidates = protectedCandidates,
+                    partialCandidates = partialCandidates,
+                    failedCandidates = failedCandidates,
+                    classifiedDeletedBytes = classifiedDeletedBytes,
+                    unattributedDeletedBytes = unattributedDeletedBytes,
+                    categoryStats = categoryStats.toString(),
+                    riskStats = riskStats.toString(),
                     failures = cumulativeFailures,
                     progressCurrent = (originalCacheCount + originalSafeCount - remaining).coerceAtLeast(0),
                     progressTotal = (originalCacheCount + originalSafeCount).coerceAtLeast(1),
@@ -591,8 +613,17 @@ class ResumableSmartScanActivity : ComponentActivity() {
         deletedBytes = plan.optLong("deletedBytes", 0L).coerceAtLeast(0L)
         deletedFiles = plan.optLong("deletedFiles", 0L).coerceAtLeast(0L)
         deletedDirectories = plan.optLong("deletedDirectories", 0L).coerceAtLeast(0L)
+        processedCandidates = plan.optInt("processedCandidates", 0).coerceAtLeast(0)
         cleanedCandidates = plan.optInt("cleanedCandidates", 0).coerceAtLeast(0)
-        cumulativeFailures = plan.optInt("failures", 0).coerceAtLeast(0)
+        changedCandidates = plan.optInt("changedCandidates", 0).coerceAtLeast(0)
+        protectedCandidates = plan.optInt("protectedCandidates", 0).coerceAtLeast(0)
+        partialCandidates = plan.optInt("partialCandidates", 0).coerceAtLeast(0)
+        failedCandidates = plan.optInt("failedCandidates", 0).coerceAtLeast(0)
+        classifiedDeletedBytes = plan.optLong("classifiedDeletedBytes", 0L).coerceAtLeast(0L)
+        unattributedDeletedBytes = plan.optLong("unattributedDeletedBytes", 0L).coerceAtLeast(0L)
+        categoryStats = plan.optJSONObject("categoryStats") ?: JSONObject()
+        riskStats = plan.optJSONObject("riskStats") ?: JSONObject()
+        cumulativeFailures = plan.optInt("deleteErrors", plan.optInt("failures", 0)).coerceAtLeast(0)
         resumable = plan.optBoolean("resumable", runCount > 0)
         val total = cacheCount + safeCount
         if (cleanPlanId.isBlank() || total <= 0 || (cacheSnapshotId.isBlank() && safeSnapshotId.isBlank())) {
@@ -609,7 +640,16 @@ class ResumableSmartScanActivity : ComponentActivity() {
             resumable = resumable,
             runCount = runCount,
             deletedBytes = deletedBytes,
+            processedCandidates = processedCandidates,
             cleanedCandidates = cleanedCandidates,
+            changedCandidates = changedCandidates,
+            protectedCandidates = protectedCandidates,
+            partialCandidates = partialCandidates,
+            failedCandidates = failedCandidates,
+            classifiedDeletedBytes = classifiedDeletedBytes,
+            unattributedDeletedBytes = unattributedDeletedBytes,
+            categoryStats = categoryStats.toString(),
+            riskStats = riskStats.toString(),
             failures = cumulativeFailures,
             cacheSummary = plan.optString("cacheSummary", "剩余 $cacheCount 项"),
             safeSummary = plan.optString("safeSummary", "剩余 $safeCount 项")
@@ -693,15 +733,33 @@ class ResumableSmartScanActivity : ComponentActivity() {
         deletedBytes = json.optLong("deletedBytes", deletedBytes).coerceAtLeast(0L)
         deletedFiles = json.optLong("deletedFiles", deletedFiles).coerceAtLeast(0L)
         deletedDirectories = json.optLong("deletedDirectories", deletedDirectories).coerceAtLeast(0L)
+        processedCandidates = json.optInt("processedCandidates", processedCandidates).coerceAtLeast(0)
         cleanedCandidates = json.optInt("cleanedCandidates", cleanedCandidates).coerceAtLeast(0)
-        cumulativeFailures = json.optInt("failures", cumulativeFailures).coerceAtLeast(0)
+        changedCandidates = json.optInt("changedCandidates", changedCandidates).coerceAtLeast(0)
+        protectedCandidates = json.optInt("protectedCandidates", protectedCandidates).coerceAtLeast(0)
+        partialCandidates = json.optInt("partialCandidates", partialCandidates).coerceAtLeast(0)
+        failedCandidates = json.optInt("failedCandidates", failedCandidates).coerceAtLeast(0)
+        classifiedDeletedBytes = json.optLong("classifiedDeletedBytes", classifiedDeletedBytes).coerceAtLeast(0L)
+        unattributedDeletedBytes = json.optLong("unattributedDeletedBytes", unattributedDeletedBytes).coerceAtLeast(0L)
+        categoryStats = json.optJSONObject("categoryStats") ?: categoryStats
+        riskStats = json.optJSONObject("riskStats") ?: riskStats
+        cumulativeFailures = json.optInt("deleteErrors", json.optInt("failures", cumulativeFailures)).coerceAtLeast(0)
         resumable = json.optBoolean("resumable", cacheCount + safeCount > 0 && runCount > 0)
         screenState = screenState.copy(
             totalSafe = cacheCount + safeCount,
             resumable = resumable,
             runCount = runCount,
             deletedBytes = deletedBytes,
+            processedCandidates = processedCandidates,
             cleanedCandidates = cleanedCandidates,
+            changedCandidates = changedCandidates,
+            protectedCandidates = protectedCandidates,
+            partialCandidates = partialCandidates,
+            failedCandidates = failedCandidates,
+            classifiedDeletedBytes = classifiedDeletedBytes,
+            unattributedDeletedBytes = unattributedDeletedBytes,
+            categoryStats = categoryStats.toString(),
+            riskStats = riskStats.toString(),
             failures = cumulativeFailures,
             cacheSummary = "应用缓存剩余 $cacheCount 项",
             safeSummary = "安全项目剩余 $safeCount 项"
@@ -726,7 +784,17 @@ class ResumableSmartScanActivity : ComponentActivity() {
             .put("deletedBytes", deletedBytes)
             .put("deletedFiles", deletedFiles)
             .put("deletedDirectories", deletedDirectories)
+            .put("processedCandidates", processedCandidates)
             .put("cleanedCandidates", cleanedCandidates)
+            .put("changedCandidates", changedCandidates)
+            .put("protectedCandidates", protectedCandidates)
+            .put("partialCandidates", partialCandidates)
+            .put("failedCandidates", failedCandidates)
+            .put("classifiedDeletedBytes", classifiedDeletedBytes)
+            .put("unattributedDeletedBytes", unattributedDeletedBytes)
+            .put("categoryStats", categoryStats)
+            .put("riskStats", riskStats)
+            .put("deleteErrors", cumulativeFailures)
             .put("failures", cumulativeFailures)
             .put("resumable", resumable)
             .put("cacheSummary", screenState.cacheSummary)
@@ -790,7 +858,16 @@ class ResumableSmartScanActivity : ComponentActivity() {
         deletedBytes = 0L
         deletedFiles = 0L
         deletedDirectories = 0L
+        processedCandidates = 0
         cleanedCandidates = 0
+        changedCandidates = 0
+        protectedCandidates = 0
+        partialCandidates = 0
+        failedCandidates = 0
+        classifiedDeletedBytes = 0L
+        unattributedDeletedBytes = 0L
+        categoryStats = JSONObject()
+        riskStats = JSONObject()
         cumulativeFailures = 0
         resumable = false
         restoredPlanNeedsValidation = false
@@ -829,7 +906,16 @@ private data class ResumeSmartUiState(
     val resumable: Boolean = false,
     val runCount: Int = 0,
     val deletedBytes: Long = 0L,
+    val processedCandidates: Int = 0,
     val cleanedCandidates: Int = 0,
+    val changedCandidates: Int = 0,
+    val protectedCandidates: Int = 0,
+    val partialCandidates: Int = 0,
+    val failedCandidates: Int = 0,
+    val classifiedDeletedBytes: Long = 0L,
+    val unattributedDeletedBytes: Long = 0L,
+    val categoryStats: String = "{}",
+    val riskStats: String = "{}",
     val failures: Int = 0,
     val progressCurrent: Int = 0,
     val progressTotal: Int = 0,
@@ -944,9 +1030,20 @@ private fun ResumeSmartScreen(
                     Text("TRANSACTION", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
                     Text("清理事务", fontSize = 26.sp, fontWeight = FontWeight.Black)
                     Text(
-                        "执行 ${state.runCount} 次 · 累计释放 ${Formatter.formatFileSize(context, state.deletedBytes)} · 完成 ${state.cleanedCandidates} 项",
+                        "执行 ${state.runCount} 次 · 授权 ${state.totalSafe + state.processedCandidates} 项 · 已处理 ${state.processedCandidates} 项 · 实际清理 ${state.cleanedCandidates} 项",
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
+                    Text(
+                        "释放 ${Formatter.formatFileSize(context, state.deletedBytes)} · 变化 ${state.changedCandidates} · 保护 ${state.protectedCandidates} · 部分 ${state.partialCandidates} · 失败 ${state.failedCandidates}",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    if (state.unattributedDeletedBytes > 0L) {
+                        Text(
+                            "其中 ${Formatter.formatFileSize(context, state.unattributedDeletedBytes)} 来自引擎总计，缺少逐项归属但仍计入真实释放量",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 12.sp
+                        )
+                    }
                     if (state.failures > 0) {
                         Text("累计失败记录 ${state.failures} 项，失败项目会保留在剩余计划中", color = MaterialTheme.colorScheme.error)
                     }
@@ -954,6 +1051,8 @@ private fun ResumeSmartScreen(
             }
             item { ResumeInfoCard("应用缓存", state.cacheSummary) }
             item { ResumeInfoCard("安全项目", state.safeSummary) }
+            item { ResumeInfoCard("按类别统计", formatMetricBuckets(state.categoryStats)) }
+            item { ResumeInfoCard("按风险统计", formatMetricBuckets(state.riskStats)) }
             item {
                 Card(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding(),
@@ -986,4 +1085,41 @@ private fun ResumeInfoCard(title: String, summary: String) {
             Text(summary, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, maxLines = 3, overflow = TextOverflow.Ellipsis)
         }
     }
+}
+
+
+private fun formatMetricBuckets(raw: String): String {
+    val root = runCatching { JSONObject(raw) }.getOrDefault(JSONObject())
+    if (root.length() == 0) return "尚无已处理项目"
+    val labels = mapOf(
+        "cache" to "应用缓存",
+        "empty" to "空项目",
+        "rules" to "规则垃圾",
+        "fragment" to "残留碎片",
+        "other" to "其他",
+        "low" to "低风险",
+        "medium" to "中风险",
+        "high" to "高风险",
+        "critical" to "关键风险"
+    )
+    val lines = ArrayList<String>()
+    val keys = root.keys()
+    while (keys.hasNext()) {
+        val key = keys.next()
+        val bucket = root.optJSONObject(key) ?: continue
+        lines += buildString {
+            append(labels[key] ?: key)
+            append("：处理 ").append(bucket.optInt("processed"))
+            append(" · 清理 ").append(bucket.optInt("cleaned"))
+            val changed = bucket.optInt("changed")
+            val protected = bucket.optInt("protected")
+            val partial = bucket.optInt("partial")
+            val failed = bucket.optInt("failed")
+            if (changed > 0) append(" · 变化 ").append(changed)
+            if (protected > 0) append(" · 保护 ").append(protected)
+            if (partial > 0) append(" · 部分 ").append(partial)
+            if (failed > 0) append(" · 失败 ").append(failed)
+        }
+    }
+    return lines.joinToString("\n")
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt
@@ -24,7 +24,7 @@ class CleanPlanResumeRootService : RootService() {
             return JSONObject()
                 .put("uid", Process.myUid())
                 .put("root", Process.myUid() == 0)
-                .put("engine", "clean-plan-resume-v1")
+                .put("engine", "clean-plan-resume-v2-result-model")
                 .put("transactions", transactionRoot().listFiles()?.count { it.isDirectory } ?: 0)
                 .toString()
         }
@@ -63,13 +63,14 @@ class CleanPlanResumeRootService : RootService() {
         override fun checkpointCache(planId: String?, resultJson: String?): String = guarded(planId) { _, directory ->
             val state = readState(directory) ?: return@guarded error("transaction_missing", "清理事务不存在")
             val result = parseJson(resultJson)
-            accumulate(state, result)
+            accumulateCounters(state, result)
             restoreCacheIfMissing(state, directory)
 
             val terminal = cacheTerminalPaths(state)
             val hasFailure = result.has("error") || result.optInt("failures", 0) > 0
             val interrupted = result.optBoolean("cancelled") || result.optBoolean("timedOut")
             val cleanFinished = result.optBoolean("success") && !hasFailure && !interrupted
+            captureCacheOutcomes(state, result, directory, terminal, cleanFinished)
 
             val remaining = if (cleanFinished) {
                 deleteCacheSnapshot()
@@ -91,10 +92,11 @@ class CleanPlanResumeRootService : RootService() {
         override fun checkpointSafe(planId: String?, resultJson: String?): String = guarded(planId) { _, directory ->
             val state = readState(directory) ?: return@guarded error("transaction_missing", "清理事务不存在")
             val result = parseJson(resultJson)
-            accumulate(state, result)
+            accumulateCounters(state, result)
             restoreSafeIfMissing(state, directory)
 
             val remaining = filterSafeSnapshot(state, result, directory)
+            captureSafeOutcomes(state, result, directory)
             state.put("safeRemaining", remaining)
                 .put("safeComplete", remaining <= 0)
                 .put("safeLastError", result.optString("message", result.optString("error")))
@@ -161,11 +163,26 @@ class CleanPlanResumeRootService : RootService() {
         .put("safeRemaining", safeCount.coerceAtLeast(0))
         .put("cacheComplete", cacheSnapshotId.isBlank() || cacheCount <= 0)
         .put("safeComplete", safeSnapshotId.isBlank() || safeCount <= 0)
+        .put("resultSchema", "clean-result-v1")
+        .put("scannedCandidates", cacheCount.coerceAtLeast(0) + safeCount.coerceAtLeast(0))
+        .put("authorizedCandidates", cacheCount.coerceAtLeast(0) + safeCount.coerceAtLeast(0))
+        .put("processedCandidates", 0)
+        .put("cleanedCandidates", 0)
+        .put("changedCandidates", 0)
+        .put("protectedCandidates", 0)
+        .put("partialCandidates", 0)
+        .put("failedCandidates", 0)
+        .put("skippedCandidates", 0)
         .put("deletedBytes", 0L)
         .put("deletedFiles", 0L)
         .put("deletedDirectories", 0L)
-        .put("cleanedCandidates", 0)
+        .put("classifiedDeletedBytes", 0L)
+        .put("unattributedDeletedBytes", 0L)
+        .put("deleteErrors", 0)
         .put("failures", 0)
+        .put("itemStates", JSONObject())
+        .put("categoryStats", JSONObject())
+        .put("riskStats", JSONObject())
 
     private fun response(state: JSONObject): String = JSONObject(state.toString())
         .put("success", true)
@@ -173,13 +190,268 @@ class CleanPlanResumeRootService : RootService() {
         .put("resumable", state.optInt("cacheRemaining") + state.optInt("safeRemaining") > 0)
         .toString()
 
-    private fun accumulate(state: JSONObject, result: JSONObject) {
+    private data class OutcomeItem(
+        val id: String,
+        val path: String,
+        val category: String,
+        val risk: String,
+        val estimatedBytes: Long = 0L,
+        val estimatedFiles: Long = 0L,
+        val estimatedDirectories: Long = 0L
+    )
+
+    private data class OutcomeDetail(
+        val action: String,
+        val reason: String,
+        val bytes: Long,
+        val files: Long,
+        val directories: Long
+    )
+
+    private fun accumulateCounters(state: JSONObject, result: JSONObject) {
         state.put("deletedBytes", state.optLong("deletedBytes") + result.optLong("deletedBytes"))
             .put("deletedFiles", state.optLong("deletedFiles") + result.optLong("deletedFiles"))
             .put("deletedDirectories", state.optLong("deletedDirectories") + result.optLong("deletedDirectories"))
-            .put("cleanedCandidates", state.optInt("cleanedCandidates") + result.optInt("cleanedCandidates"))
-            .put("failures", state.optInt("failures") + result.optInt("failures"))
+            .put("deleteErrors", state.optInt("deleteErrors") + result.optInt("failures"))
+            .put("failures", state.optInt("deleteErrors") + result.optInt("failures"))
     }
+
+    private fun captureCacheOutcomes(
+        state: JSONObject,
+        result: JSONObject,
+        directory: File,
+        terminal: Set<String>,
+        cleanFinished: Boolean
+    ) {
+        val source = readCacheOutcomeItems(File(directory, "cache/cache_scan.items.tsv"))
+        val details = readCacheReportDetails(state)
+        source.forEach { item ->
+            if (!cleanFinished && item.path !in terminal && item.path !in details) return@forEach
+            val detail = details[item.path] ?: OutcomeDetail(
+                action = if (cleanFinished) "cleaned" else "partial",
+                reason = if (cleanFinished) "" else result.optString("message"),
+                bytes = 0L,
+                files = 0L,
+                directories = 0L
+            )
+            recordOutcome(state, item, detail)
+        }
+        rebuildResultMetrics(state)
+    }
+
+    private fun captureSafeOutcomes(state: JSONObject, result: JSONObject, directory: File) {
+        val before = readSafeOutcomeItems(File(directory, "safe.json"))
+        if (before.isEmpty()) return
+        val live = safeSnapshotFile(state.optString("safeSnapshotId"))
+        val remainingKeys = readSafeOutcomeItems(live).flatMapTo(HashSet()) { listOf(it.id, it.path) }
+        val details = readSafeDetails(result)
+        before.forEach { item ->
+            val detail = details[item.id] ?: details[item.path]
+            val terminal = item.id !in remainingKeys && item.path !in remainingKeys
+            if (detail != null) {
+                recordOutcome(state, item, detail)
+            } else if (terminal) {
+                recordOutcome(
+                    state,
+                    item,
+                    OutcomeDetail(
+                        action = if (result.optBoolean("success") && !result.has("error")) "cleaned" else "skipped",
+                        reason = result.optString("message"),
+                        bytes = 0L,
+                        files = 0L,
+                        directories = 0L
+                    )
+                )
+            }
+        }
+        rebuildResultMetrics(state)
+    }
+
+    private fun readCacheOutcomeItems(file: File): List<OutcomeItem> {
+        if (!file.isFile) return emptyList()
+        return buildList {
+            file.useLines { lines ->
+                lines.drop(1).forEach { line ->
+                    val fields = line.split('\t', limit = 6)
+                    val path = fields.getOrNull(5)?.trim().orEmpty()
+                    if (fields.size < 6 || !path.startsWith("/")) return@forEach
+                    add(
+                        OutcomeItem(
+                            id = sha256Text(path),
+                            path = path,
+                            category = normalizeCategory(fields[1]),
+                            risk = "low",
+                            estimatedBytes = fields[3].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                            estimatedFiles = fields[2].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                            estimatedDirectories = fields[4].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private fun readSafeOutcomeItems(file: File?): List<OutcomeItem> {
+        if (file == null || !file.isFile) return emptyList()
+        val items = parseJson(file.readText()).optJSONArray("items") ?: JSONArray()
+        return buildList {
+            for (index in 0 until items.length()) {
+                val item = items.optJSONObject(index) ?: continue
+                val path = item.optString("path")
+                if (!path.startsWith("/")) continue
+                add(
+                    OutcomeItem(
+                        id = item.optString("id").ifBlank { sha256Text(path) },
+                        path = path,
+                        category = normalizeCategory(item.optString("category", item.optString("categoryLabel"))),
+                        risk = normalizeRisk(item.optString("risk")),
+                        estimatedBytes = item.optLong("bytes", item.optLong("estimatedBytes", 0L)).coerceAtLeast(0L),
+                        estimatedFiles = item.optLong("files", 0L).coerceAtLeast(0L),
+                        estimatedDirectories = item.optLong("directories", 0L).coerceAtLeast(0L)
+                    )
+                )
+            }
+        }
+    }
+
+    private fun readCacheReportDetails(state: JSONObject): Map<String, OutcomeDetail> {
+        val report = File(RootPaths.STATE_DIR, "reports/latest.tsv")
+        val runStarted = state.optLong("runStartedAt", 0L)
+        if (!report.isFile || report.lastModified() + REPORT_CLOCK_SLOP_MS < runStarted) return emptyMap()
+        val result = LinkedHashMap<String, OutcomeDetail>()
+        report.useLines { lines ->
+            lines.drop(1).forEach { line ->
+                val fields = line.split('\t', limit = 6)
+                val path = fields.getOrNull(5)?.trim().orEmpty()
+                if (fields.size < 6 || !path.startsWith("/")) return@forEach
+                result[path] = OutcomeDetail(
+                    action = normalizeAction(fields[0]),
+                    reason = "",
+                    files = fields[3].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                    bytes = fields[4].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                    directories = 0L
+                )
+            }
+        }
+        return result
+    }
+
+    private fun readSafeDetails(result: JSONObject): Map<String, OutcomeDetail> {
+        val values = LinkedHashMap<String, OutcomeDetail>()
+        val details = result.optJSONArray("details") ?: JSONArray()
+        for (index in 0 until details.length()) {
+            val detail = details.optJSONObject(index) ?: continue
+            val value = OutcomeDetail(
+                action = normalizeAction(detail.optString("action")),
+                reason = detail.optString("reason"),
+                bytes = detail.optLong("bytes").coerceAtLeast(0L),
+                files = detail.optLong("files").coerceAtLeast(0L),
+                directories = detail.optLong("directories").coerceAtLeast(0L)
+            )
+            detail.optString("id").takeIf { it.isNotBlank() }?.let { values[it] = value }
+            detail.optString("path").takeIf { it.startsWith("/") }?.let { values[it] = value }
+        }
+        return values
+    }
+
+    private fun recordOutcome(state: JSONObject, item: OutcomeItem, detail: OutcomeDetail) {
+        val states = state.optJSONObject("itemStates") ?: JSONObject().also { state.put("itemStates", it) }
+        val key = item.id.ifBlank { sha256Text(item.path) }
+        val previous = states.optJSONObject(key)
+        states.put(
+            key,
+            JSONObject()
+                .put("id", item.id)
+                .put("path", item.path)
+                .put("category", item.category)
+                .put("risk", item.risk)
+                .put("action", normalizeAction(detail.action))
+                .put("reason", detail.reason)
+                .put("deletedBytes", (previous?.optLong("deletedBytes") ?: 0L) + detail.bytes)
+                .put("deletedFiles", (previous?.optLong("deletedFiles") ?: 0L) + detail.files)
+                .put("deletedDirectories", (previous?.optLong("deletedDirectories") ?: 0L) + detail.directories)
+                .put("updatedAt", System.currentTimeMillis())
+        )
+    }
+
+    private fun rebuildResultMetrics(state: JSONObject) {
+        val states = state.optJSONObject("itemStates") ?: JSONObject()
+        val categories = JSONObject()
+        val risks = JSONObject()
+        var processed = 0
+        var cleaned = 0
+        var changed = 0
+        var protected = 0
+        var partial = 0
+        var failed = 0
+        var classifiedBytes = 0L
+        val keys = states.keys()
+        while (keys.hasNext()) {
+            val value = states.optJSONObject(keys.next()) ?: continue
+            val action = normalizeAction(value.optString("action"))
+            processed++
+            when (action) {
+                "cleaned" -> cleaned++
+                "protected" -> protected++
+                "partial" -> partial++
+                "failed" -> failed++
+                else -> changed++
+            }
+            classifiedBytes += value.optLong("deletedBytes").coerceAtLeast(0L)
+            incrementBucket(categories, normalizeCategory(value.optString("category")), action, value)
+            incrementBucket(risks, normalizeRisk(value.optString("risk")), action, value)
+        }
+        state.put("processedCandidates", processed)
+            .put("cleanedCandidates", cleaned)
+            .put("changedCandidates", changed)
+            .put("protectedCandidates", protected)
+            .put("partialCandidates", partial)
+            .put("failedCandidates", failed)
+            .put("skippedCandidates", changed + protected)
+            .put("classifiedDeletedBytes", classifiedBytes)
+            .put("unattributedDeletedBytes", (state.optLong("deletedBytes") - classifiedBytes).coerceAtLeast(0L))
+            .put("categoryStats", categories)
+            .put("riskStats", risks)
+    }
+
+    private fun incrementBucket(root: JSONObject, key: String, action: String, item: JSONObject) {
+        val bucket = root.optJSONObject(key) ?: JSONObject().also { root.put(key, it) }
+        bucket.put("processed", bucket.optInt("processed") + 1)
+            .put(action, bucket.optInt(action) + 1)
+            .put("deletedBytes", bucket.optLong("deletedBytes") + item.optLong("deletedBytes"))
+            .put("deletedFiles", bucket.optLong("deletedFiles") + item.optLong("deletedFiles"))
+            .put("deletedDirectories", bucket.optLong("deletedDirectories") + item.optLong("deletedDirectories"))
+    }
+
+    private fun normalizeAction(raw: String): String = when (raw.trim().lowercase()) {
+        "cleaned", "deleted", "success" -> "cleaned"
+        "protected" -> "protected"
+        "partial" -> "partial"
+        "failed", "error" -> "failed"
+        else -> "changed"
+    }
+
+    private fun normalizeCategory(raw: String): String {
+        val value = raw.trim().lowercase()
+        return when {
+            value.contains("cache") || value.contains("缓存") || value.contains("code_cache") -> "cache"
+            value.contains("empty") || value.contains("空文件") || value.contains("空目录") -> "empty"
+            value.contains("fragment") || value.contains("碎片") || value.contains("残留") -> "fragment"
+            value.contains("rule") || value.contains("规则") -> "rules"
+            else -> "other"
+        }
+    }
+
+    private fun normalizeRisk(raw: String): String = when (raw.trim().lowercase()) {
+        "medium" -> "medium"
+        "high" -> "high"
+        "critical" -> "critical"
+        else -> "low"
+    }
+
+    private fun sha256Text(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
 
     private fun backupCurrentSnapshots(state: JSONObject, directory: File) {
         if (!state.optBoolean("cacheComplete")) backupCacheSnapshot(directory)
@@ -467,7 +739,7 @@ class CleanPlanResumeRootService : RootService() {
         .toString()
 
     companion object {
-        private const val TRANSACTION_VERSION = 1
+        private const val TRANSACTION_VERSION = 2
         private const val TRANSACTION_TTL_MS = 2L * 60L * 60_000L
         private const val REPORT_CLOCK_SLOP_MS = 5_000L
         private val CACHE_FILES = listOf(

--- a/v2/module/cache-snapshot-clean.sh
+++ b/v2/module/cache-snapshot-clean.sh
@@ -172,6 +172,17 @@ skipped=$(summary_number skipped)
 errors=$(summary_number errors)
 protected_items=$(summary_number protected_items)
 protected_bytes=$(summary_number protected_bytes)
+action_count() {
+  action=$1
+  awk -F '\t' -v action="$action" 'NR>1 && $1==action { count++ } END { print count+0 }' "$REPORT_FILE" 2>/dev/null
+}
+authorized_candidates=$(awk -F '\t' 'NR>1 && NF>=6 { count++ } END { print count+0 }' "$CACHE_SCAN_ITEMS" 2>/dev/null)
+cleaned_candidates=$(action_count cleaned)
+changed_candidates=$(action_count skipped)
+protected_candidates=$(action_count protected)
+partial_candidates=$(action_count partial)
+failed_candidates=$(action_count failed)
+processed_candidates=$((cleaned_candidates + changed_candidates + protected_candidates + partial_candidates + failed_candidates))
 end=$(date +%s)
 elapsed=$((end - START_EPOCH))
 
@@ -192,6 +203,16 @@ latest_tmp="$STATE_DIR/latest.env.tmp.$$"
 {
   echo "mode=cache-clean"
   echo "time=$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "schema=clean-result-v1"
+  echo "scanned_candidates=$authorized_candidates"
+  echo "authorized_candidates=$authorized_candidates"
+  echo "processed_candidates=$processed_candidates"
+  echo "cleaned_candidates=$cleaned_candidates"
+  echo "changed_candidates=$changed_candidates"
+  echo "protected_candidates=$protected_candidates"
+  echo "partial_candidates=$partial_candidates"
+  echo "failed_candidates=$failed_candidates"
+  echo "skipped_candidates=$((changed_candidates + protected_candidates))"
   echo "files=$deleted_files"
   echo "regular_files=$deleted_files"
   echo "empty_files=0"
@@ -203,10 +224,20 @@ latest_tmp="$STATE_DIR/latest.env.tmp.$$"
   echo "errors=$errors"
   echo "protected_items=$protected_items"
   echo "protected_bytes=$protected_bytes"
-  echo "risk_low=$deleted_files"
+  echo "risk_low=$cleaned_candidates"
+  echo "risk_low_candidates=$cleaned_candidates"
   echo "risk_medium=0"
+  echo "risk_medium_candidates=0"
   echo "risk_high=0"
+  echo "risk_high_candidates=0"
   echo "risk_critical=0"
+  echo "risk_critical_candidates=0"
+  echo "category_cache_candidates=$authorized_candidates"
+  echo "category_cache_cleaned=$cleaned_candidates"
+  echo "category_cache_changed=$changed_candidates"
+  echo "category_cache_protected=$protected_candidates"
+  echo "category_cache_partial=$partial_candidates"
+  echo "category_cache_failed=$failed_candidates"
   echo "deep_slow_items=0"
   echo "deep_mount_items=0"
   echo "deep_truncated=0"
@@ -226,8 +257,9 @@ mv -f "$latest_tmp" "$STATE_DIR/latest.env"
   echo "----------------------------------------"
   echo "$result"
   echo "扫描快照: $snapshot_id"
-  echo "授权项目: $authorized_files 个 / $(human_bytes "$authorized_bytes")"
-  echo "实际清理: $deleted_files 个 / $(human_bytes "$deleted_bytes") | 变化或跳过: $skipped | 受保护: $protected_items | 失败: $errors | 耗时: ${elapsed}s"
+  echo "授权候选: $authorized_candidates 项 · 文件 $authorized_files 个 / $(human_bytes "$authorized_bytes")"
+  echo "实际结果: 清理 $cleaned_candidates 项 · 变化 $changed_candidates · 保护 $protected_candidates · 部分 $partial_candidates · 失败 $failed_candidates"
+  echo "实际删除: $deleted_files 个文件 / $(human_bytes "$deleted_bytes") | 引擎跳过: $skipped | 引擎错误: $errors | 耗时: ${elapsed}s"
 } >>"$LOG_FILE"
 cp -f "$LOG_FILE" "$LOG_DIR/latest.log"
 

--- a/v2/tests/test-clean-result-model.py
+++ b/v2/tests/test-clean-result-model.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVICE = (ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt").read_text()
+ACTIVITY = (ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt").read_text()
+SHELL = (ROOT / "v2/module/cache-snapshot-clean.sh").read_text()
+
+
+def require(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+# Candidate outcomes are unique final states; engine file/error totals remain separate counters.
+for marker in (
+    "itemStates", "processedCandidates", "changedCandidates", "protectedCandidates",
+    "partialCandidates", "failedCandidates", "categoryStats", "riskStats",
+    "classifiedDeletedBytes", "unattributedDeletedBytes", "captureCacheOutcomes",
+    "captureSafeOutcomes", "rebuildResultMetrics"
+):
+    require(marker in SERVICE, f"missing result model primitive: {marker}")
+
+require('private const val TRANSACTION_VERSION = 2' in SERVICE, "transaction schema was not upgraded")
+require('risk = "low"' in SERVICE, "cache candidate risk must be explicit")
+require('normalizeCategory' in SERVICE and 'normalizeRisk' in SERVICE, "classification normalization missing")
+
+for marker in (
+    "processedCandidates", "changedCandidates", "protectedCandidates", "partialCandidates",
+    "failedCandidates", "categoryStats", "riskStats", "formatMetricBuckets"
+):
+    require(marker in ACTIVITY, f"result metric is not persisted/rendered: {marker}")
+
+require('risk_low=$deleted_files' not in SHELL, "legacy file-count-as-risk bug remains")
+require('risk_low=$cleaned_candidates' in SHELL, "risk count must use cleaned candidates")
+require('authorized_candidates=' in SHELL and 'processed_candidates=' in SHELL, "module result schema missing")
+require('category_cache_cleaned=' in SHELL, "module category summary missing")
+
+print("clean result model contract: ok")

--- a/v2/tests/test-clean-result-model.py
+++ b/v2/tests/test-clean-result-model.py
@@ -13,6 +13,7 @@ def require(value: bool, message: str) -> None:
 
 
 # Candidate outcomes are unique final states; engine file/error totals remain separate counters.
+# Keep this contract active after rebasing the result model onto the release baseline.
 for marker in (
     "itemStates", "processedCandidates", "changedCandidates", "protectedCandidates",
     "partialCandidates", "failedCandidates", "categoryStats", "riskStats",


### PR DESCRIPTION
## 第三阶段：真实分类统计

- 引入 `clean-result-v1` 结果协议，明确区分扫描、授权、处理、实际清理、变化、保护、部分和失败候选。
- 事务层以候选唯一 ID 保存最终状态；同一项目重试时覆盖状态，不重复累计候选数。
- 实际释放空间仍以清理引擎返回值为准；逐项无法归属的字节单独记为 `unattributedDeletedBytes`，不伪造分类数据。
- 按应用缓存、空项目、规则垃圾、残留碎片和其他类别统计。
- 按低、中、高、关键风险等级统计，应用缓存明确归为低风险候选。
- 修正模块 `latest.env` 把文件数当候选数、把全部文件直接写入 `risk_low` 的问题。
- 智能清理页面展示真实处理结果和分类明细，并在断点恢复后继续保留。
- 新增 `test-clean-result-model.py` 回归约束。

## 验证结果

- 结果模型契约、Root 脚本与既有回归：通过
- Android Release 与 Debug Kotlin：通过
- Lint：通过
- Macrobenchmark：通过
- ARM64 原生扫描器：通过
- 模块封包、PR 签名和正式产物结构校验：通过

完整验证运行：BaiZe v2.4.0 Verify and Release #27。