### PR TITLE
feat(clean): browse and finalize selected candidates

### DIFF
--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -30,10 +30,11 @@
         <activity android:name=".CacheActivity" android:exported="false" />
         <activity android:name=".PersistentSmartScanActivity" android:exported="false" />
         <activity android:name=".ResumableSmartScanActivity" android:exported="false" />
+        <activity android:name=".CandidateSmartScanActivity" android:exported="false" />
         <activity-alias
             android:name=".SmartScanActivity"
             android:exported="false"
-            android:targetActivity=".ResumableSmartScanActivity" />
+            android:targetActivity=".CandidateSmartScanActivity" />
         <activity android:name=".ApkScanActivity" android:exported="false" />
         <activity android:name=".InstantCacheActivity" android:exported="false" />
         <activity android:name=".FileOrganizerActivity" android:exported="false" />
@@ -65,6 +66,10 @@
             tools:ignore="Instantiatable" />
         <service
             android:name=".root.CleanPlanResumeRootService"
+            android:exported="false"
+            tools:ignore="Instantiatable" />
+        <service
+            android:name=".root.CandidatePlanRootService"
             android:exported="false"
             tools:ignore="Instantiatable" />
     </application>

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICandidatePlanService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICandidatePlanService.aidl
@@ -1,0 +1,6 @@
+package io.github.xgl34222220.baize.root;
+
+interface ICandidatePlanService {
+    String ping();
+    String finalizePlan(String cacheSnapshotId, String safeSnapshotId, String selectionJson);
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CandidateSmartScanActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CandidateSmartScanActivity.kt
@@ -1,0 +1,1241 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.IBinder
+import android.os.SystemClock
+import android.text.format.Formatter
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.DeleteSweep
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Stop
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.BaiZeRootService
+import io.github.xgl34222220.baize.root.CandidatePlanRootService
+import io.github.xgl34222220.baize.root.IBaiZeRootService
+import io.github.xgl34222220.baize.root.ICandidatePlanService
+import io.github.xgl34222220.baize.root.IPersistentCleanPlanService
+import io.github.xgl34222220.baize.root.PersistentCleanPlanRootService
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.security.MessageDigest
+import java.util.UUID
+
+/**
+ * Stage four smart-clean entry: browse every scanned candidate, group it, exclude unwanted items,
+ * then atomically reduce both Root snapshots to the exact final plan. Actual deletion and resume
+ * remain owned by [ResumableSmartScanActivity].
+ */
+class CandidateSmartScanActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private val preferences by lazy { getSharedPreferences("baize_v2", MODE_PRIVATE) }
+
+    private var cacheService: IBaiZeRootService? = null
+    private var safeService: IPersistentCleanPlanService? = null
+    private var candidateService: ICandidatePlanService? = null
+    private var cacheBinding = false
+    private var safeBinding = false
+    private var candidateBinding = false
+    private var pollJob: Job? = null
+    private var resumedOnce = false
+
+    private var cleanPlanId = ""
+    private var cleanPlanCreatedAt = 0L
+    private var cacheSnapshotId = ""
+    private var safeSnapshotId = ""
+    private var cacheCount = 0
+    private var safeCount = 0
+    private var selectionFinalized = false
+    private var excludedIds = linkedSetOf<String>()
+
+    private var screenState by mutableStateOf(CandidatePickerState())
+
+    private val cacheConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            cacheService = IBaiZeRootService.Stub.asInterface(binder)
+            cacheBinding = true
+            updateConnections()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            cacheService = null
+            cacheBinding = false
+            updateConnections()
+        }
+    }
+
+    private val safeConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            safeService = IPersistentCleanPlanService.Stub.asInterface(binder)
+            safeBinding = true
+            updateConnections()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            safeService = null
+            safeBinding = false
+            updateConnections()
+        }
+    }
+
+    private val candidateConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            candidateService = ICandidatePlanService.Stub.asInterface(binder)
+            candidateBinding = true
+            updateConnections()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            candidateService = null
+            candidateBinding = false
+            updateConnections()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        restorePlan()
+        setContent {
+            val appearance by appearanceViewModel.settings.collectAsState()
+            BaiZeTheme(appearance) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    CandidatePickerScreen(
+                        state = screenState,
+                        onBack = ::finish,
+                        onScan = ::startScan,
+                        onStop = ::stopScan,
+                        onReconnect = ::bindServices,
+                        onReload = ::loadCandidates,
+                        onGrouping = ::setGrouping,
+                        onToggleExpanded = ::toggleExpanded,
+                        onToggleCandidate = ::toggleCandidate,
+                        onToggleGroup = ::toggleGroup,
+                        onSelectAll = ::selectAll,
+                        onSelectNone = ::selectNone,
+                        onFinalize = { finalizeSelection(false) },
+                        onFinalizeAndClean = { finalizeSelection(true) },
+                        onOpenClean = ::openResumableClean
+                    )
+                }
+            }
+        }
+        bindServices()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (resumedOnce && !screenState.running) {
+            val hadPlan = screenState.planReady
+            restorePlan()
+            if (hadPlan && !screenState.planReady) {
+                screenState = CandidatePickerState(
+                    connected = servicesReady(),
+                    status = if (servicesReady()) "候选计划引擎已连接" else "正在连接 Root 引擎…",
+                    phase = "上一份清理计划已完成，可开始新的智能扫描"
+                )
+            }
+        }
+        resumedOnce = true
+    }
+
+    private fun bindServices() {
+        if (cacheService == null && !cacheBinding) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, BaiZeRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    cacheConnection
+                )
+                cacheBinding = true
+            }.onFailure {
+                cacheBinding = false
+                screenState = screenState.copy(phase = "缓存 Root 服务启动失败：${it.message}")
+            }
+        }
+        if (safeService == null && !safeBinding) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, PersistentCleanPlanRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    safeConnection
+                )
+                safeBinding = true
+            }.onFailure {
+                safeBinding = false
+                screenState = screenState.copy(phase = "安全项目 Root 服务启动失败：${it.message}")
+            }
+        }
+        if (candidateService == null && !candidateBinding) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, CandidatePlanRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    candidateConnection
+                )
+                candidateBinding = true
+            }.onFailure {
+                candidateBinding = false
+                screenState = screenState.copy(phase = "候选计划 Root 服务启动失败：${it.message}")
+            }
+        }
+        updateConnections()
+    }
+
+    private fun servicesReady(): Boolean =
+        cacheService != null && safeService != null && candidateService != null
+
+    private fun updateConnections() {
+        val ready = listOf(cacheService, safeService, candidateService).count { it != null }
+        screenState = screenState.copy(
+            connected = ready == 3,
+            status = if (ready == 3) "扫描、分页与候选计划引擎已连接" else "正在连接 Root 引擎 · $ready/3"
+        )
+        if (ready == 3 && screenState.planReady && !selectionFinalized &&
+            screenState.candidates.isEmpty() && !screenState.loadingCandidates && !screenState.running
+        ) {
+            loadCandidates()
+        }
+    }
+
+    private fun startScan() {
+        if (screenState.running) return
+        val cache = cacheService
+        val safe = safeService
+        if (cache == null || safe == null || candidateService == null) {
+            screenState = screenState.copy(phase = "Root 引擎尚未全部连接")
+            bindServices()
+            return
+        }
+
+        clearPlan()
+        screenState = CandidatePickerState(
+            connected = true,
+            running = true,
+            operation = "scan",
+            status = "扫描、分页与候选计划引擎已连接",
+            phase = "正在并行扫描应用缓存与安全项目…",
+            progressCurrent = 0,
+            progressTotal = 2
+        )
+        startPolling()
+
+        lifecycleScope.launch {
+            val started = SystemClock.elapsedRealtime()
+            try {
+                val packageWhitelist = preferences.getStringSet("package_whitelist", emptySet()).orEmpty()
+                val options = optionsJson()
+                val (cacheJson, safeJson) = withContext(Dispatchers.IO) {
+                    coroutineScope {
+                        val cacheJob = async {
+                            JSONObject(cache.scanCandidates(JSONArray(packageWhitelist.toList().sorted()).toString()))
+                        }
+                        val safeJob = async { JSONObject(safe.scanSafe(options)) }
+                        cacheJob.await() to safeJob.await()
+                    }
+                }
+                if (cacheJson.optString("error") == "busy" || safeJson.optString("error") == "busy") {
+                    screenState = screenState.copy(running = false, operation = "", phase = "当前已有扫描或清理任务正在运行")
+                    return@launch
+                }
+
+                cacheSnapshotId = cacheJson.takeUnless { it.has("error") }?.optString("snapshotId").orEmpty()
+                safeSnapshotId = safeJson.takeUnless { it.has("error") }?.optString("snapshotId").orEmpty()
+                cacheCount = if (cacheSnapshotId.isBlank()) 0 else cacheJson.optInt("totalCandidates").coerceAtLeast(0)
+                safeCount = if (safeSnapshotId.isBlank()) 0 else (
+                    safeJson.optInt("low") + safeJson.optInt("medium")
+                ).coerceAtLeast(0)
+                cleanPlanId = UUID.randomUUID().toString()
+                cleanPlanCreatedAt = System.currentTimeMillis()
+                selectionFinalized = false
+                excludedIds.clear()
+                val total = cacheCount + safeCount
+                val cancelled = cacheJson.optBoolean("cancelled") || safeJson.optBoolean("cancelled")
+                if (cancelled || total <= 0) {
+                    clearPlan()
+                    screenState = screenState.copy(
+                        running = false,
+                        operation = "",
+                        phase = if (cancelled) "智能扫描已停止" else "扫描完成，没有发现可安全清理的项目",
+                        progressCurrent = 2,
+                        progressTotal = 2
+                    )
+                    return@launch
+                }
+
+                persistPlan()
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    planReady = true,
+                    finalized = false,
+                    phase = "扫描完成 · $total 项\n正在读取候选明细，可按应用或类别自由勾选",
+                    cacheCount = cacheCount,
+                    safeCount = safeCount,
+                    selectedCount = total,
+                    progressCurrent = 2,
+                    progressTotal = 2
+                )
+                loadCandidates()
+                val elapsed = SystemClock.elapsedRealtime() - started
+                screenState = screenState.copy(phase = "扫描完成 · $total 项 · ${elapsed}ms\n请选择要进入最终清理计划的项目")
+            } catch (throwable: Throwable) {
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    phase = "智能扫描失败：${throwable.message ?: throwable.javaClass.simpleName}"
+                )
+            } finally {
+                pollJob?.cancel()
+            }
+        }
+    }
+
+    private fun loadCandidates() {
+        if (screenState.running || screenState.loadingCandidates || selectionFinalized) return
+        val cache = cacheService ?: return
+        val safe = safeService ?: return
+        if (cacheSnapshotId.isBlank() && safeSnapshotId.isBlank()) return
+        screenState = screenState.copy(
+            loadingCandidates = true,
+            phase = "正在分页读取候选明细…"
+        )
+
+        lifecycleScope.launch {
+            try {
+                val candidates = withContext(Dispatchers.IO) {
+                    coroutineScope {
+                        val cacheJob = async {
+                            loadAllPages(cacheSnapshotId) { offset, limit ->
+                                cache.getResultPage(cacheSnapshotId, offset, limit)
+                            }.map { json -> cacheCandidate(json) }
+                        }
+                        val safeJob = async {
+                            loadAllPages(safeSnapshotId) { offset, limit ->
+                                safe.getPage(safeSnapshotId, offset, limit)
+                            }.mapNotNull { json -> safeCandidate(json) }
+                        }
+                        (cacheJob.await() + safeJob.await())
+                            .distinctBy { it.id }
+                            .sortedWith(
+                                compareByDescending<PickerCandidate> { it.bytes.coerceAtLeast(0L) }
+                                    .thenBy { it.appName }
+                                    .thenBy { it.path }
+                            )
+                    }
+                }
+                val validIds = candidates.mapTo(HashSet()) { it.id }
+                excludedIds.retainAll(validIds)
+                val selected = candidates.filterNot { it.id in excludedIds }
+                persistSelection()
+                screenState = screenState.copy(
+                    loadingCandidates = false,
+                    candidates = candidates,
+                    selectedCount = selected.size,
+                    selectedBytes = selected.sumOf { it.bytes.coerceAtLeast(0L) },
+                    phase = "候选明细已加载 · 共 ${candidates.size} 项，已选 ${selected.size} 项"
+                )
+            } catch (throwable: Throwable) {
+                screenState = screenState.copy(
+                    loadingCandidates = false,
+                    phase = "候选明细读取失败：${throwable.message ?: throwable.javaClass.simpleName}"
+                )
+            }
+        }
+    }
+
+    private fun loadAllPages(
+        snapshotId: String,
+        fetch: (Int, Int) -> String
+    ): List<JSONObject> {
+        if (snapshotId.isBlank()) return emptyList()
+        val result = ArrayList<JSONObject>()
+        var offset = 0
+        var total = Int.MAX_VALUE
+        while (offset < total && result.size < MAX_UI_CANDIDATES) {
+            val page = JSONObject(fetch(offset, PAGE_SIZE))
+            if (page.has("error")) throw IllegalStateException(page.optString("message", "候选快照已失效"))
+            total = page.optInt("total", 0).coerceAtMost(MAX_UI_CANDIDATES)
+            val items = page.optJSONArray("items") ?: JSONArray()
+            if (items.length() == 0) break
+            for (index in 0 until items.length()) {
+                items.optJSONObject(index)?.let(result::add)
+            }
+            offset += items.length()
+        }
+        if (total > MAX_UI_CANDIDATES) throw IllegalStateException("候选数量超过界面安全上限，请缩小扫描范围")
+        return result
+    }
+
+    private fun cacheCandidate(json: JSONObject): PickerCandidate {
+        val packageName = json.optString("packageName")
+        val path = json.optString("path")
+        val category = json.optString("categoryLabel", "应用缓存")
+        return PickerCandidate(
+            id = "cache:$path",
+            source = "cache",
+            appName = resolveAppName(packageName),
+            packageName = packageName,
+            category = category,
+            risk = "low",
+            path = path,
+            bytes = json.optLong("bytes", 0L),
+            files = json.optLong("files", 0L),
+            directories = json.optLong("directories", 0L),
+            measured = true,
+            note = "应用缓存快照"
+        )
+    }
+
+    private fun safeCandidate(json: JSONObject): PickerCandidate? {
+        val path = json.optString("path")
+        val id = json.optString("id")
+        if (path.isBlank() || id.isBlank()) return null
+        val packageName = json.optString("packageName")
+        return PickerCandidate(
+            id = id,
+            source = "safe",
+            appName = if (packageName.isBlank()) "系统与共享存储" else resolveAppName(packageName),
+            packageName = packageName,
+            category = json.optString("categoryLabel", "安全项目"),
+            risk = json.optString("risk", "low"),
+            path = path,
+            bytes = json.optLong("bytes", -1L),
+            files = json.optLong("files", -1L),
+            directories = json.optLong("directories", -1L),
+            measured = json.optBoolean("measured", false),
+            note = json.optString("note")
+        )
+    }
+
+    private fun resolveAppName(packageName: String): String {
+        if (packageName.isBlank()) return "系统与共享存储"
+        return runCatching {
+            val info = packageManager.getApplicationInfo(packageName, 0)
+            packageManager.getApplicationLabel(info).toString().ifBlank { packageName }
+        }.getOrDefault(packageName)
+    }
+
+    private fun toggleCandidate(id: String) {
+        if (selectionFinalized || screenState.running) return
+        if (!excludedIds.add(id)) excludedIds.remove(id)
+        updateSelectionState()
+    }
+
+    private fun toggleGroup(candidates: List<PickerCandidate>) {
+        if (selectionFinalized || screenState.running) return
+        val allSelected = candidates.all { it.id !in excludedIds }
+        if (allSelected) candidates.forEach { excludedIds += it.id }
+        else candidates.forEach { excludedIds -= it.id }
+        updateSelectionState()
+    }
+
+    private fun selectAll() {
+        if (selectionFinalized || screenState.running) return
+        excludedIds.clear()
+        updateSelectionState()
+    }
+
+    private fun selectNone() {
+        if (selectionFinalized || screenState.running) return
+        excludedIds = screenState.candidates.mapTo(linkedSetOf()) { it.id }
+        updateSelectionState()
+    }
+
+    private fun updateSelectionState() {
+        val selected = screenState.candidates.filterNot { it.id in excludedIds }
+        screenState = screenState.copy(
+            selectedCount = selected.size,
+            selectedBytes = selected.sumOf { it.bytes.coerceAtLeast(0L) },
+            excludedIds = excludedIds.toSet(),
+            phase = "已选择 ${selected.size}/${screenState.candidates.size} 项"
+        )
+        persistSelection()
+    }
+
+    private fun setGrouping(grouping: String) {
+        screenState = screenState.copy(grouping = grouping, expandedGroups = emptySet())
+    }
+
+    private fun toggleExpanded(key: String) {
+        val expanded = screenState.expandedGroups.toMutableSet()
+        if (!expanded.add(key)) expanded.remove(key)
+        screenState = screenState.copy(expandedGroups = expanded)
+    }
+
+    private fun finalizeSelection(openAfter: Boolean) {
+        if (screenState.running || selectionFinalized) {
+            if (selectionFinalized && openAfter) openResumableClean()
+            return
+        }
+        val service = candidateService
+        if (service == null) {
+            screenState = screenState.copy(phase = "候选计划 Root 服务尚未连接")
+            bindServices()
+            return
+        }
+        if (screenState.selectedCount <= 0) {
+            screenState = screenState.copy(phase = "请至少选择一个候选项目")
+            return
+        }
+
+        val selectedBefore = screenState.candidates.filterNot { it.id in excludedIds }
+        screenState = screenState.copy(
+            running = true,
+            operation = "finalize",
+            phase = "正在固化最终清理计划；不会重新扫描…"
+        )
+        lifecycleScope.launch {
+            try {
+                val selection = JSONObject()
+                    .put("__all_safe__", true)
+                    .put("__exclude__", JSONArray(excludedIds.toList().sorted()))
+                val result = withContext(Dispatchers.IO) {
+                    JSONObject(service.finalizePlan(cacheSnapshotId, safeSnapshotId, selection.toString()))
+                }
+                if (result.has("error")) throw IllegalStateException(result.optString("message", "最终计划生成失败"))
+
+                cacheSnapshotId = result.optString("cacheSnapshotId")
+                safeSnapshotId = result.optString("safeSnapshotId")
+                cacheCount = result.optInt("cacheCount", 0).coerceAtLeast(0)
+                safeCount = result.optInt("safeCount", 0).coerceAtLeast(0)
+                selectionFinalized = true
+                excludedIds.clear()
+                persistPlan()
+                val selectedCount = cacheCount + safeCount
+                val selectedBytes = result.optLong("selectedBytes", selectedBefore.sumOf { it.bytes.coerceAtLeast(0L) })
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    finalized = true,
+                    candidates = selectedBefore,
+                    excludedIds = emptySet(),
+                    selectedCount = selectedCount,
+                    selectedBytes = selectedBytes,
+                    cacheCount = cacheCount,
+                    safeCount = safeCount,
+                    phase = "最终清理计划已锁定 · $selectedCount 项\n未选项目已从 Root 快照移除，后续只会处理当前计划"
+                )
+                if (openAfter) openResumableClean()
+            } catch (throwable: Throwable) {
+                screenState = screenState.copy(
+                    running = false,
+                    operation = "",
+                    phase = "最终计划生成失败：${throwable.message ?: throwable.javaClass.simpleName}"
+                )
+            }
+        }
+    }
+
+    private fun openResumableClean() {
+        if (!selectionFinalized && screenState.selectedCount > 0) {
+            finalizeSelection(true)
+            return
+        }
+        if (!screenState.planReady) return
+        startActivity(Intent(this, ResumableSmartScanActivity::class.java))
+    }
+
+    private fun stopScan() {
+        cacheService?.cancelCurrentTask()
+        safeService?.cancelCurrentTask()
+        screenState = screenState.copy(phase = "已发送停止请求…")
+    }
+
+    private fun startPolling() {
+        pollJob?.cancel()
+        pollJob = lifecycleScope.launch {
+            while (isActive && screenState.running && screenState.operation == "scan") {
+                val states = withContext(Dispatchers.IO) {
+                    listOfNotNull(
+                        cacheService?.getTaskState()?.let { runCatching { JSONObject(it) }.getOrNull() },
+                        safeService?.getTaskState()?.let { runCatching { JSONObject(it) }.getOrNull() }
+                    )
+                }
+                val active = states.filter { it.optBoolean("running") }
+                if (active.isNotEmpty()) {
+                    val current = active.sumOf { it.optInt("current", it.optInt("progress_current", 0)).coerceAtLeast(0) }
+                    val total = active.sumOf { it.optInt("total", it.optInt("progress_total", 0)).coerceAtLeast(0) }
+                    val phase = active.joinToString(" · ") { it.optString("phase", "扫描中") }
+                    screenState = screenState.copy(
+                        phase = phase,
+                        progressCurrent = current,
+                        progressTotal = total
+                    )
+                }
+                delay(300)
+            }
+        }
+    }
+
+    private fun restorePlan() {
+        val raw = preferences.getString(CLEAN_PLAN_KEY, null).orEmpty()
+        val plan = runCatching { JSONObject(raw) }.getOrNull()
+        if (plan == null) {
+            clearPlanMemory()
+            return
+        }
+        val createdAt = plan.optLong("createdAt", 0L)
+        if (createdAt <= 0L || System.currentTimeMillis() - createdAt !in 0L..CLEAN_PLAN_TTL_MS) {
+            clearPlan()
+            return
+        }
+        cleanPlanId = plan.optString("planId")
+        cleanPlanCreatedAt = createdAt
+        cacheSnapshotId = plan.optString("cacheSnapshotId")
+        safeSnapshotId = plan.optString("safeSnapshotId")
+        cacheCount = plan.optInt("cacheCount", 0).coerceAtLeast(0)
+        safeCount = plan.optInt("safeCount", 0).coerceAtLeast(0)
+        excludedIds = jsonStrings(plan.optJSONArray("excludedCandidateIds")).toCollection(linkedSetOf())
+        selectionFinalized = plan.optBoolean("selectionFinalized", false) || plan.optInt("runCount", 0) > 0
+        val total = cacheCount + safeCount
+        if (cleanPlanId.isBlank() || total <= 0 || (cacheSnapshotId.isBlank() && safeSnapshotId.isBlank())) {
+            clearPlan()
+            return
+        }
+        screenState = screenState.copy(
+            planReady = true,
+            finalized = selectionFinalized,
+            phase = if (selectionFinalized) {
+                "已恢复最终清理计划 ${cleanPlanId.take(8)} · 剩余 $total 项"
+            } else {
+                "已恢复待选择计划 ${cleanPlanId.take(8)} · $total 项"
+            },
+            cacheCount = cacheCount,
+            safeCount = safeCount,
+            selectedCount = plan.optInt("selectedCandidateCount", total).coerceIn(0, total),
+            selectedBytes = plan.optLong("selectedCandidateBytes", 0L).coerceAtLeast(0L),
+            excludedIds = excludedIds.toSet()
+        )
+    }
+
+    private fun persistSelection() {
+        if (cleanPlanId.isBlank()) return
+        val raw = preferences.getString(CLEAN_PLAN_KEY, null).orEmpty()
+        val plan = runCatching { JSONObject(raw) }.getOrElse { return }
+        plan.put("excludedCandidateIds", JSONArray(excludedIds.toList().sorted()))
+            .put("selectedCandidateCount", screenState.selectedCount)
+            .put("selectedCandidateBytes", screenState.selectedBytes)
+            .put("selectionFinalized", selectionFinalized)
+        preferences.edit().putString(CLEAN_PLAN_KEY, plan.toString()).apply()
+    }
+
+    private fun persistPlan() {
+        val total = cacheCount + safeCount
+        if (cleanPlanId.isBlank() || total <= 0) return
+        val plan = JSONObject()
+            .put("version", 2)
+            .put("planId", cleanPlanId)
+            .put("createdAt", cleanPlanCreatedAt)
+            .put("optionsSha", sha256(optionsJson()))
+            .put("cacheSnapshotId", cacheSnapshotId)
+            .put("safeSnapshotId", safeSnapshotId)
+            .put("cacheCount", cacheCount)
+            .put("safeCount", safeCount)
+            .put("originalCacheCount", cacheCount)
+            .put("originalSafeCount", safeCount)
+            .put("runCount", 0)
+            .put("deletedBytes", 0L)
+            .put("deletedFiles", 0L)
+            .put("deletedDirectories", 0L)
+            .put("processedCandidates", 0)
+            .put("cleanedCandidates", 0)
+            .put("changedCandidates", 0)
+            .put("protectedCandidates", 0)
+            .put("partialCandidates", 0)
+            .put("failedCandidates", 0)
+            .put("classifiedDeletedBytes", 0L)
+            .put("unattributedDeletedBytes", 0L)
+            .put("categoryStats", JSONObject())
+            .put("riskStats", JSONObject())
+            .put("deleteErrors", 0)
+            .put("failures", 0)
+            .put("resumable", false)
+            .put("cacheSummary", "应用缓存 $cacheCount 项")
+            .put("safeSummary", "安全项目 $safeCount 项")
+            .put("selectionFinalized", selectionFinalized)
+            .put("excludedCandidateIds", JSONArray(excludedIds.toList().sorted()))
+            .put("selectedCandidateCount", cacheCount + safeCount)
+            .put("selectedCandidateBytes", screenState.selectedBytes)
+        preferences.edit()
+            .putString(CLEAN_PLAN_KEY, plan.toString())
+            .remove(LEGACY_PLAN_KEY)
+            .apply()
+    }
+
+    private fun clearPlan() {
+        preferences.edit().remove(CLEAN_PLAN_KEY).remove(LEGACY_PLAN_KEY).apply()
+        clearPlanMemory()
+    }
+
+    private fun clearPlanMemory() {
+        cleanPlanId = ""
+        cleanPlanCreatedAt = 0L
+        cacheSnapshotId = ""
+        safeSnapshotId = ""
+        cacheCount = 0
+        safeCount = 0
+        selectionFinalized = false
+        excludedIds.clear()
+    }
+
+    private fun optionsJson(): String {
+        val packages = preferences.getStringSet("package_whitelist", emptySet()).orEmpty().toList().sorted()
+        val paths = preferences.getStringSet("path_whitelist", emptySet()).orEmpty().toList().sorted()
+        val maxMb = preferences.getFloat("large_file_mb", 512f).toLong().coerceIn(64L, 16_384L)
+        return JSONObject()
+            .put("whitelistPackages", JSONArray(packages))
+            .put("whitelistPaths", JSONArray(paths))
+            .put("maxFileBytes", maxMb * 1024L * 1024L)
+            .put("fragmentDays", preferences.getInt("fragment_days", 7).coerceIn(0, 365))
+            .put("allowHighRisk", false)
+            .toString()
+    }
+
+    private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+
+    private fun jsonStrings(array: JSONArray?): Set<String> {
+        val result = LinkedHashSet<String>()
+        if (array == null) return result
+        for (index in 0 until array.length()) {
+            array.optString(index).trim().takeIf { it.isNotBlank() }?.let(result::add)
+        }
+        return result
+    }
+
+    override fun onDestroy() {
+        pollJob?.cancel()
+        if (cacheBinding) runCatching { RootService.unbind(cacheConnection) }
+        if (safeBinding) runCatching { RootService.unbind(safeConnection) }
+        if (candidateBinding) runCatching { RootService.unbind(candidateConnection) }
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val CLEAN_PLAN_KEY = "smart_clean_plan_v2"
+        private const val LEGACY_PLAN_KEY = "smart_clean_plan_v1"
+        private const val CLEAN_PLAN_TTL_MS = 30L * 60_000L
+        private const val PAGE_SIZE = 100
+        private const val MAX_UI_CANDIDATES = 20_000
+    }
+}
+
+private data class PickerCandidate(
+    val id: String,
+    val source: String,
+    val appName: String,
+    val packageName: String,
+    val category: String,
+    val risk: String,
+    val path: String,
+    val bytes: Long,
+    val files: Long,
+    val directories: Long,
+    val measured: Boolean,
+    val note: String
+)
+
+private data class CandidatePickerState(
+    val connected: Boolean = false,
+    val running: Boolean = false,
+    val operation: String = "",
+    val status: String = "正在连接 Root 引擎…",
+    val phase: String = "连接完成后可开始智能扫描",
+    val planReady: Boolean = false,
+    val finalized: Boolean = false,
+    val loadingCandidates: Boolean = false,
+    val cacheCount: Int = 0,
+    val safeCount: Int = 0,
+    val selectedCount: Int = 0,
+    val selectedBytes: Long = 0L,
+    val candidates: List<PickerCandidate> = emptyList(),
+    val excludedIds: Set<String> = emptySet(),
+    val grouping: String = "app",
+    val expandedGroups: Set<String> = emptySet(),
+    val progressCurrent: Int = 0,
+    val progressTotal: Int = 0
+)
+
+private data class PickerGroup(
+    val key: String,
+    val title: String,
+    val subtitle: String,
+    val candidates: List<PickerCandidate>,
+    val bytes: Long
+)
+
+@Composable
+private fun CandidatePickerScreen(
+    state: CandidatePickerState,
+    onBack: () -> Unit,
+    onScan: () -> Unit,
+    onStop: () -> Unit,
+    onReconnect: () -> Unit,
+    onReload: () -> Unit,
+    onGrouping: (String) -> Unit,
+    onToggleExpanded: (String) -> Unit,
+    onToggleCandidate: (String) -> Unit,
+    onToggleGroup: (List<PickerCandidate>) -> Unit,
+    onSelectAll: () -> Unit,
+    onSelectNone: () -> Unit,
+    onFinalize: () -> Unit,
+    onFinalizeAndClean: () -> Unit,
+    onOpenClean: () -> Unit
+) {
+    val context = LocalContext.current
+    val progress = if (state.progressTotal > 0) {
+        (state.progressCurrent.toFloat() / state.progressTotal.toFloat()).coerceIn(0f, 1f)
+    } else 0f
+    val groups = candidateGroups(state)
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 34.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) {
+                    Icon(Icons.Rounded.ArrowBack, contentDescription = "返回")
+                }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        "CANDIDATE PLAN",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 2.sp
+                    )
+                    Text("智能清理", fontSize = 30.sp, fontWeight = FontWeight.Black)
+                    Text("逐项查看 · 自由勾选 · 固化最终计划", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(30.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+            ) {
+                Column(modifier = Modifier.padding(22.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier.size(58.dp).background(
+                                if (state.finalized) MaterialTheme.colorScheme.primaryContainer
+                                else MaterialTheme.colorScheme.secondaryContainer,
+                                RoundedCornerShape(20.dp)
+                            ),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                if (state.finalized) Icons.Rounded.CheckCircle else Icons.Rounded.CleaningServices,
+                                contentDescription = null,
+                                tint = if (state.finalized) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.secondary,
+                                modifier = Modifier.size(30.dp)
+                            )
+                        }
+                        Spacer(Modifier.size(14.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(state.status, fontWeight = FontWeight.Bold)
+                            Text(
+                                state.phase,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 5,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+
+                    if (state.running) {
+                        if (state.progressTotal > 0) {
+                            LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+                        } else {
+                            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        }
+                        if (state.operation == "scan") {
+                            OutlinedButton(onClick = onStop, modifier = Modifier.fillMaxWidth()) {
+                                Icon(Icons.Rounded.Stop, contentDescription = null)
+                                Spacer(Modifier.size(8.dp))
+                                Text("停止扫描")
+                            }
+                        }
+                    } else if (!state.connected) {
+                        OutlinedButton(onClick = onReconnect, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("重新连接 Root 引擎")
+                        }
+                    } else if (!state.planReady) {
+                        Button(onClick = onScan, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("开始智能扫描")
+                        }
+                    } else if (state.finalized) {
+                        Button(onClick = onOpenClean, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.DeleteSweep, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("进入清理计划 · ${state.selectedCount} 项")
+                        }
+                        OutlinedButton(onClick = onScan, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("放弃当前计划并重新扫描")
+                        }
+                    }
+                }
+            }
+        }
+
+        if (state.planReady) {
+            item {
+                Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+                    Text(
+                        "SELECTION",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                        letterSpacing = 2.sp
+                    )
+                    Text(
+                        if (state.finalized) "最终清理计划" else "候选选择",
+                        fontSize = 26.sp,
+                        fontWeight = FontWeight.Black
+                    )
+                    Text(
+                        "应用缓存 ${state.cacheCount} 项 · 安全项目 ${state.safeCount} 项",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        "已选 ${state.selectedCount} 项 · ${Formatter.formatFileSize(context, state.selectedBytes)}",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+
+        if (state.loadingCandidates) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    shape = RoundedCornerShape(24.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(20.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                        Text("正在分页读取候选，目录大小会在 Root 侧按需计算")
+                    }
+                }
+            }
+        } else if (state.planReady && !state.finalized && state.candidates.isEmpty()) {
+            item {
+                OutlinedButton(
+                    onClick = onReload,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+                ) {
+                    Icon(Icons.Rounded.Refresh, contentDescription = null)
+                    Spacer(Modifier.size(8.dp))
+                    Text("重新读取候选明细")
+                }
+            }
+        }
+
+        if (state.candidates.isNotEmpty() && !state.finalized) {
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    shape = RoundedCornerShape(24.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+                ) {
+                    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            FilterChip(
+                                selected = state.grouping == "app",
+                                onClick = { onGrouping("app") },
+                                label = { Text("按应用") }
+                            )
+                            FilterChip(
+                                selected = state.grouping == "category",
+                                onClick = { onGrouping("category") },
+                                label = { Text("按类别") }
+                            )
+                        }
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            OutlinedButton(onClick = onSelectAll, modifier = Modifier.weight(1f)) {
+                                Text("全选")
+                            }
+                            OutlinedButton(onClick = onSelectNone, modifier = Modifier.weight(1f)) {
+                                Text("全不选")
+                            }
+                        }
+                    }
+                }
+            }
+
+            groups.forEach { group ->
+                item(key = "group:${group.key}") {
+                    CandidateGroupHeader(
+                        group = group,
+                        selectedCount = group.candidates.count { it.id !in state.excludedIds },
+                        expanded = group.key in state.expandedGroups,
+                        onToggleSelection = { onToggleGroup(group.candidates) },
+                        onToggleExpanded = { onToggleExpanded(group.key) }
+                    )
+                }
+                if (group.key in state.expandedGroups) {
+                    items(group.candidates, key = { "candidate:${it.id}" }) { candidate ->
+                        CandidateRow(
+                            candidate = candidate,
+                            selected = candidate.id !in state.excludedIds,
+                            onToggle = { onToggleCandidate(candidate.id) }
+                        )
+                    }
+                }
+            }
+
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding(),
+                    shape = RoundedCornerShape(26.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+                ) {
+                    Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(
+                            "已选 ${state.selectedCount} 项 · ${Formatter.formatFileSize(context, state.selectedBytes)}",
+                            fontWeight = FontWeight.Bold
+                        )
+                        Button(
+                            onClick = onFinalizeAndClean,
+                            enabled = state.selectedCount > 0,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Icon(Icons.Rounded.DeleteSweep, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("生成计划并进入清理")
+                        }
+                        OutlinedButton(
+                            onClick = onFinalize,
+                            enabled = state.selectedCount > 0,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Icon(Icons.Rounded.CheckCircle, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("仅锁定最终计划")
+                        }
+                        Text(
+                            "锁定后未选项目会从 Root 快照中移除。后续停止、异常退出和继续清理都只处理已选项目，且不会重新扫描。",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 12.sp,
+                            lineHeight = 18.sp
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun candidateGroups(state: CandidatePickerState): List<PickerGroup> {
+    val grouped = if (state.grouping == "category") {
+        state.candidates.groupBy { it.category.ifBlank { "其他" } }
+    } else {
+        state.candidates.groupBy { it.appName.ifBlank { it.packageName.ifBlank { "系统与共享存储" } } }
+    }
+    return grouped.map { (title, candidates) ->
+        val cache = candidates.count { it.source == "cache" }
+        val safe = candidates.size - cache
+        PickerGroup(
+            key = "${state.grouping}:$title",
+            title = title,
+            subtitle = buildString {
+                append(candidates.size).append(" 项")
+                if (cache > 0) append(" · 缓存 ").append(cache)
+                if (safe > 0) append(" · 安全 ").append(safe)
+            },
+            candidates = candidates.sortedByDescending { it.bytes.coerceAtLeast(0L) },
+            bytes = candidates.sumOf { it.bytes.coerceAtLeast(0L) }
+        )
+    }.sortedWith(compareByDescending<PickerGroup> { it.bytes }.thenBy { it.title })
+}
+
+@Composable
+private fun CandidateGroupHeader(
+    group: PickerGroup,
+    selectedCount: Int,
+    expanded: Boolean,
+    onToggleSelection: () -> Unit,
+    onToggleExpanded: () -> Unit
+) {
+    val context = LocalContext.current
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().clickable(onClick = onToggleExpanded).padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Checkbox(
+                checked = selectedCount == group.candidates.size,
+                onCheckedChange = { onToggleSelection() }
+            )
+            Box(
+                modifier = Modifier.size(42.dp).background(
+                    MaterialTheme.colorScheme.secondaryContainer,
+                    RoundedCornerShape(15.dp)
+                ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Rounded.Folder, contentDescription = null, tint = MaterialTheme.colorScheme.secondary)
+            }
+            Spacer(Modifier.size(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(group.title, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    "${group.subtitle} · 已选 $selectedCount · ${Formatter.formatFileSize(context, group.bytes)}",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp
+                )
+            }
+            Icon(
+                if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                contentDescription = if (expanded) "收起" else "展开"
+            )
+        }
+    }
+}
+
+@Composable
+private fun CandidateRow(
+    candidate: PickerCandidate,
+    selected: Boolean,
+    onToggle: () -> Unit
+) {
+    val context = LocalContext.current
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 28.dp),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().clickable(onClick = onToggle).padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Checkbox(checked = selected, onCheckedChange = { onToggle() })
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(candidate.category, fontWeight = FontWeight.Bold)
+                    Text(
+                        buildString {
+                            append(riskLabel(candidate.risk))
+                            append(" · ")
+                            append(if (candidate.source == "cache") "应用缓存" else "安全项目")
+                            if (candidate.measured && candidate.bytes >= 0L) {
+                                append(" · ").append(Formatter.formatFileSize(context, candidate.bytes))
+                            } else {
+                                append(" · 大小待计算")
+                            }
+                            if (candidate.files >= 0L) append(" · ").append(candidate.files).append(" 文件")
+                        },
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp
+                    )
+                }
+            }
+            HorizontalDivider()
+            Text(
+                candidate.path,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (candidate.note.isNotBlank()) {
+                Text(candidate.note, color = MaterialTheme.colorScheme.primary, fontSize = 11.sp)
+            }
+        }
+    }
+}
+
+private fun riskLabel(risk: String): String = when (risk) {
+    "low" -> "低风险"
+    "medium" -> "中风险"
+    "high" -> "高风险"
+    "critical" -> "关键风险"
+    else -> risk.ifBlank { "未知风险" }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/CandidatePlanRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/CandidatePlanRootService.kt
@@ -1,0 +1,535 @@
+package io.github.xgl34222220.baize.root
+
+import android.content.Intent
+import android.os.IBinder
+import android.os.Process
+import com.topjohnwu.superuser.ipc.RootService
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Converts broad scan snapshots into the exact immutable candidate set selected by the user.
+ *
+ * The service never discovers new paths. It only removes unselected candidates from the two
+ * already-authorized snapshots and commits both snapshot changes as one rollback-capable operation.
+ */
+class CandidatePlanRootService : RootService() {
+    private val running = AtomicBoolean(false)
+
+    private val binder = object : ICandidatePlanService.Stub() {
+        override fun ping(): String = JSONObject()
+            .put("uid", Process.myUid())
+            .put("root", Process.myUid() == 0)
+            .put("engine", "candidate-plan-v1")
+            .put("running", running.get())
+            .toString()
+
+        override fun finalizePlan(
+            cacheSnapshotId: String?,
+            safeSnapshotId: String?,
+            selectionJson: String?
+        ): String {
+            if (!running.compareAndSet(false, true)) {
+                return error("busy", "正在固化另一份清理计划")
+            }
+            return try {
+                finalizePlanInternal(
+                    cacheSnapshotId.orEmpty().trim(),
+                    safeSnapshotId.orEmpty().trim(),
+                    selectionJson.orEmpty()
+                )
+            } catch (throwable: Throwable) {
+                error("selection_finalize_failed", throwable.message ?: throwable.javaClass.simpleName)
+            } finally {
+                running.set(false)
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+
+    private data class CacheItem(
+        val packageName: String,
+        val category: String,
+        val files: Long,
+        val bytes: Long,
+        val directories: Long,
+        val path: String
+    ) {
+        val id: String get() = "cache:$path"
+
+        fun row(): String = listOf(
+            packageName,
+            category,
+            files.toString(),
+            bytes.toString(),
+            directories.toString(),
+            path
+        ).joinToString("\t")
+    }
+
+    private data class CacheStage(
+        val directory: File,
+        val oldSnapshotId: String,
+        val newSnapshotId: String,
+        val selectedCount: Int,
+        val selectedBytes: Long,
+        val removeSnapshot: Boolean,
+        val originals: List<File>,
+        var committed: Boolean = false
+    )
+
+    private data class SafeStage(
+        val directory: File,
+        val oldFile: File?,
+        val newFile: File?,
+        val oldSnapshotId: String,
+        val newSnapshotId: String,
+        val selectedCount: Int,
+        val selectedBytes: Long,
+        val categoryCounts: JSONObject,
+        val riskCounts: JSONObject,
+        var committed: Boolean = false
+    )
+
+    private fun finalizePlanInternal(cacheId: String, safeId: String, rawSelection: String): String {
+        val selection = runCatching { JSONObject(rawSelection) }.getOrElse {
+            return error("invalid_selection", "候选选择数据无效")
+        }
+        val selectAllSafe = selection.optBoolean("__all_safe__", false)
+        if (!selectAllSafe) return error("selection_required", "必须明确授权候选项目")
+        val excluded = jsonStrings(selection.optJSONArray("__exclude__"))
+
+        val token = UUID.randomUUID().toString()
+        val root = File(RootPaths.STATE_DIR, "candidate-plan-stage/$token").apply { mkdirs() }
+        var cacheStage: CacheStage? = null
+        var safeStage: SafeStage? = null
+        try {
+            cacheStage = prepareCache(root, cacheId, excluded)
+            safeStage = prepareSafe(root, safeId, excluded)
+            val selected = (cacheStage?.selectedCount ?: 0) + (safeStage?.selectedCount ?: 0)
+            if (selected <= 0) return error("empty_selection", "当前没有选中任何可清理项目")
+
+            cacheStage?.let(::commitCache)
+            try {
+                safeStage?.let(::commitSafe)
+            } catch (throwable: Throwable) {
+                cacheStage?.let(::rollbackCache)
+                throw throwable
+            }
+
+            return JSONObject()
+                .put("success", true)
+                .put("schema", "candidate-plan-v1")
+                .put("cacheSnapshotId", cacheStage?.newSnapshotId.orEmpty())
+                .put("cacheCount", cacheStage?.selectedCount ?: 0)
+                .put("cacheBytes", cacheStage?.selectedBytes ?: 0L)
+                .put("safeSnapshotId", safeStage?.newSnapshotId.orEmpty())
+                .put("safeCount", safeStage?.selectedCount ?: 0)
+                .put("safeBytes", safeStage?.selectedBytes ?: 0L)
+                .put("selectedCount", selected)
+                .put("selectedBytes", (cacheStage?.selectedBytes ?: 0L) + (safeStage?.selectedBytes ?: 0L))
+                .put("categoryCounts", safeStage?.categoryCounts ?: JSONObject())
+                .put("riskCounts", safeStage?.riskCounts ?: JSONObject())
+                .toString()
+        } finally {
+            if (safeStage?.committed != true) safeStage?.let(::rollbackSafe)
+            if (cacheStage?.committed != true) cacheStage?.let(::rollbackCache)
+            root.deleteRecursively()
+        }
+    }
+
+    private fun prepareCache(root: File, snapshotId: String, excluded: Set<String>): CacheStage? {
+        if (snapshotId.isBlank()) return null
+        val stateDir = File(RootPaths.STATE_DIR)
+        val state = File(stateDir, "cache_scan.env")
+        val targets = File(stateDir, "cache_scan.targets")
+        val items = File(stateDir, "cache_scan.items.tsv")
+        val manifest = File(stateDir, "cache_scan.manifest0")
+        val originals = listOf(state, targets, items, manifest)
+        if (originals.any { !it.isFile }) throw IllegalStateException("缓存快照文件不完整")
+
+        val env = readEnv(state)
+        val epoch = env["epoch"]?.toLongOrNull() ?: 0L
+        if (env["snapshot_id"].orEmpty() != snapshotId ||
+            epoch <= 0L ||
+            System.currentTimeMillis() / 1000L - epoch !in 0L..SNAPSHOT_TTL_SECONDS
+        ) {
+            throw IllegalStateException("缓存快照已过期或发生变化")
+        }
+        requireHash(targets, env["targets_sha"], "缓存目标")
+        requireHash(items, env["items_sha"], "缓存摘要")
+        requireHash(manifest, env["manifest_sha"], "缓存逐文件清单")
+
+        val parsed = parseCacheItems(items)
+        val selected = parsed.filterNot { it.id in excluded || it.path in excluded }
+        val selectedRoots = selected.mapTo(HashSet()) { it.path.trimEnd('/') }
+        val stage = File(root, "cache").apply { mkdirs() }
+        val stageTargets = File(stage, targets.name)
+        val stageItems = File(stage, items.name)
+        val stageManifest = File(stage, manifest.name)
+        val stageState = File(stage, state.name)
+
+        if (selected.isEmpty()) {
+            return CacheStage(
+                directory = stage,
+                oldSnapshotId = snapshotId,
+                newSnapshotId = "",
+                selectedCount = 0,
+                selectedBytes = 0L,
+                removeSnapshot = true,
+                originals = originals
+            )
+        }
+
+        stageTargets.bufferedWriter().use { writer ->
+            selected.forEach { writer.appendLine(it.path) }
+        }
+        stageItems.bufferedWriter().use { writer ->
+            writer.appendLine("package\tcategory\tfiles\tbytes\tdirectories\tpath")
+            selected.forEach { writer.appendLine(it.row()) }
+        }
+
+        var manifestItems = 0L
+        BufferedInputStream(FileInputStream(manifest), 64 * 1024).use { input ->
+            BufferedOutputStream(FileOutputStream(stageManifest), 64 * 1024).use { output ->
+                while (true) {
+                    val record = readManifestRecord(input) ?: break
+                    val path = record[MANIFEST_PATH_INDEX].toString(Charsets.UTF_8)
+                    if (underSelectedRoot(path, selectedRoots)) {
+                        record.forEach { field ->
+                            output.write(field)
+                            output.write(0)
+                        }
+                        manifestItems += 1L
+                    }
+                }
+            }
+        }
+
+        val expectedFiles = selected.sumOf { it.files }
+        if (manifestItems <= 0L || manifestItems != expectedFiles) {
+            throw IllegalStateException("缓存候选与逐文件清单不一致：候选 $expectedFiles，清单 $manifestItems")
+        }
+
+        val manifestSha = sha256(stageManifest)
+        val newSnapshotId = "$epoch-${manifestSha.take(16)}"
+        env["snapshot_id"] = newSnapshotId
+        env["targets_sha"] = sha256(stageTargets)
+        env["items_sha"] = sha256(stageItems)
+        env["manifest_sha"] = manifestSha
+        env["manifest_format"] = "nul-v2"
+        env["manifest_items"] = manifestItems.toString()
+        env["bytes"] = selected.sumOf { it.bytes }.toString()
+        env["files"] = manifestItems.toString()
+        env["items"] = selected.size.toString()
+        env["targets"] = selected.size.toString()
+        writeEnv(stageState, env)
+        listOf(stageState, stageTargets, stageItems, stageManifest).forEach(::ownerOnly)
+
+        return CacheStage(
+            directory = stage,
+            oldSnapshotId = snapshotId,
+            newSnapshotId = newSnapshotId,
+            selectedCount = selected.size,
+            selectedBytes = selected.sumOf { it.bytes },
+            removeSnapshot = false,
+            originals = originals
+        )
+    }
+
+    private fun prepareSafe(root: File, snapshotId: String, excluded: Set<String>): SafeStage? {
+        if (snapshotId.isBlank()) return null
+        val normalized = runCatching { UUID.fromString(snapshotId).toString() }.getOrElse {
+            throw IllegalStateException("安全项目快照标识无效")
+        }
+        val snapshots = File(RootPaths.STATE_DIR, "profile-snapshots").apply { mkdirs() }
+        val oldFile = File(snapshots, "$normalized.json")
+        if (!oldFile.isFile) throw IllegalStateException("安全项目快照不存在或已过期")
+        val source = runCatching { JSONObject(oldFile.readText()) }.getOrElse {
+            throw IllegalStateException("安全项目快照损坏")
+        }
+        val createdAt = source.optLong("createdAt", 0L)
+        if (source.optInt("version", 0) != SAFE_SNAPSHOT_VERSION ||
+            source.optString("snapshotId") != normalized ||
+            createdAt <= 0L ||
+            System.currentTimeMillis() - createdAt !in 0L..SAFE_SNAPSHOT_TTL_MS
+        ) {
+            throw IllegalStateException("安全项目快照已过期")
+        }
+
+        val sourceItems = source.optJSONArray("items") ?: JSONArray()
+        val selectedItems = JSONArray()
+        var selectedBytes = 0L
+        val categoryCounts = JSONObject()
+        val riskCounts = JSONObject()
+        for (index in 0 until sourceItems.length()) {
+            val item = sourceItems.optJSONObject(index) ?: continue
+            val risk = item.optString("risk")
+            val id = item.optString("id")
+            val path = item.optString("path")
+            val allowed = risk == "low" || risk == "medium"
+            val rejected = id in excluded || path in excluded || "safe:$id" in excluded
+            if (!allowed || rejected) continue
+            selectedItems.put(item)
+            selectedBytes += item.optLong("bytes", 0L).coerceAtLeast(0L)
+            increment(categoryCounts, item.optString("category", "other"))
+            increment(riskCounts, risk.ifBlank { "low" })
+        }
+
+        val stage = File(root, "safe").apply { mkdirs() }
+        val backup = File(stage, "original.json")
+        oldFile.copyTo(backup, overwrite = true)
+        if (selectedItems.length() == 0) {
+            return SafeStage(
+                directory = stage,
+                oldFile = oldFile,
+                newFile = null,
+                oldSnapshotId = snapshotId,
+                newSnapshotId = "",
+                selectedCount = 0,
+                selectedBytes = 0L,
+                categoryCounts = categoryCounts,
+                riskCounts = riskCounts
+            )
+        }
+
+        val newId = UUID.randomUUID().toString()
+        val payload = JSONObject(source.toString())
+            .put("snapshotId", newId)
+            .put("items", selectedItems)
+            .put(
+                "summary",
+                JSONObject(source.optJSONObject("summary")?.toString() ?: "{}")
+                    .put("snapshotId", newId)
+                    .put("totalCandidates", selectedItems.length())
+                    .put("low", riskCounts.optInt("low"))
+                    .put("medium", riskCounts.optInt("medium"))
+                    .put("high", 0)
+                    .put("critical", 0)
+                    .put("knownBytes", selectedBytes)
+            )
+        val staged = File(stage, "$newId.json")
+        staged.writeText(payload.toString())
+        ownerOnly(staged)
+        return SafeStage(
+            directory = stage,
+            oldFile = oldFile,
+            newFile = staged,
+            oldSnapshotId = snapshotId,
+            newSnapshotId = newId,
+            selectedCount = selectedItems.length(),
+            selectedBytes = selectedBytes,
+            categoryCounts = categoryCounts,
+            riskCounts = riskCounts
+        )
+    }
+
+    private fun commitCache(stage: CacheStage) {
+        val backup = File(stage.directory, "backup").apply { mkdirs() }
+        stage.originals.forEach { source ->
+            source.copyTo(File(backup, source.name), overwrite = true)
+        }
+        try {
+            if (stage.removeSnapshot) {
+                stage.originals.forEach { it.delete() }
+            } else {
+                val ordered = stage.originals.filter { it.name != "cache_scan.env" } +
+                    stage.originals.first { it.name == "cache_scan.env" }
+                ordered.forEach { destination ->
+                    val source = File(stage.directory, destination.name)
+                    replaceFile(source, destination)
+                }
+            }
+            stage.committed = true
+        } catch (throwable: Throwable) {
+            rollbackCache(stage)
+            throw throwable
+        }
+    }
+
+    private fun rollbackCache(stage: CacheStage) {
+        val backup = File(stage.directory, "backup")
+        if (!backup.isDirectory) return
+        stage.originals.forEach { destination ->
+            val source = File(backup, destination.name)
+            if (source.isFile) replaceFile(source, destination) else destination.delete()
+        }
+        stage.committed = false
+    }
+
+    private fun commitSafe(stage: SafeStage) {
+        try {
+            val old = stage.oldFile
+            val staged = stage.newFile
+            if (staged == null) {
+                old?.delete()
+            } else {
+                val destination = File(old?.parentFile ?: File(RootPaths.STATE_DIR, "profile-snapshots"), staged.name)
+                replaceFile(staged, destination)
+                if (old != null && old != destination) old.delete()
+            }
+            stage.committed = true
+        } catch (throwable: Throwable) {
+            rollbackSafe(stage)
+            throw throwable
+        }
+    }
+
+    private fun rollbackSafe(stage: SafeStage) {
+        val backup = File(stage.directory, "original.json")
+        val old = stage.oldFile
+        if (old != null && backup.isFile) replaceFile(backup, old)
+        if (stage.newSnapshotId.isNotBlank()) {
+            File(old?.parentFile ?: File(RootPaths.STATE_DIR, "profile-snapshots"), "${stage.newSnapshotId}.json").delete()
+        }
+        stage.committed = false
+    }
+
+    private fun parseCacheItems(file: File): List<CacheItem> = buildList {
+        file.forEachLine { raw ->
+            val columns = raw.split('\t', limit = 6)
+            if (columns.size < 6 || columns[0] == "package") return@forEachLine
+            val packageName = columns[0].trim()
+            val path = columns[5].trim()
+            if (packageName.isBlank() || !path.startsWith("/")) return@forEachLine
+            add(
+                CacheItem(
+                    packageName = packageName,
+                    category = columns[1].trim(),
+                    files = columns[2].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                    bytes = columns[3].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                    directories = columns[4].toLongOrNull()?.coerceAtLeast(0L) ?: 0L,
+                    path = path
+                )
+            )
+        }
+    }
+
+    private fun readManifestRecord(input: BufferedInputStream): List<ByteArray>? {
+        val first = readNulField(input) ?: return null
+        val fields = ArrayList<ByteArray>(MANIFEST_FIELDS)
+        fields += first
+        repeat(MANIFEST_FIELDS - 1) {
+            fields += readNulField(input) ?: throw IllegalStateException("缓存清单记录不完整")
+        }
+        return fields
+    }
+
+    private fun readNulField(input: BufferedInputStream): ByteArray? {
+        val output = ByteArrayOutputStream(128)
+        while (true) {
+            val value = input.read()
+            if (value < 0) return if (output.size() == 0) null else throw IllegalStateException("缓存清单字段未结束")
+            if (value == 0) return output.toByteArray()
+            if (output.size() >= MAX_MANIFEST_FIELD_BYTES) throw IllegalStateException("缓存清单字段过长")
+            output.write(value)
+        }
+    }
+
+    private fun underSelectedRoot(path: String, roots: Set<String>): Boolean {
+        var current = path.trimEnd('/')
+        while (current.isNotEmpty()) {
+            if (current in roots) return true
+            val slash = current.lastIndexOf('/')
+            if (slash <= 0) return "/" in roots
+            current = current.substring(0, slash)
+        }
+        return false
+    }
+
+    private fun readEnv(file: File): LinkedHashMap<String, String> {
+        val result = LinkedHashMap<String, String>()
+        file.forEachLine { raw ->
+            val index = raw.indexOf('=')
+            if (index > 0) result[raw.substring(0, index)] = raw.substring(index + 1)
+        }
+        return result
+    }
+
+    private fun writeEnv(file: File, values: Map<String, String>) {
+        file.bufferedWriter().use { writer ->
+            values.forEach { (key, value) ->
+                writer.append(key).append('=').append(value.replace('\n', ' ').replace('\r', ' ')).append('\n')
+            }
+        }
+    }
+
+    private fun requireHash(file: File, expected: String?, label: String) {
+        if (expected.isNullOrBlank() || sha256(file) != expected) {
+            throw IllegalStateException("$label 快照校验失败")
+        }
+    }
+
+    private fun replaceFile(source: File, destination: File) {
+        destination.parentFile?.mkdirs()
+        val temporary = File(destination.parentFile, ".${destination.name}.${System.nanoTime()}.tmp")
+        source.copyTo(temporary, overwrite = true)
+        ownerOnly(temporary)
+        if (destination.exists() && !destination.delete()) {
+            temporary.delete()
+            throw IllegalStateException("无法替换 ${destination.name}")
+        }
+        if (!temporary.renameTo(destination)) {
+            temporary.delete()
+            throw IllegalStateException("无法提交 ${destination.name}")
+        }
+    }
+
+    private fun ownerOnly(file: File) {
+        file.setReadable(false, false)
+        file.setWritable(false, false)
+        file.setExecutable(false, false)
+        file.setReadable(true, true)
+        file.setWritable(true, true)
+    }
+
+    private fun sha256(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        FileInputStream(file).use { input ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val count = input.read(buffer)
+                if (count <= 0) break
+                digest.update(buffer, 0, count)
+            }
+        }
+        return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun jsonStrings(array: JSONArray?): Set<String> {
+        val result = LinkedHashSet<String>()
+        if (array == null) return result
+        for (index in 0 until array.length()) {
+            array.optString(index).trim().takeIf { it.isNotBlank() }?.let(result::add)
+        }
+        return result
+    }
+
+    private fun increment(target: JSONObject, key: String) {
+        target.put(key, target.optInt(key, 0) + 1)
+    }
+
+    private fun error(code: String, message: String): String = JSONObject()
+        .put("error", code)
+        .put("message", message)
+        .toString()
+
+    companion object {
+        private const val SNAPSHOT_TTL_SECONDS = 30L * 60L
+        private const val SAFE_SNAPSHOT_TTL_MS = 30L * 60_000L
+        private const val SAFE_SNAPSHOT_VERSION = 1
+        private const val MANIFEST_FIELDS = 10
+        private const val MANIFEST_PATH_INDEX = 9
+        private const val MAX_MANIFEST_FIELD_BYTES = 16 * 1024
+    }
+}

--- a/v2/tests/test-candidate-selection-plan.py
+++ b/v2/tests/test-candidate-selection-plan.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
+ACTIVITY = (APP / "CandidateSmartScanActivity.kt").read_text(encoding="utf-8")
+SERVICE = (APP / "root/CandidatePlanRootService.kt").read_text(encoding="utf-8")
+AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICandidatePlanService.aidl").read_text(encoding="utf-8")
+MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+require('android:name=".CandidateSmartScanActivity"' in MANIFEST, "candidate selection activity is not registered")
+require('android:targetActivity=".CandidateSmartScanActivity"' in MANIFEST,
+        "smart scan entry must route through candidate selection")
+require('android:name=".root.CandidatePlanRootService"' in MANIFEST,
+        "candidate plan Root service is not registered")
+require("finalizePlan" in AIDL, "candidate plan binder method is missing")
+
+for marker in (
+    "loadAllPages", "getResultPage", "getPage", "按应用", "按类别",
+    "excludedCandidateIds", "__exclude__", "toggleCandidate", "toggleGroup",
+    "生成计划并进入清理", "仅锁定最终计划"
+):
+    require(marker in ACTIVITY, f"candidate selection UI contract is missing: {marker}")
+
+finalize_start = ACTIVITY.index("private fun finalizeSelection")
+finalize_end = ACTIVITY.index("private fun openResumableClean", finalize_start)
+finalize_path = ACTIVITY[finalize_start:finalize_end]
+require("finalizePlan(" in finalize_path, "final selection must be committed by the Root service")
+require("scanCandidates(" not in finalize_path and "scanSafe(" not in finalize_path,
+        "finalizing a selection must never start discovery")
+require("ResumableSmartScanActivity::class.java" in ACTIVITY,
+        "final candidate plan must hand off to the verified resumable cleaner")
+
+for marker in (
+    "candidate-plan-stage", "prepareCache", "prepareSafe", "commitCache", "rollbackCache",
+    "commitSafe", "rollbackSafe", "cache_scan.manifest0", "profile-snapshots",
+    "MANIFEST_FIELDS = 10", "underSelectedRoot", "snapshot_id", "manifest_sha"
+):
+    require(marker in SERVICE, f"Root candidate-plan transaction is missing: {marker}")
+
+require("scanCandidates(" not in SERVICE and "scanSafe(" not in SERVICE and "engine.scan(" not in SERVICE,
+        "candidate plan service must only reduce existing snapshots, never discover paths")
+require("selectedItems.put(item)" in SERVICE, "safe snapshot must be reduced to explicit candidates")
+require("manifestItems != expectedFiles" in SERVICE,
+        "cache manifest and selected candidate file counts must be cross-checked")
+require("selected <= 0" in SERVICE and "empty_selection" in SERVICE,
+        "empty candidate plans must be rejected")
+
+print("candidate selection plan contract: ok")

--- a/v2/tests/test-clean-plan-persistence.py
+++ b/v2/tests/test-clean-plan-persistence.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import runpy
 from pathlib import Path
 
 # This test intentionally inspects the call path: a clean action may consume snapshots, but it may
@@ -7,6 +8,7 @@ ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
 ACTIVITY = (APP / "PersistentSmartScanActivity.kt").read_text(encoding="utf-8")
 RESUMABLE = (APP / "ResumableSmartScanActivity.kt").read_text(encoding="utf-8")
+CANDIDATE = (APP / "CandidateSmartScanActivity.kt").read_text(encoding="utf-8")
 SERVICE = (APP / "root/PersistentCleanPlanRootService.kt").read_text(encoding="utf-8")
 MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
 AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IPersistentCleanPlanService.aidl").read_text(encoding="utf-8")
@@ -53,15 +55,19 @@ require("engine.scan(" not in SERVICE[SERVICE.index("private fun cleanPersistedS
 
 require('android:name=".PersistentSmartScanActivity"' in MANIFEST, "persistent activity is not registered")
 require('android:name=".ResumableSmartScanActivity"' in MANIFEST, "resumable activity is not registered")
+require('android:name=".CandidateSmartScanActivity"' in MANIFEST, "candidate activity is not registered")
 require('android:name=".SmartScanActivity"' in MANIFEST, "legacy component alias is missing")
-require('android:targetActivity=".ResumableSmartScanActivity"' in MANIFEST,
-        "legacy smart-scan entry must route to the latest resumable activity")
+require('android:targetActivity=".CandidateSmartScanActivity"' in MANIFEST,
+        "smart-scan entry must route through the candidate plan stage")
 require('android:name=".root.PersistentCleanPlanRootService"' in MANIFEST,
         "persistent root service is not registered")
 require("PersistentCleanPlanRootService" in RESUMABLE and "IPersistentCleanPlanService" in RESUMABLE,
         "resumable flow must keep using the persisted safe snapshot engine")
+require("ResumableSmartScanActivity::class.java" in CANDIDATE,
+        "candidate stage must hand finalized plans to the resumable cleaner")
 
 for method in ("scanSafe", "getPage", "cleanSafe", "getTaskState", "cancelCurrentTask"):
     require(method in AIDL, f"binder method missing: {method}")
 
+runpy.run_path(str(ROOT / "v2/tests/test-candidate-selection-plan.py"), run_name="__main__")
 print("clean plan persistence contract: ok")

--- a/v2/tests/test-clean-plan-resume.py
+++ b/v2/tests/test-clean-plan-resume.py
@@ -4,6 +4,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
 ACTIVITY = (APP / "ResumableSmartScanActivity.kt").read_text(encoding="utf-8")
+CANDIDATE = (APP / "CandidateSmartScanActivity.kt").read_text(encoding="utf-8")
 SERVICE = (APP / "root/CleanPlanResumeRootService.kt").read_text(encoding="utf-8")
 MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
 AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanPlanResumeService.aidl").read_text(encoding="utf-8")
@@ -50,7 +51,10 @@ for marker in (
 require('JSONObject(response(state)).put("recovered", true)' in SERVICE,
         "recover must return the transaction payload with its recovered flag")
 require('android:name=".ResumableSmartScanActivity"' in MANIFEST, "resume activity is not registered")
-require('android:targetActivity=".ResumableSmartScanActivity"' in MANIFEST, "smart scan alias does not use resume flow")
+require('android:targetActivity=".CandidateSmartScanActivity"' in MANIFEST,
+        "smart scan alias must enter candidate selection before resume")
+require("ResumableSmartScanActivity::class.java" in CANDIDATE,
+        "candidate selection must hand finalized snapshots to resume flow")
 require('android:name=".root.CleanPlanResumeRootService"' in MANIFEST, "resume Root service is not registered")
 
 for method in ("begin", "checkpointCache", "checkpointSafe", "recover", "finish"):


### PR DESCRIPTION
## 第四阶段：候选浏览与最终清理计划

- 智能扫描后分页读取缓存与安全项目候选，不重新扫描。
- 支持按应用、按类别分组展开，查看路径、大小、文件数、风险等级与备注。
- 默认选择全部低/中风险安全候选，可逐项、整组、全选或全不选。
- 使用排除集合持久化用户选择，页面重建后保持勾选状态。
- 在 Root 侧原子裁剪缓存 NUL 清单与安全项目快照，未选择项目不会进入清理事务。
- 缓存快照重新计算目标、摘要、逐文件清单 SHA 与快照 ID，并校验候选文件数和 NUL 清单记录数一致。
- 安全项目生成新的只读派生快照，只保留明确选中的低/中风险候选。
- 固化完成后交给 v2.4.1 已验证的可恢复清理页面，停止、异常退出与继续清理仍只消费最终快照。
- 最终计划固化路径禁止调用任何扫描接口；缓存与安全快照任一提交失败都会回滚。
- 空选择会被拒绝，不会产生可执行清理计划。

## 堆叠关系

本 PR 基于 v2.4.1 发布候选 `release/v2.4.1`，当前已整理为 1 个干净提交、7 个第四阶段文件。

## 验证结果

完整工作流 `BaiZe v2.4.1 Verify and Release #42` 已全部通过：

- 候选选择与快照裁剪契约：通过
- 清理计划持久化、断点恢复与真实统计回归：通过
- Root Shell、调度公平性、增量索引和归类事务回归：通过
- Android Release、Debug Kotlin、Lint 和 Macrobenchmark：通过
- ARM64 原生扫描器：通过
- 模块封包、内置 APK 一致性和签名产物校验：通过

最终分支仅保留：Manifest、候选计划 AIDL、候选选择页、Root 固化服务和 3 个契约测试文件。