### PR TITLE
feat(result): add explainable before-after clean reports

### DIFF
--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity android:name=".PersistentSmartScanActivity" android:exported="false" />
         <activity android:name=".ResumableSmartScanActivity" android:exported="false" />
         <activity android:name=".CandidateSmartScanActivity" android:exported="false" />
+        <activity android:name=".CleanResultActivity" android:exported="false" />
         <activity-alias
             android:name=".SmartScanActivity"
             android:exported="false"
@@ -70,6 +71,10 @@
             tools:ignore="Instantiatable" />
         <service
             android:name=".root.CandidatePlanRootService"
+            android:exported="false"
+            tools:ignore="Instantiatable" />
+        <service
+            android:name=".root.CleanResultRootService"
             android:exported="false"
             tools:ignore="Instantiatable" />
     </application>

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanResultService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanResultService.aidl
@@ -1,0 +1,9 @@
+package io.github.xgl34222220.baize.root;
+
+interface ICleanResultService {
+    String ping();
+    String registerPlan(String planId, int authorizedCandidates, long estimatedBytes);
+    String archive(String planId);
+    String getSummary(String reportId);
+    String getPage(String reportId, int offset, int limit, String filterJson);
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanResultActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanResultActivity.kt
@@ -1,0 +1,442 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.IBinder
+import android.text.format.Formatter
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.CleanResultRootService
+import io.github.xgl34222220.baize.root.ICleanResultService
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+/** Stage five read-only result viewer. */
+class CleanResultActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private val preferences by lazy { getSharedPreferences("baize_v2", MODE_PRIVATE) }
+    private var service: ICleanResultService? = null
+    private var binding = false
+    private var reportId = ""
+    private var state by mutableStateOf(CleanResultUiState())
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            service = ICleanResultService.Stub.asInterface(binder)
+            binding = true
+            state = state.copy(connected = true, status = "清理报告引擎已连接")
+            loadReport(reset = true)
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            service = null
+            binding = false
+            state = state.copy(connected = false, status = "清理报告引擎连接已断开")
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        reportId = intent.getStringExtra(EXTRA_REPORT_ID).orEmpty()
+            .ifBlank { preferences.getString(PREF_LAST_REPORT_ID, "").orEmpty() }
+        setContent {
+            val appearance by appearanceViewModel.settings.collectAsState()
+            BaiZeTheme(appearance) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    CleanResultScreen(
+                        state = state,
+                        onBack = ::finish,
+                        onReconnect = ::bindService,
+                        onRefresh = { loadReport(reset = true) },
+                        onAction = ::selectAction,
+                        onLoadMore = { loadReport(reset = false) }
+                    )
+                }
+            }
+        }
+        bindService()
+    }
+
+    private fun bindService() {
+        if (service != null || binding) return
+        runCatching {
+            RootService.bind(
+                Intent(this, CleanResultRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                connection
+            )
+            binding = true
+            state = state.copy(status = "正在连接清理报告引擎…")
+        }.onFailure {
+            binding = false
+            state = state.copy(status = "清理报告引擎启动失败：${it.message}")
+        }
+    }
+
+    private fun selectAction(action: String) {
+        if (state.action == action || state.loading) return
+        state = state.copy(action = action)
+        loadReport(reset = true)
+    }
+
+    private fun loadReport(reset: Boolean) {
+        val resultService = service ?: return
+        if (state.loading) return
+        val offset = if (reset) 0 else state.items.size
+        state = state.copy(loading = true, message = if (reset) "正在读取清理报告…" else "正在加载更多结果…")
+        lifecycleScope.launch {
+            try {
+                val (summary, page) = withContext(Dispatchers.IO) {
+                    val summaryJson = JSONObject(resultService.getSummary(reportId.ifBlank { "latest" }))
+                    if (summaryJson.has("error")) throw IllegalStateException(summaryJson.optString("message"))
+                    val resolvedId = summaryJson.optString("reportId")
+                    val filters = JSONObject().put("action", state.action)
+                    val pageJson = JSONObject(resultService.getPage(resolvedId, offset, PAGE_SIZE, filters.toString()))
+                    if (pageJson.has("error")) throw IllegalStateException(pageJson.optString("message"))
+                    summaryJson to pageJson
+                }
+                reportId = summary.optString("reportId", reportId)
+                if (reportId.isNotBlank()) preferences.edit().putString(PREF_LAST_REPORT_ID, reportId).apply()
+                val parsed = parseItems(page.optJSONArray("items"))
+                state = state.copy(
+                    connected = true,
+                    loading = false,
+                    status = if (summary.optBoolean("live")) "清理事务实时报告" else "已归档清理报告",
+                    message = if (page.optInt("total") == 0) "当前筛选下没有结果" else "共 ${page.optInt("total")} 项结果",
+                    reportId = reportId,
+                    authorizedCandidates = summary.optInt("authorizedCandidates").coerceAtLeast(0),
+                    processedCandidates = summary.optInt("processedCandidates").coerceAtLeast(0),
+                    remainingCandidates = summary.optInt("remainingCandidates").coerceAtLeast(0),
+                    cleanedCandidates = summary.optInt("cleanedCandidates").coerceAtLeast(0),
+                    changedCandidates = summary.optInt("changedCandidates").coerceAtLeast(0),
+                    protectedCandidates = summary.optInt("protectedCandidates").coerceAtLeast(0),
+                    partialCandidates = summary.optInt("partialCandidates").coerceAtLeast(0),
+                    failedCandidates = summary.optInt("failedCandidates").coerceAtLeast(0),
+                    estimatedBytes = summary.optLong("estimatedBytes").coerceAtLeast(0L),
+                    deletedBytes = summary.optLong("actualDeletedBytes", summary.optLong("deletedBytes")).coerceAtLeast(0L),
+                    completionPercent = summary.optInt("completionPercent").coerceIn(0, 100),
+                    spaceRecoveryPercent = summary.optInt("spaceRecoveryPercent").coerceAtLeast(0),
+                    items = if (reset) parsed else state.items + parsed,
+                    totalItems = page.optInt("total").coerceAtLeast(0),
+                    hasMore = page.optBoolean("hasMore")
+                )
+            } catch (throwable: Throwable) {
+                state = state.copy(loading = false, message = "清理报告读取失败：${throwable.message ?: throwable.javaClass.simpleName}")
+            }
+        }
+    }
+
+    private fun parseItems(array: JSONArray?): List<CleanResultItem> {
+        if (array == null) return emptyList()
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                add(
+                    CleanResultItem(
+                        id = item.optString("id", item.optString("path")),
+                        path = item.optString("path"),
+                        category = item.optString("category", "other"),
+                        risk = item.optString("risk", "low"),
+                        action = item.optString("action", "changed"),
+                        reason = item.optString("reason"),
+                        estimatedBytes = item.optLong("estimatedBytes").coerceAtLeast(0L),
+                        deletedBytes = item.optLong("deletedBytes").coerceAtLeast(0L),
+                        deletedFiles = item.optLong("deletedFiles").coerceAtLeast(0L),
+                        deletedDirectories = item.optLong("deletedDirectories").coerceAtLeast(0L)
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        if (binding) runCatching { RootService.unbind(connection) }
+        super.onDestroy()
+    }
+
+    companion object {
+        const val EXTRA_REPORT_ID = "reportId"
+        private const val PREF_LAST_REPORT_ID = "last_clean_result_id"
+        private const val PAGE_SIZE = 60
+    }
+}
+
+private data class CleanResultItem(
+    val id: String,
+    val path: String,
+    val category: String,
+    val risk: String,
+    val action: String,
+    val reason: String,
+    val estimatedBytes: Long,
+    val deletedBytes: Long,
+    val deletedFiles: Long,
+    val deletedDirectories: Long
+)
+
+private data class CleanResultUiState(
+    val connected: Boolean = false,
+    val loading: Boolean = false,
+    val status: String = "正在连接清理报告引擎…",
+    val message: String = "等待读取最近一次清理报告",
+    val reportId: String = "",
+    val action: String = "all",
+    val authorizedCandidates: Int = 0,
+    val processedCandidates: Int = 0,
+    val remainingCandidates: Int = 0,
+    val cleanedCandidates: Int = 0,
+    val changedCandidates: Int = 0,
+    val protectedCandidates: Int = 0,
+    val partialCandidates: Int = 0,
+    val failedCandidates: Int = 0,
+    val estimatedBytes: Long = 0L,
+    val deletedBytes: Long = 0L,
+    val completionPercent: Int = 0,
+    val spaceRecoveryPercent: Int = 0,
+    val items: List<CleanResultItem> = emptyList(),
+    val totalItems: Int = 0,
+    val hasMore: Boolean = false
+)
+
+@Composable
+private fun CleanResultScreen(
+    state: CleanResultUiState,
+    onBack: () -> Unit,
+    onReconnect: () -> Unit,
+    onRefresh: () -> Unit,
+    onAction: (String) -> Unit,
+    onLoadMore: () -> Unit
+) {
+    val context = LocalContext.current
+    val actions = listOf(
+        "all" to "全部",
+        "cleaned" to "已清理 ${state.cleanedCandidates}",
+        "changed" to "已变化 ${state.changedCandidates}",
+        "protected" to "受保护 ${state.protectedCandidates}",
+        "partial" to "部分 ${state.partialCandidates}",
+        "failed" to "失败 ${state.failedCandidates}"
+    )
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 34.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("CLEAN REPORT", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+                    Text("清理报告", fontSize = 30.sp, fontWeight = FontWeight.Black)
+                    Text("清理前后对比 · 逐项结果 · 原因可追踪", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                IconButton(onClick = onRefresh, enabled = state.connected && !state.loading) {
+                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(30.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+            ) {
+                Column(modifier = Modifier.padding(22.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier.size(58.dp).background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(20.dp)),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Icon(
+                                if (state.processedCandidates > 0) Icons.Rounded.CheckCircle else Icons.Rounded.CleaningServices,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(30.dp)
+                            )
+                        }
+                        Spacer(Modifier.size(14.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(state.status, fontWeight = FontWeight.Bold)
+                            Text(state.message, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            if (state.reportId.isNotBlank()) {
+                                Text("报告 ${state.reportId.take(8)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                            }
+                        }
+                    }
+                    if (state.loading) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    if (!state.connected) {
+                        OutlinedButton(onClick = onReconnect, modifier = Modifier.fillMaxWidth()) { Text("重新连接 Root 引擎") }
+                    }
+                }
+            }
+        }
+
+        if (state.authorizedCandidates > 0 || state.processedCandidates > 0) {
+            item {
+                Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+                    Text("BEFORE / AFTER", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+                    Text("清理前后对比", fontSize = 26.sp, fontWeight = FontWeight.Black)
+                }
+            }
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                    shape = RoundedCornerShape(26.dp),
+                    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+                ) {
+                    Column(modifier = Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("计划预计 ${Formatter.formatFileSize(context, state.estimatedBytes)}", fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                        Text("实际释放 ${Formatter.formatFileSize(context, state.deletedBytes)} · 空间兑现 ${state.spaceRecoveryPercent}%", color = MaterialTheme.colorScheme.primary)
+                        Text(
+                            "授权 ${state.authorizedCandidates} 项 · 已处理 ${state.processedCandidates} 项 · 剩余 ${state.remainingCandidates} 项 · 完成度 ${state.completionPercent}%",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+            item {
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(actions, key = { it.first }) { (key, label) ->
+                        FilterChip(selected = state.action == key, onClick = { onAction(key) }, label = { Text(label) })
+                    }
+                }
+            }
+        }
+
+        items(state.items, key = { it.id + it.action }) { item ->
+            CleanResultItemCard(item)
+        }
+
+        if (state.hasMore) {
+            item {
+                Button(onClick = onLoadMore, enabled = !state.loading, modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+                    Text("加载更多 · ${state.items.size}/${state.totalItems}")
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding(),
+                shape = RoundedCornerShape(22.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+            ) {
+                Text(
+                    "“已变化”表示扫描后目标不存在或属性变化；“受保护”表示白名单、安全边界或系统保护生效；“部分”和“失败”会继续保留在断点计划中，不会被伪装成清理成功。",
+                    modifier = Modifier.padding(18.dp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                    lineHeight = 18.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CleanResultItemCard(item: CleanResultItem) {
+    val context = LocalContext.current
+    val actionLabel = when (item.action) {
+        "cleaned" -> "已清理"
+        "protected" -> "受保护"
+        "partial" -> "部分完成"
+        "failed" -> "清理失败"
+        else -> "已变化"
+    }
+    val categoryLabel = when (item.category) {
+        "cache" -> "应用缓存"
+        "empty" -> "空项目"
+        "rules" -> "规则垃圾"
+        "fragment" -> "残留碎片"
+        else -> "其他"
+    }
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(actionLabel, color = if (item.action == "failed") MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                Spacer(Modifier.weight(1f))
+                Text("$categoryLabel · ${riskLabel(item.risk)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+            }
+            Text(item.path, fontWeight = FontWeight.SemiBold, maxLines = 3, overflow = TextOverflow.Ellipsis)
+            Text(item.reason, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            Text(
+                "预计 ${Formatter.formatFileSize(context, item.estimatedBytes)} · 实际 ${Formatter.formatFileSize(context, item.deletedBytes)} · 文件 ${item.deletedFiles} · 目录 ${item.deletedDirectories}",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 11.sp
+            )
+        }
+    }
+}
+
+private fun riskLabel(value: String): String = when (value) {
+    "medium" -> "中风险"
+    "high" -> "高风险"
+    "critical" -> "关键风险"
+    else -> "低风险"
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ResumableSmartScanActivity.kt
@@ -62,8 +62,10 @@ import androidx.lifecycle.lifecycleScope
 import com.topjohnwu.superuser.ipc.RootService
 import io.github.xgl34222220.baize.root.BaiZeRootService
 import io.github.xgl34222220.baize.root.CleanPlanResumeRootService
+import io.github.xgl34222220.baize.root.CleanResultRootService
 import io.github.xgl34222220.baize.root.IBaiZeRootService
 import io.github.xgl34222220.baize.root.ICleanPlanResumeService
+import io.github.xgl34222220.baize.root.ICleanResultService
 import io.github.xgl34222220.baize.root.IPersistentCleanPlanService
 import io.github.xgl34222220.baize.root.PersistentCleanPlanRootService
 import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
@@ -81,7 +83,7 @@ import org.json.JSONObject
 import java.security.MessageDigest
 import java.util.UUID
 
-/** Smart clean with stage checkpoints and crash-safe resume. */
+/** Smart clean with stage checkpoints, crash-safe resume and explainable reports. */
 class ResumableSmartScanActivity : ComponentActivity() {
     private val appearanceViewModel: AppearanceViewModel by viewModels()
     private val preferences by lazy { getSharedPreferences("baize_v2", MODE_PRIVATE) }
@@ -89,9 +91,11 @@ class ResumableSmartScanActivity : ComponentActivity() {
     private var cacheService: IBaiZeRootService? = null
     private var planService: IPersistentCleanPlanService? = null
     private var resumeService: ICleanPlanResumeService? = null
+    private var resultService: ICleanResultService? = null
     private var cacheBindingRequested = false
     private var planBindingRequested = false
     private var resumeBindingRequested = false
+    private var resultBindingRequested = false
     private var pollJob: Job? = null
 
     private var cacheSnapshotId = ""
@@ -102,6 +106,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
     private var originalSafeCount = 0
     private var cleanPlanId = ""
     private var cleanPlanCreatedAt = 0L
+    private var authorizedBytes = 0L
+    private var lastResultId = ""
     private var runCount = 0
     private var deletedBytes = 0L
     private var deletedFiles = 0L
@@ -166,6 +172,20 @@ class ResumableSmartScanActivity : ComponentActivity() {
         }
     }
 
+    private val resultConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            resultService = ICleanResultService.Stub.asInterface(binder)
+            resultBindingRequested = true
+            updateConnectionState()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            resultService = null
+            resultBindingRequested = false
+            updateConnectionState()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -180,7 +200,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
                         onScan = ::startSmartScan,
                         onClean = { showCleanConfirm = true },
                         onStop = ::stopTask,
-                        onReconnect = ::bindServices
+                        onReconnect = ::bindServices,
+                        onReport = ::openResultReport
                     )
                     if (showCleanConfirm) {
                         AlertDialog(
@@ -256,16 +277,34 @@ class ResumableSmartScanActivity : ComponentActivity() {
                 screenState = screenState.copy(phase = "断点事务 Root 服务启动失败：${it.message}")
             }
         }
+        if (resultService == null && !resultBindingRequested) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, CleanResultRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    resultConnection
+                )
+                resultBindingRequested = true
+            }.onFailure {
+                resultBindingRequested = false
+                screenState = screenState.copy(phase = "清理报告 Root 服务启动失败：${it.message}")
+            }
+        }
         updateConnectionState()
     }
 
     private fun updateConnectionState() {
-        val readyCount = listOf(cacheService, planService, resumeService).count { it != null }
+        val readyCount = listOf(cacheService, planService, resumeService, resultService).count { it != null }
         screenState = screenState.copy(
-            connected = readyCount == 3,
-            status = if (readyCount == 3) "扫描、快照与断点事务引擎已连接" else "正在连接 Root 引擎 · $readyCount/3"
+            connected = readyCount == 4,
+            status = if (readyCount == 4) {
+                "扫描、快照、断点与报告引擎已连接"
+            } else {
+                "正在连接 Root 引擎 · $readyCount/4"
+            },
+            resultId = lastResultId
         )
-        if (readyCount == 3 && restoredPlanNeedsValidation && !validationRunning) validateRestoredPlan()
+        if (readyCount == 4 && restoredPlanNeedsValidation && !validationRunning) validateRestoredPlan()
     }
 
     private fun startSmartScan() {
@@ -273,7 +312,7 @@ class ResumableSmartScanActivity : ComponentActivity() {
         val cache = cacheService
         val plans = planService
         val transactions = resumeService
-        if (cache == null || plans == null || transactions == null) {
+        if (cache == null || plans == null || transactions == null || resultService == null) {
             screenState = screenState.copy(phase = "Root 引擎尚未全部连接，正在重新连接…")
             bindServices()
             return
@@ -286,10 +325,11 @@ class ResumableSmartScanActivity : ComponentActivity() {
             connected = true,
             running = true,
             operation = "scan",
-            status = "扫描、快照与断点事务引擎已连接",
+            status = "扫描、快照、断点与报告引擎已连接",
             phase = "正在并行生成应用缓存与安全项目清理计划…",
             progressCurrent = 0,
             progressTotal = 2,
+            resultId = lastResultId,
             cacheSummary = "正在扫描",
             safeSummary = "正在扫描"
         )
@@ -324,6 +364,10 @@ class ResumableSmartScanActivity : ComponentActivity() {
                 ).coerceAtLeast(0)
                 originalCacheCount = cacheCount
                 originalSafeCount = safeCount
+                authorizedBytes = (
+                    cacheJson.optLong("snapshotBytes", cacheJson.optLong("bytes", 0L)) +
+                        safeJson.optLong("knownBytes", 0L)
+                    ).coerceAtLeast(0L)
                 cleanPlanId = UUID.randomUUID().toString()
                 cleanPlanCreatedAt = System.currentTimeMillis()
 
@@ -344,6 +388,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     resumable = false,
                     progressCurrent = 2,
                     progressTotal = 2,
+                    estimatedBytes = authorizedBytes,
+                    resultId = lastResultId,
                     cacheSummary = if (cacheJson.has("error")) {
                         cacheJson.optString("message", "缓存扫描失败")
                     } else "$cacheCount 项 · ${cacheJson.optLong("elapsedMs")}ms",
@@ -375,7 +421,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
         val cache = cacheService
         val plans = planService
         val transactions = resumeService
-        if (cache == null || plans == null || transactions == null) {
+        val results = resultService
+        if (cache == null || plans == null || transactions == null || results == null) {
             screenState = screenState.copy(phase = "Root 引擎尚未全部连接")
             bindServices()
             return
@@ -394,6 +441,13 @@ class ResumableSmartScanActivity : ComponentActivity() {
         lifecycleScope.launch {
             var interrupted = false
             try {
+                val registered = JSONObject(withContext(Dispatchers.IO) {
+                    results.registerPlan(cleanPlanId, originalCacheCount + originalSafeCount, authorizedBytes)
+                })
+                if (registered.has("error")) {
+                    throw IllegalStateException(registered.optString("message", "无法登记清理前统计"))
+                }
+
                 val begin = JSONObject(withContext(Dispatchers.IO) {
                     transactions.begin(cleanPlanId, cacheSnapshotId, safeSnapshotId, cacheCount, safeCount)
                 })
@@ -408,11 +462,13 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     screenState = screenState.copy(phase = "正在清理应用缓存 · 已建立事务检查点")
                     val result = withContext(Dispatchers.IO) {
                         runCatching {
-                            JSONObject(cache.cleanSelected(
-                                cacheSnapshotId,
-                                selection,
-                                JSONArray(whitelist.toList().sorted()).toString()
-                            ))
+                            JSONObject(
+                                cache.cleanSelected(
+                                    cacheSnapshotId,
+                                    selection,
+                                    JSONArray(whitelist.toList().sorted()).toString()
+                                )
+                            )
                         }.getOrElse { throwableJson(it) }
                     }
                     val checkpoint = JSONObject(withContext(Dispatchers.IO) {
@@ -445,9 +501,11 @@ class ResumableSmartScanActivity : ComponentActivity() {
                 val remaining = cacheCount + safeCount
                 val elapsed = SystemClock.elapsedRealtime() - started
                 val report = buildString {
-                    append(if (remaining > 0) {
-                        if (interrupted) "清理已安全停止" else "清理部分完成"
-                    } else "清理计划执行完成")
+                    append(
+                        if (remaining > 0) {
+                            if (interrupted) "清理已安全停止" else "清理部分完成"
+                        } else "清理计划执行完成"
+                    )
                     append(" · ${elapsed}ms")
                     append("\n累计释放 ${Formatter.formatFileSize(this@ResumableSmartScanActivity, deletedBytes)}")
                     append(" · 已处理 $processedCandidates 项 · 实际清理 $cleanedCandidates 项 · 剩余 $remaining 项")
@@ -464,12 +522,21 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     .apply()
 
                 if (remaining <= 0) {
+                    val archived = JSONObject(withContext(Dispatchers.IO) { results.archive(cleanPlanId) })
+                    if (archived.has("error")) {
+                        throw IllegalStateException(archived.optString("message", "清理完成但报告归档失败"))
+                    }
+                    lastResultId = archived.optString("reportId", cleanPlanId)
+                    preferences.edit().putString(PREF_LAST_RESULT_ID, lastResultId).apply()
                     withContext(Dispatchers.IO) { runCatching { transactions.finish(cleanPlanId) } }
                     clearLocalPlan()
                 } else {
                     resumable = true
+                    lastResultId = cleanPlanId
+                    preferences.edit().putString(PREF_LAST_RESULT_ID, lastResultId).apply()
                     persistCleanPlan()
                 }
+
                 screenState = screenState.copy(
                     running = false,
                     operation = "",
@@ -490,6 +557,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     unattributedDeletedBytes = unattributedDeletedBytes,
                     categoryStats = categoryStats.toString(),
                     riskStats = riskStats.toString(),
+                    estimatedBytes = authorizedBytes,
+                    resultId = lastResultId,
                     failures = cumulativeFailures,
                     progressCurrent = (originalCacheCount + originalSafeCount - remaining).coerceAtLeast(0),
                     progressTotal = (originalCacheCount + originalSafeCount).coerceAtLeast(1),
@@ -509,6 +578,10 @@ class ResumableSmartScanActivity : ComponentActivity() {
                 if (recovered != null && !recovered.has("error")) applyTransaction(recovered)
                 val remaining = cacheCount + safeCount
                 resumable = remaining > 0
+                if (processedCandidates > 0 && cleanPlanId.isNotBlank()) {
+                    lastResultId = cleanPlanId
+                    preferences.edit().putString(PREF_LAST_RESULT_ID, lastResultId).apply()
+                }
                 if (remaining > 0) persistCleanPlan()
                 screenState = screenState.copy(
                     running = false,
@@ -520,7 +593,14 @@ class ResumableSmartScanActivity : ComponentActivity() {
                     resumable = remaining > 0,
                     runCount = runCount,
                     deletedBytes = deletedBytes,
+                    processedCandidates = processedCandidates,
                     cleanedCandidates = cleanedCandidates,
+                    changedCandidates = changedCandidates,
+                    protectedCandidates = protectedCandidates,
+                    partialCandidates = partialCandidates,
+                    failedCandidates = failedCandidates,
+                    estimatedBytes = authorizedBytes,
+                    resultId = lastResultId,
                     failures = cumulativeFailures,
                     cacheSummary = "应用缓存剩余 $cacheCount 项",
                     safeSummary = "安全项目剩余 $safeCount 项"
@@ -531,6 +611,18 @@ class ResumableSmartScanActivity : ComponentActivity() {
                 updateConnectionState()
             }
         }
+    }
+
+    private fun openResultReport() {
+        val id = lastResultId.ifBlank { cleanPlanId }
+        if (id.isBlank()) {
+            screenState = screenState.copy(phase = "当前还没有可查看的逐项清理结果")
+            return
+        }
+        startActivity(
+            Intent(this, CleanResultActivity::class.java)
+                .putExtra(CleanResultActivity.EXTRA_REPORT_ID, id)
+        )
     }
 
     private fun stopTask() {
@@ -586,23 +678,32 @@ class ResumableSmartScanActivity : ComponentActivity() {
     }
 
     private fun restoreCleanPlan() {
+        lastResultId = preferences.getString(PREF_LAST_RESULT_ID, "").orEmpty()
         val rawV2 = preferences.getString(CLEAN_PLAN_KEY, null).orEmpty()
         val raw = if (rawV2.isNotBlank()) rawV2 else preferences.getString(LEGACY_PLAN_KEY, null).orEmpty()
-        if (raw.isBlank()) return
+        if (raw.isBlank()) {
+            screenState = screenState.copy(resultId = lastResultId)
+            return
+        }
         val plan = runCatching { JSONObject(raw) }.getOrNull() ?: run {
             clearLocalPlan()
+            screenState = screenState.copy(resultId = lastResultId)
             return
         }
         val createdAt = plan.optLong("createdAt", 0L)
         val age = System.currentTimeMillis() - createdAt
         if (createdAt <= 0L || age !in 0..CLEAN_PLAN_TTL_MS || plan.optString("optionsSha") != sha256(optionsJson())) {
             clearLocalPlan()
-            screenState = screenState.copy(phase = "旧清理计划已过期或设置已变化，请重新扫描")
+            screenState = screenState.copy(
+                phase = "旧清理计划已过期或设置已变化，请重新扫描",
+                resultId = lastResultId
+            )
             return
         }
 
         cleanPlanId = plan.optString("planId")
         cleanPlanCreatedAt = createdAt
+        authorizedBytes = plan.optLong("selectedCandidateBytes", plan.optLong("estimatedBytes", 0L)).coerceAtLeast(0L)
         cacheSnapshotId = plan.optString("cacheSnapshotId")
         safeSnapshotId = plan.optString("safeSnapshotId")
         cacheCount = plan.optInt("cacheCount").coerceAtLeast(0)
@@ -625,9 +726,11 @@ class ResumableSmartScanActivity : ComponentActivity() {
         riskStats = plan.optJSONObject("riskStats") ?: JSONObject()
         cumulativeFailures = plan.optInt("deleteErrors", plan.optInt("failures", 0)).coerceAtLeast(0)
         resumable = plan.optBoolean("resumable", runCount > 0)
+        if (lastResultId.isBlank() && processedCandidates > 0) lastResultId = cleanPlanId
         val total = cacheCount + safeCount
         if (cleanPlanId.isBlank() || total <= 0 || (cacheSnapshotId.isBlank() && safeSnapshotId.isBlank())) {
             clearLocalPlan()
+            screenState = screenState.copy(resultId = lastResultId)
             return
         }
         if (rawV2.isBlank()) persistCleanPlan()
@@ -650,6 +753,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
             unattributedDeletedBytes = unattributedDeletedBytes,
             categoryStats = categoryStats.toString(),
             riskStats = riskStats.toString(),
+            estimatedBytes = authorizedBytes,
+            resultId = lastResultId,
             failures = cumulativeFailures,
             cacheSummary = plan.optString("cacheSummary", "剩余 $cacheCount 项"),
             safeSummary = plan.optString("safeSummary", "剩余 $safeCount 项")
@@ -660,6 +765,7 @@ class ResumableSmartScanActivity : ComponentActivity() {
         val cache = cacheService ?: return
         val plans = planService ?: return
         val transactions = resumeService ?: return
+        val results = resultService ?: return
         if (!restoredPlanNeedsValidation || validationRunning) return
         validationRunning = true
         lifecycleScope.launch {
@@ -692,6 +798,20 @@ class ResumableSmartScanActivity : ComponentActivity() {
                 val remaining = cacheCount + safeCount
                 resumable = runCount > 0 && remaining > 0
                 if (remaining <= 0) {
+                    if (processedCandidates > 0) {
+                        withContext(Dispatchers.IO) {
+                            runCatching {
+                                results.registerPlan(cleanPlanId, originalCacheCount + originalSafeCount, authorizedBytes)
+                                val archived = JSONObject(results.archive(cleanPlanId))
+                                if (!archived.has("error")) {
+                                    lastResultId = archived.optString("reportId", cleanPlanId)
+                                }
+                            }
+                        }
+                        if (lastResultId.isNotBlank()) {
+                            preferences.edit().putString(PREF_LAST_RESULT_ID, lastResultId).apply()
+                        }
+                    }
                     withContext(Dispatchers.IO) { runCatching { transactions.finish(cleanPlanId) } }
                     clearLocalPlan()
                     screenState = screenState.copy(
@@ -699,7 +819,9 @@ class ResumableSmartScanActivity : ComponentActivity() {
                         totalSafe = 0,
                         cleanReady = false,
                         scanCompleted = false,
-                        resumable = false
+                        resumable = false,
+                        estimatedBytes = authorizedBytes,
+                        resultId = lastResultId
                     )
                 } else {
                     persistCleanPlan()
@@ -713,7 +835,14 @@ class ResumableSmartScanActivity : ComponentActivity() {
                         resumable = resumable,
                         runCount = runCount,
                         deletedBytes = deletedBytes,
+                        processedCandidates = processedCandidates,
                         cleanedCandidates = cleanedCandidates,
+                        changedCandidates = changedCandidates,
+                        protectedCandidates = protectedCandidates,
+                        partialCandidates = partialCandidates,
+                        failedCandidates = failedCandidates,
+                        estimatedBytes = authorizedBytes,
+                        resultId = lastResultId,
                         failures = cumulativeFailures,
                         cacheSummary = "应用缓存剩余 $cacheCount 项",
                         safeSummary = "安全项目剩余 $safeCount 项"
@@ -745,6 +874,10 @@ class ResumableSmartScanActivity : ComponentActivity() {
         riskStats = json.optJSONObject("riskStats") ?: riskStats
         cumulativeFailures = json.optInt("deleteErrors", json.optInt("failures", cumulativeFailures)).coerceAtLeast(0)
         resumable = json.optBoolean("resumable", cacheCount + safeCount > 0 && runCount > 0)
+        if (processedCandidates > 0 && cleanPlanId.isNotBlank()) {
+            lastResultId = cleanPlanId
+            preferences.edit().putString(PREF_LAST_RESULT_ID, lastResultId).apply()
+        }
         screenState = screenState.copy(
             totalSafe = cacheCount + safeCount,
             resumable = resumable,
@@ -760,6 +893,8 @@ class ResumableSmartScanActivity : ComponentActivity() {
             unattributedDeletedBytes = unattributedDeletedBytes,
             categoryStats = categoryStats.toString(),
             riskStats = riskStats.toString(),
+            estimatedBytes = authorizedBytes,
+            resultId = lastResultId,
             failures = cumulativeFailures,
             cacheSummary = "应用缓存剩余 $cacheCount 项",
             safeSummary = "安全项目剩余 $safeCount 项"
@@ -780,6 +915,7 @@ class ResumableSmartScanActivity : ComponentActivity() {
             .put("safeCount", safeCount)
             .put("originalCacheCount", originalCacheCount)
             .put("originalSafeCount", originalSafeCount)
+            .put("selectedCandidateBytes", authorizedBytes)
             .put("runCount", runCount)
             .put("deletedBytes", deletedBytes)
             .put("deletedFiles", deletedFiles)
@@ -854,6 +990,7 @@ class ResumableSmartScanActivity : ComponentActivity() {
         originalSafeCount = 0
         cleanPlanId = ""
         cleanPlanCreatedAt = 0L
+        authorizedBytes = 0L
         runCount = 0
         deletedBytes = 0L
         deletedFiles = 0L
@@ -883,6 +1020,7 @@ class ResumableSmartScanActivity : ComponentActivity() {
         if (cacheBindingRequested) runCatching { RootService.unbind(cacheConnection) }
         if (planBindingRequested) runCatching { RootService.unbind(planConnection) }
         if (resumeBindingRequested) runCatching { RootService.unbind(resumeConnection) }
+        if (resultBindingRequested) runCatching { RootService.unbind(resultConnection) }
         super.onDestroy()
     }
 
@@ -891,6 +1029,7 @@ class ResumableSmartScanActivity : ComponentActivity() {
         private const val LEGACY_PLAN_KEY = "smart_clean_plan_v1"
         private const val CLEAN_PLAN_VERSION = 2
         private const val CLEAN_PLAN_TTL_MS = 30L * 60_000L
+        private const val PREF_LAST_RESULT_ID = "last_clean_result_id"
     }
 }
 
@@ -916,6 +1055,8 @@ private data class ResumeSmartUiState(
     val unattributedDeletedBytes: Long = 0L,
     val categoryStats: String = "{}",
     val riskStats: String = "{}",
+    val estimatedBytes: Long = 0L,
+    val resultId: String = "",
     val failures: Int = 0,
     val progressCurrent: Int = 0,
     val progressTotal: Int = 0,
@@ -930,7 +1071,8 @@ private fun ResumeSmartScreen(
     onScan: () -> Unit,
     onClean: () -> Unit,
     onStop: () -> Unit,
-    onReconnect: () -> Unit
+    onReconnect: () -> Unit,
+    onReport: () -> Unit
 ) {
     val context = LocalContext.current
     val progress = if (state.progressTotal > 0) {
@@ -951,7 +1093,7 @@ private fun ResumeSmartScreen(
                 Column(modifier = Modifier.weight(1f)) {
                     Text("RESUME CLEAN", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
                     Text("智能扫描", fontSize = 30.sp, fontWeight = FontWeight.Black)
-                    Text("扫描一次 · 清理中断后从剩余项目继续", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("扫描一次 · 中断续清 · 逐项报告", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
@@ -969,7 +1111,7 @@ private fun ResumeSmartScreen(
                             contentAlignment = Alignment.Center
                         ) {
                             Icon(
-                                if (state.cleanReady) Icons.Rounded.CheckCircle else Icons.Rounded.CleaningServices,
+                                if (state.cleanReady || state.resultId.isNotBlank()) Icons.Rounded.CheckCircle else Icons.Rounded.CleaningServices,
                                 contentDescription = null,
                                 tint = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier.size(30.dp)
@@ -1020,11 +1162,18 @@ private fun ResumeSmartScreen(
                             Text("开始智能扫描")
                         }
                     }
+                    if (state.resultId.isNotBlank()) {
+                        OutlinedButton(onClick = onReport, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.CheckCircle, contentDescription = null)
+                            Spacer(Modifier.size(8.dp))
+                            Text("查看逐项清理报告")
+                        }
+                    }
                 }
             }
         }
 
-        if (state.scanCompleted || state.runCount > 0) {
+        if (state.scanCompleted || state.runCount > 0 || state.processedCandidates > 0) {
             item {
                 Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                     Text("TRANSACTION", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
@@ -1049,6 +1198,7 @@ private fun ResumeSmartScreen(
                     }
                 }
             }
+            item { ResumeComparisonCard(state) }
             item { ResumeInfoCard("应用缓存", state.cacheSummary) }
             item { ResumeInfoCard("安全项目", state.safeSummary) }
             item { ResumeInfoCard("按类别统计", formatMetricBuckets(state.categoryStats)) }
@@ -1060,7 +1210,7 @@ private fun ResumeSmartScreen(
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
                 ) {
                     Text(
-                        "已完成或确认失效的候选会从事务快照中移除；部分删除、失败和未执行候选继续保留。应用或 Root 服务异常退出后，会先恢复快照检查点，再允许继续清理。",
+                        "已完成或确认失效的候选会从事务快照中移除；部分删除、失败和未执行候选继续保留。完成后先归档逐项报告，再删除事务备份。",
                         modifier = Modifier.padding(18.dp),
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontSize = 12.sp,
@@ -1068,6 +1218,36 @@ private fun ResumeSmartScreen(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun ResumeComparisonCard(state: ResumeSmartUiState) {
+    val context = LocalContext.current
+    val authorized = (state.totalSafe + state.processedCandidates).coerceAtLeast(0)
+    val completion = if (authorized > 0) (state.processedCandidates * 100 / authorized).coerceIn(0, 100) else 0
+    val recovery = if (state.estimatedBytes > 0L) {
+        ((state.deletedBytes * 100L / state.estimatedBytes).coerceIn(0L, 999L)).toInt()
+    } else 0
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Column(modifier = Modifier.padding(horizontal = 18.dp, vertical = 17.dp)) {
+            Text("清理前后对比", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+            Spacer(Modifier.height(3.dp))
+            Text(
+                "预计 ${Formatter.formatFileSize(context, state.estimatedBytes)} · 实际 ${Formatter.formatFileSize(context, state.deletedBytes)} · 空间兑现 $recovery%",
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                fontSize = 12.sp
+            )
+            Text(
+                "处理完成度 $completion% · 剩余 ${state.totalSafe} 项",
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                fontSize = 12.sp
+            )
         }
     }
 }
@@ -1082,11 +1262,10 @@ private fun ResumeInfoCard(title: String, summary: String) {
         Column(modifier = Modifier.padding(horizontal = 18.dp, vertical = 17.dp)) {
             Text(title, fontWeight = FontWeight.Bold, fontSize = 16.sp)
             Spacer(Modifier.height(3.dp))
-            Text(summary, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, maxLines = 3, overflow = TextOverflow.Ellipsis)
+            Text(summary, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, maxLines = 4, overflow = TextOverflow.Ellipsis)
         }
     }
 }
-
 
 private fun formatMetricBuckets(raw: String): String {
     val root = runCatching { JSONObject(raw) }.getOrDefault(JSONObject())

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanResultRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanResultRootService.kt
@@ -1,0 +1,378 @@
+package io.github.xgl34222220.baize.root
+
+import android.content.Intent
+import android.os.IBinder
+import android.os.Process
+import com.topjohnwu.superuser.ipc.RootService
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.util.UUID
+
+/**
+ * Read-only clean result archive and paging service.
+ *
+ * This service never discovers or accepts deletion targets. It reads the transaction journal written
+ * by [CleanPlanResumeRootService], archives terminal reports before the transaction is removed, and
+ * exposes compact summaries plus bounded result pages to the UI.
+ */
+class CleanResultRootService : RootService() {
+    private val binder = object : ICleanResultService.Stub() {
+        override fun ping(): String {
+            pruneReports()
+            return JSONObject()
+                .put("uid", Process.myUid())
+                .put("root", Process.myUid() == 0)
+                .put("engine", "clean-result-archive-v1")
+                .put("reports", reportRoot().listFiles()?.count { it.isDirectory && summaryFile(it).isFile } ?: 0)
+                .put("latest", latestReportId())
+                .toString()
+        }
+
+        override fun registerPlan(
+            planId: String?,
+            authorizedCandidates: Int,
+            estimatedBytes: Long
+        ): String = guarded(planId) { id ->
+            pruneReports()
+            val directory = reportDirectory(id).apply { mkdirs() }
+            val previous = readJson(metaFile(directory))
+            val meta = JSONObject()
+                .put("version", REPORT_VERSION)
+                .put("reportId", id)
+                .put("createdAt", previous.optLong("createdAt", System.currentTimeMillis()))
+                .put("updatedAt", System.currentTimeMillis())
+                .put("authorizedCandidates", authorizedCandidates.coerceAtLeast(0))
+                .put("estimatedBytes", estimatedBytes.coerceAtLeast(0L))
+            if (!atomicWrite(metaFile(directory), meta.toString())) {
+                return@guarded error("result_meta_write_failed", "无法保存清理前统计")
+            }
+            JSONObject(meta.toString()).put("success", true).toString()
+        }
+
+        override fun archive(planId: String?): String = guarded(planId) { id ->
+            pruneReports()
+            val directory = reportDirectory(id).apply { mkdirs() }
+            val transaction = transactionState(id)
+            if (transaction == null) {
+                val existing = readJson(summaryFile(directory))
+                return@guarded if (existing.length() > 0) {
+                    JSONObject(existing.toString()).put("success", true).toString()
+                } else {
+                    error("transaction_missing", "清理事务不存在，无法生成报告")
+                }
+            }
+
+            val itemStates = transaction.optJSONObject("itemStates") ?: JSONObject()
+            val items = resultItems(itemStates)
+            val summary = compactSummary(id, transaction, readJson(metaFile(directory)))
+                .put("archived", true)
+                .put("completedAt", System.currentTimeMillis())
+                .put("itemResultCount", items.size)
+            val rows = items.joinToString(
+                separator = "\n",
+                postfix = if (items.isEmpty()) "" else "\n"
+            ) { it.toString() }
+
+            if (!atomicWrite(itemsFile(directory), rows)) {
+                return@guarded error("result_items_write_failed", "无法保存逐项清理结果")
+            }
+            if (!atomicWrite(summaryFile(directory), summary.toString())) {
+                return@guarded error("result_summary_write_failed", "无法保存清理报告摘要")
+            }
+            if (!atomicWrite(latestFile(), "$id\n")) {
+                return@guarded error("result_latest_write_failed", "清理报告已保存，但最近报告索引写入失败")
+            }
+            JSONObject(summary.toString()).put("success", true).toString()
+        }
+
+        override fun getSummary(reportId: String?): String {
+            pruneReports()
+            val id = resolveReportId(reportId.orEmpty())
+                ?: return error("report_missing", "没有可查看的清理报告")
+            val live = transactionState(id)
+            val archived = readJson(summaryFile(reportDirectory(id)))
+            if (live == null && archived.length() == 0) {
+                return error("report_missing", "清理报告不存在或已过期")
+            }
+            val summary = if (live != null) {
+                compactSummary(id, live, readJson(metaFile(reportDirectory(id))))
+            } else {
+                JSONObject(archived.toString())
+            }
+            return summary
+                .put("success", true)
+                .put("live", live != null)
+                .put("archived", live == null)
+                .toString()
+        }
+
+        override fun getPage(
+            reportId: String?,
+            offset: Int,
+            limit: Int,
+            filterJson: String?
+        ): String {
+            pruneReports()
+            val id = resolveReportId(reportId.orEmpty())
+                ?: return error("report_missing", "没有可查看的清理报告")
+            if (transactionState(id) == null && !summaryFile(reportDirectory(id)).isFile) {
+                return error("report_missing", "清理报告不存在或已过期")
+            }
+
+            val filters = parseJson(filterJson)
+            val action = normalizeFilter(filters.optString("action", "all"))
+            val category = normalizeFilter(filters.optString("category", "all"))
+            val risk = normalizeFilter(filters.optString("risk", "all"))
+            val query = filters.optString("query").trim().lowercase().take(160)
+            val filtered = loadItems(id)
+                .asSequence()
+                .filter { action == "all" || normalizeAction(it.optString("action")) == action }
+                .filter { category == "all" || normalizeCategory(it.optString("category")) == category }
+                .filter { risk == "all" || normalizeRisk(it.optString("risk")) == risk }
+                .filter {
+                    query.isBlank() ||
+                        it.optString("path").lowercase().contains(query) ||
+                        it.optString("reason").lowercase().contains(query) ||
+                        it.optString("category").lowercase().contains(query)
+                }
+                .sortedWith(
+                    compareBy<JSONObject> { actionPriority(normalizeAction(it.optString("action"))) }
+                        .thenByDescending { it.optLong("deletedBytes") }
+                        .thenBy { it.optString("path") }
+                )
+                .toList()
+
+            val start = offset.coerceAtLeast(0).coerceAtMost(filtered.size)
+            val pageSize = limit.coerceIn(1, MAX_PAGE_SIZE)
+            val end = (start + pageSize).coerceAtMost(filtered.size)
+            val page = JSONArray()
+            for (index in start until end) page.put(filtered[index])
+            return JSONObject()
+                .put("success", true)
+                .put("reportId", id)
+                .put("offset", start)
+                .put("limit", pageSize)
+                .put("total", filtered.size)
+                .put("hasMore", end < filtered.size)
+                .put("items", page)
+                .toString()
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+
+    private inline fun guarded(rawPlanId: String?, block: (String) -> String): String {
+        val id = validId(rawPlanId.orEmpty()) ?: return error("invalid_report", "清理报告编号无效")
+        return runCatching { block(id) }
+            .getOrElse { error("clean_result_failed", it.message ?: it.javaClass.simpleName) }
+    }
+
+    private fun compactSummary(id: String, state: JSONObject, meta: JSONObject): JSONObject {
+        val summary = JSONObject(state.toString()).apply { remove("itemStates") }
+        val authorized = meta.optInt(
+            "authorizedCandidates",
+            summary.optInt("authorizedCandidates", summary.optInt("scannedCandidates", 0))
+        ).coerceAtLeast(0)
+        val processed = summary.optInt("processedCandidates", 0).coerceAtLeast(0)
+        val remaining = summary.optInt("cacheRemaining", 0).coerceAtLeast(0) +
+            summary.optInt("safeRemaining", 0).coerceAtLeast(0)
+        val estimated = meta.optLong(
+            "estimatedBytes",
+            summary.optLong("estimatedBytes", 0L)
+        ).coerceAtLeast(0L)
+        val deleted = summary.optLong("deletedBytes", 0L).coerceAtLeast(0L)
+        return summary
+            .put("resultSchema", "clean-report-v1")
+            .put("reportId", id)
+            .put("authorizedCandidates", authorized)
+            .put("processedCandidates", processed)
+            .put("remainingCandidates", remaining)
+            .put("estimatedBytes", estimated)
+            .put("actualDeletedBytes", deleted)
+            .put(
+                "completionPercent",
+                if (authorized > 0) (processed * 100 / authorized).coerceIn(0, 100) else 0
+            )
+            .put(
+                "spaceRecoveryPercent",
+                if (estimated > 0L) ((deleted * 100L / estimated).coerceIn(0L, 999L)).toInt() else 0
+            )
+            .put("updatedAt", summary.optLong("updatedAt", System.currentTimeMillis()))
+    }
+
+    private fun loadItems(id: String): List<JSONObject> {
+        val live = transactionState(id)?.optJSONObject("itemStates")
+        if (live != null) return resultItems(live)
+        val file = itemsFile(reportDirectory(id))
+        if (!file.isFile) return emptyList()
+        return buildList {
+            file.useLines { lines ->
+                lines.take(MAX_RESULT_ITEMS).forEach { line ->
+                    parseJson(line).takeIf { it.length() > 0 }?.let(::add)
+                }
+            }
+        }
+    }
+
+    private fun resultItems(states: JSONObject): List<JSONObject> {
+        val values = ArrayList<JSONObject>()
+        val keys = states.keys()
+        while (keys.hasNext() && values.size < MAX_RESULT_ITEMS) {
+            val source = states.optJSONObject(keys.next()) ?: continue
+            val path = source.optString("path")
+            if (!path.startsWith("/")) continue
+            val action = normalizeAction(source.optString("action"))
+            val reason = source.optString("reason").ifBlank { defaultReason(action) }
+            val deletedBytes = source.optLong("deletedBytes", 0L).coerceAtLeast(0L)
+            val estimatedBytes = source.optLong(
+                "estimatedBytes",
+                if (action == "cleaned") deletedBytes else 0L
+            ).coerceAtLeast(0L)
+            values += JSONObject(source.toString())
+                .put("action", action)
+                .put("reason", reason)
+                .put("category", normalizeCategory(source.optString("category")))
+                .put("risk", normalizeRisk(source.optString("risk")))
+                .put("estimatedBytes", estimatedBytes)
+                .put("deletedBytes", deletedBytes)
+                .put("remainingEstimatedBytes", (estimatedBytes - deletedBytes).coerceAtLeast(0L))
+        }
+        return values
+    }
+
+    private fun transactionState(id: String): JSONObject? {
+        val file = File(transactionRoot(), "$id/state.json")
+        if (!file.isFile) return null
+        return readJson(file).takeIf { it.optString("planId") == id }
+    }
+
+    private fun resolveReportId(raw: String): String? {
+        val value = raw.trim()
+        if (value.isBlank() || value == "latest") return latestReportId().takeIf { it.isNotBlank() }
+        return validId(value)?.takeIf { reportExists(it) }
+    }
+
+    private fun latestReportId(): String {
+        val indexed = latestFile().takeIf { it.isFile }?.readText()?.trim().orEmpty()
+        if (validId(indexed) != null && reportExists(indexed)) return indexed
+        return reportRoot().listFiles()
+            ?.filter { it.isDirectory && summaryFile(it).isFile }
+            ?.maxByOrNull { summaryFile(it).lastModified() }
+            ?.name
+            .orEmpty()
+    }
+
+    private fun reportExists(id: String): Boolean =
+        transactionState(id) != null || summaryFile(reportDirectory(id)).isFile
+
+    private fun reportRoot(): File = File(RootPaths.STATE_DIR, "clean-result-reports").apply { mkdirs() }
+    private fun transactionRoot(): File = File(RootPaths.STATE_DIR, "clean-plan-transactions")
+    private fun reportDirectory(id: String): File = File(reportRoot(), id)
+    private fun metaFile(directory: File): File = File(directory, "meta.json")
+    private fun summaryFile(directory: File): File = File(directory, "summary.json")
+    private fun itemsFile(directory: File): File = File(directory, "items.ndjson")
+    private fun latestFile(): File = File(reportRoot(), "latest.txt")
+
+    private fun pruneReports() {
+        val now = System.currentTimeMillis()
+        val completed = reportRoot().listFiles()
+            ?.filter { it.isDirectory && summaryFile(it).isFile }
+            ?.sortedByDescending { summaryFile(it).lastModified() }
+            .orEmpty()
+        completed.forEachIndexed { index, directory ->
+            val updated = summaryFile(directory).lastModified().takeIf { it > 0L } ?: directory.lastModified()
+            if (index >= MAX_REPORTS || updated <= 0L || now - updated > REPORT_TTL_MS) {
+                deleteTree(directory)
+            }
+        }
+        val latest = latestFile().takeIf { it.isFile }?.readText()?.trim().orEmpty()
+        if (latest.isNotBlank() && !reportExists(latest)) latestFile().delete()
+    }
+
+    private fun readJson(file: File): JSONObject {
+        if (!file.isFile) return JSONObject()
+        return runCatching { JSONObject(file.readText()) }.getOrDefault(JSONObject())
+    }
+
+    private fun parseJson(raw: String?): JSONObject =
+        runCatching { JSONObject(raw.orEmpty()) }.getOrDefault(JSONObject())
+
+    private fun atomicWrite(target: File, content: String): Boolean = runCatching {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        temporary.writeText(content)
+        if (!temporary.renameTo(target)) {
+            temporary.copyTo(target, overwrite = true)
+            temporary.delete()
+        }
+        restrict(target)
+        true
+    }.getOrDefault(false)
+
+    private fun restrict(file: File) {
+        file.setReadable(false, false)
+        file.setWritable(false, false)
+        file.setExecutable(false, false)
+        file.setReadable(true, true)
+        file.setWritable(true, true)
+    }
+
+    private fun deleteTree(file: File): Boolean = runCatching {
+        if (!file.exists()) return@runCatching true
+        file.walkBottomUp().forEach { it.delete() }
+        !file.exists()
+    }.getOrDefault(false)
+
+    private fun normalizeAction(raw: String): String = when (raw.trim().lowercase()) {
+        "cleaned", "deleted", "success" -> "cleaned"
+        "protected" -> "protected"
+        "partial" -> "partial"
+        "failed", "error" -> "failed"
+        else -> "changed"
+    }
+
+    private fun normalizeCategory(raw: String): String = when (raw.trim().lowercase()) {
+        "cache", "empty", "rules", "fragment", "other" -> raw.trim().lowercase()
+        else -> "other"
+    }
+
+    private fun normalizeRisk(raw: String): String = when (raw.trim().lowercase()) {
+        "medium", "high", "critical" -> raw.trim().lowercase()
+        else -> "low"
+    }
+
+    private fun normalizeFilter(raw: String): String = raw.trim().lowercase().ifBlank { "all" }
+
+    private fun defaultReason(action: String): String = when (action) {
+        "cleaned" -> "已通过快照校验并完成删除"
+        "protected" -> "白名单、安全边界或系统保护阻止了删除"
+        "partial" -> "部分内容已删除，剩余内容保留在断点计划中"
+        "failed" -> "删除失败，项目保留以便继续处理"
+        else -> "扫描后目标已不存在或文件状态发生变化"
+    }
+
+    private fun actionPriority(action: String): Int = when (action) {
+        "failed" -> 0
+        "partial" -> 1
+        "protected" -> 2
+        "changed" -> 3
+        else -> 4
+    }
+
+    private fun validId(raw: String): String? =
+        runCatching { UUID.fromString(raw).toString() }.getOrNull()
+
+    private fun error(code: String, message: String): String = JSONObject()
+        .put("error", code)
+        .put("message", message)
+        .toString()
+
+    companion object {
+        private const val REPORT_VERSION = 1
+        private const val REPORT_TTL_MS = 30L * 24L * 60L * 60_000L
+        private const val MAX_REPORTS = 50
+        private const val MAX_RESULT_ITEMS = 20_000
+        private const val MAX_PAGE_SIZE = 100
+    }
+}

--- a/v2/tests/test-clean-plan-persistence.py
+++ b/v2/tests/test-clean-plan-persistence.py
@@ -70,4 +70,5 @@ for method in ("scanSafe", "getPage", "cleanSafe", "getTaskState", "cancelCurren
     require(method in AIDL, f"binder method missing: {method}")
 
 runpy.run_path(str(ROOT / "v2/tests/test-candidate-selection-plan.py"), run_name="__main__")
+runpy.run_path(str(ROOT / "v2/tests/test-clean-result-report.py"), run_name="__main__")
 print("clean plan persistence contract: ok")

--- a/v2/tests/test-clean-result-report.py
+++ b/v2/tests/test-clean-result-report.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+# Fifth-stage contract: reporting is read-only, paginated, and archived before transaction removal.
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
+ACTIVITY = (APP / "CleanResultActivity.kt").read_text(encoding="utf-8")
+RESUMABLE = (APP / "ResumableSmartScanActivity.kt").read_text(encoding="utf-8")
+SERVICE = (APP / "root/CleanResultRootService.kt").read_text(encoding="utf-8")
+AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanResultService.aidl").read_text(encoding="utf-8")
+MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
+
+
+def require(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+for method in ("registerPlan", "archive", "getSummary", "getPage"):
+    require(method in AIDL, f"clean result binder method missing: {method}")
+
+for marker in (
+    "clean-result-reports", "summary.json", "items.ndjson", "latest.txt",
+    "compactSummary", "resultItems", "MAX_PAGE_SIZE", "REPORT_TTL_MS",
+    "estimatedBytes", "actualDeletedBytes", "completionPercent", "spaceRecoveryPercent",
+    "defaultReason", "actionPriority", "remove(\"itemStates\")"
+):
+    require(marker in SERVICE, f"result archive primitive missing: {marker}")
+
+require("scanCandidates(" not in SERVICE and "scanSafe(" not in SERVICE and "engine.scan(" not in SERVICE,
+        "result service must never discover candidates")
+require("MAX_PAGE_SIZE = 100" in SERVICE, "result pages must stay Binder-safe")
+require("items.ndjson" in SERVICE and "MAX_RESULT_ITEMS" in SERVICE,
+        "item outcomes must be stored outside the compact summary")
+
+for marker in (
+    "BEFORE / AFTER", "清理前后对比", "逐项结果", "受保护", "已变化",
+    "getSummary", "getPage", "FilterChip", "加载更多"
+):
+    require(marker in ACTIVITY, f"result UI contract missing: {marker}")
+
+require("results.registerPlan" in RESUMABLE, "clean flow must register before-clean totals")
+require("results.archive" in RESUMABLE, "completed transactions must be archived before finish")
+clean_start = RESUMABLE.index("private fun cleanSnapshots()")
+clean_end = RESUMABLE.index("private fun openResultReport()", clean_start)
+clean_path = RESUMABLE[clean_start:clean_end]
+require("scanCandidates(" not in clean_path and "scanSafe(" not in clean_path,
+        "report integration must not reintroduce discovery into clean")
+archive_pos = clean_path.index("results.archive")
+finish_pos = clean_path.index("transactions.finish", archive_pos)
+require(archive_pos < finish_pos, "result archive must happen before transaction deletion")
+require("CleanResultActivity::class.java" in RESUMABLE, "resumable page must open the item report")
+require("PREF_LAST_RESULT_ID" in RESUMABLE, "latest archived report must survive process death")
+
+require('android:name=".CleanResultActivity"' in MANIFEST, "result activity is not registered")
+require('android:name=".root.CleanResultRootService"' in MANIFEST, "result Root service is not registered")
+
+print("clean result report contract: ok")


### PR DESCRIPTION
## 第五阶段：清理前后对比与逐项结果说明

- 清理开始前登记最终计划的授权项目数与预计空间。
- 清理完成后先归档摘要和逐项结果，再删除可恢复事务。
- 逐项报告按状态分页读取：已清理、已变化、受保护、部分完成、失败。
- 每项显示路径、类别、风险、预计空间、实际释放、文件/目录数和具体原因。
- 支持未完成事务的实时报告，以及完成报告 30 天持久化恢复。
- 报告摘要与逐项 NDJSON 分离，分页最多返回 100 项，避免报告归档进入 Binder 大对象。
- 报告服务只读取事务日志，不接受删除路径，也不会触发扫描。
- 最近一次报告编号会持久化，App 被回收后仍可重新打开。

## 堆叠关系

本 PR 基于第四阶段 `agent/candidate-selection-plan`，当前已整理为 1 个干净提交、7 个第五阶段文件。

## 验证结果

完整工作流 `BaiZe v2.4.1 Verify and Release #43` 已全部通过：

- 第五阶段报告归档、分页、只读与执行顺序契约：通过
- 清理计划持久化、断点恢复、真实统计与候选选择回归：通过
- Root Shell、调度公平性、增量索引和归类事务回归：通过
- Android Release、Debug Kotlin、Lint 和 Macrobenchmark：通过
- ARM64 原生扫描器：通过
- 模块封包、内置 APK 一致性和签名产物校验：通过

最终分支仅保留 Manifest、报告 AIDL、报告 Activity、只读报告 RootService、可恢复清理页接线和 2 个契约测试文件。