### PR TITLE
feat(result): explain rule matches and add whitelist shortcuts

### DIFF
--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanResultActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanResultActivity.kt
@@ -3,6 +3,7 @@ package io.github.xgl34222220.baize
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
+import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.text.format.Formatter
@@ -57,8 +58,10 @@ import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.BaiZeProfileRootService
 import io.github.xgl34222220.baize.root.CleanResultRootService
 import io.github.xgl34222220.baize.root.ICleanResultService
+import io.github.xgl34222220.baize.root.IProfileRootService
 import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
 import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
 import kotlinx.coroutines.Dispatchers
@@ -67,27 +70,45 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
-/** Stage five read-only result viewer. */
+/** Stage six read-only result viewer with explainable rules and safe whitelist shortcuts. */
 class CleanResultActivity : ComponentActivity() {
     private val appearanceViewModel: AppearanceViewModel by viewModels()
     private val preferences by lazy { getSharedPreferences("baize_v2", MODE_PRIVATE) }
-    private var service: ICleanResultService? = null
-    private var binding = false
+
+    private var reportService: ICleanResultService? = null
+    private var whitelistService: IProfileRootService? = null
+    private var reportBinding = false
+    private var whitelistBinding = false
     private var reportId = ""
     private var state by mutableStateOf(CleanResultUiState())
 
-    private val connection = object : ServiceConnection {
+    private val reportConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
-            service = ICleanResultService.Stub.asInterface(binder)
-            binding = true
+            reportService = ICleanResultService.Stub.asInterface(binder)
+            reportBinding = true
             state = state.copy(connected = true, status = "清理报告引擎已连接")
             loadReport(reset = true)
         }
 
         override fun onServiceDisconnected(name: ComponentName?) {
-            service = null
-            binding = false
+            reportService = null
+            reportBinding = false
             state = state.copy(connected = false, status = "清理报告引擎连接已断开")
+        }
+    }
+
+    private val whitelistConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            whitelistService = IProfileRootService.Stub.asInterface(binder)
+            whitelistBinding = true
+            state = state.copy(whitelistConnected = true)
+            refreshProtectedPackages()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            whitelistService = null
+            whitelistBinding = false
+            state = state.copy(whitelistConnected = false)
         }
     }
 
@@ -96,6 +117,10 @@ class CleanResultActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         reportId = intent.getStringExtra(EXTRA_REPORT_ID).orEmpty()
             .ifBlank { preferences.getString(PREF_LAST_REPORT_ID, "").orEmpty() }
+        state = state.copy(
+            protectedPackages = preferences.getStringSet(PREF_PACKAGE_WHITELIST, emptySet()).orEmpty(),
+            protectedPaths = preferences.getStringSet(PREF_PATH_WHITELIST, emptySet()).orEmpty()
+        )
         setContent {
             val appearance by appearanceViewModel.settings.collectAsState()
             BaiZeTheme(appearance) {
@@ -103,29 +128,49 @@ class CleanResultActivity : ComponentActivity() {
                     CleanResultScreen(
                         state = state,
                         onBack = ::finish,
-                        onReconnect = ::bindService,
+                        onReconnect = ::bindRootServices,
                         onRefresh = { loadReport(reset = true) },
                         onAction = ::selectAction,
-                        onLoadMore = { loadReport(reset = false) }
+                        onLoadMore = { loadReport(reset = false) },
+                        onProtectPackage = ::protectPackage,
+                        onProtectPath = ::protectPath
                     )
                 }
             }
         }
-        bindService()
+        bindRootServices()
     }
 
-    private fun bindService() {
-        if (service != null || binding) return
-        runCatching {
-            RootService.bind(
-                Intent(this, CleanResultRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
-                connection
-            )
-            binding = true
-            state = state.copy(status = "正在连接清理报告引擎…")
-        }.onFailure {
-            binding = false
-            state = state.copy(status = "清理报告引擎启动失败：${it.message}")
+    private fun bindRootServices() {
+        if (reportService == null && !reportBinding) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, CleanResultRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    reportConnection
+                )
+                reportBinding = true
+                state = state.copy(status = "正在连接清理报告引擎…")
+            }.onFailure {
+                reportBinding = false
+                state = state.copy(status = "清理报告引擎启动失败：${it.message}")
+            }
+        }
+        if (whitelistService == null && !whitelistBinding) {
+            runCatching {
+                RootService.bind(
+                    Intent(this, BaiZeProfileRootService::class.java)
+                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                    whitelistConnection
+                )
+                whitelistBinding = true
+            }.onFailure {
+                whitelistBinding = false
+                state = state.copy(
+                    whitelistConnected = false,
+                    actionMessage = "应用白名单 Root 服务暂不可用；路径保护仍可使用"
+                )
+            }
         }
     }
 
@@ -136,30 +181,42 @@ class CleanResultActivity : ComponentActivity() {
     }
 
     private fun loadReport(reset: Boolean) {
-        val resultService = service ?: return
+        val service = reportService ?: return
         if (state.loading) return
         val offset = if (reset) 0 else state.items.size
-        state = state.copy(loading = true, message = if (reset) "正在读取清理报告…" else "正在加载更多结果…")
+        val selectedAction = state.action
+        state = state.copy(
+            loading = true,
+            message = if (reset) "正在读取清理报告…" else "正在加载更多结果…"
+        )
         lifecycleScope.launch {
             try {
-                val (summary, page) = withContext(Dispatchers.IO) {
-                    val summaryJson = JSONObject(resultService.getSummary(reportId.ifBlank { "latest" }))
-                    if (summaryJson.has("error")) throw IllegalStateException(summaryJson.optString("message"))
-                    val resolvedId = summaryJson.optString("reportId")
-                    val filters = JSONObject().put("action", state.action)
-                    val pageJson = JSONObject(resultService.getPage(resolvedId, offset, PAGE_SIZE, filters.toString()))
-                    if (pageJson.has("error")) throw IllegalStateException(pageJson.optString("message"))
-                    summaryJson to pageJson
+                val loaded = withContext(Dispatchers.IO) {
+                    val summary = JSONObject(service.getSummary(reportId.ifBlank { "latest" }))
+                    if (summary.has("error")) {
+                        throw IllegalStateException(summary.optString("message", "清理报告不存在"))
+                    }
+                    val resolvedId = summary.optString("reportId")
+                    val filters = JSONObject().put("action", selectedAction)
+                    val page = JSONObject(service.getPage(resolvedId, offset, PAGE_SIZE, filters.toString()))
+                    if (page.has("error")) {
+                        throw IllegalStateException(page.optString("message", "清理报告分页读取失败"))
+                    }
+                    LoadedReport(summary, page, parseItems(page.optJSONArray("items")))
                 }
+                val summary = loaded.summary
+                val page = loaded.page
                 reportId = summary.optString("reportId", reportId)
-                if (reportId.isNotBlank()) preferences.edit().putString(PREF_LAST_REPORT_ID, reportId).apply()
-                val parsed = parseItems(page.optJSONArray("items"))
+                if (reportId.isNotBlank()) {
+                    preferences.edit().putString(PREF_LAST_REPORT_ID, reportId).apply()
+                }
                 state = state.copy(
                     connected = true,
                     loading = false,
                     status = if (summary.optBoolean("live")) "清理事务实时报告" else "已归档清理报告",
                     message = if (page.optInt("total") == 0) "当前筛选下没有结果" else "共 ${page.optInt("total")} 项结果",
                     reportId = reportId,
+                    live = summary.optBoolean("live"),
                     authorizedCandidates = summary.optInt("authorizedCandidates").coerceAtLeast(0),
                     processedCandidates = summary.optInt("processedCandidates").coerceAtLeast(0),
                     remainingCandidates = summary.optInt("remainingCandidates").coerceAtLeast(0),
@@ -169,32 +226,143 @@ class CleanResultActivity : ComponentActivity() {
                     partialCandidates = summary.optInt("partialCandidates").coerceAtLeast(0),
                     failedCandidates = summary.optInt("failedCandidates").coerceAtLeast(0),
                     estimatedBytes = summary.optLong("estimatedBytes").coerceAtLeast(0L),
-                    deletedBytes = summary.optLong("actualDeletedBytes", summary.optLong("deletedBytes")).coerceAtLeast(0L),
+                    deletedBytes = summary.optLong(
+                        "actualDeletedBytes",
+                        summary.optLong("deletedBytes")
+                    ).coerceAtLeast(0L),
                     completionPercent = summary.optInt("completionPercent").coerceIn(0, 100),
                     spaceRecoveryPercent = summary.optInt("spaceRecoveryPercent").coerceAtLeast(0),
-                    items = if (reset) parsed else state.items + parsed,
+                    items = if (reset) loaded.items else state.items + loaded.items,
                     totalItems = page.optInt("total").coerceAtLeast(0),
                     hasMore = page.optBoolean("hasMore")
                 )
             } catch (throwable: Throwable) {
-                state = state.copy(loading = false, message = "清理报告读取失败：${throwable.message ?: throwable.javaClass.simpleName}")
+                state = state.copy(
+                    loading = false,
+                    message = "清理报告读取失败：${throwable.message ?: throwable.javaClass.simpleName}"
+                )
             }
         }
     }
+
+    private fun refreshProtectedPackages() {
+        val service = whitelistService ?: return
+        lifecycleScope.launch {
+            val remote = withContext(Dispatchers.IO) {
+                runCatching { parsePackageWhitelist(service.getWhitelistPackages()) }.getOrDefault(emptySet())
+            }
+            if (remote.isNotEmpty()) {
+                val merged = state.protectedPackages + remote
+                preferences.edit().putStringSet(PREF_PACKAGE_WHITELIST, merged).apply()
+                state = state.copy(protectedPackages = merged)
+            }
+        }
+    }
+
+    private fun protectPackage(item: CleanResultItem) {
+        if (!settingsCanChange()) {
+            state = state.copy(actionMessage = "当前事务仍有剩余项目，请先完成或放弃清理计划，再修改白名单")
+            return
+        }
+        val packageName = item.packageName.trim()
+        if (!PACKAGE_NAME.matches(packageName)) {
+            state = state.copy(actionMessage = "无法从该路径识别有效应用包名")
+            return
+        }
+        if (packageName in state.protectedPackages) {
+            state = state.copy(actionMessage = "${item.appName} 已在应用白名单中")
+            return
+        }
+        val service = whitelistService
+        if (service == null) {
+            state = state.copy(actionMessage = "应用白名单 Root 服务尚未连接")
+            bindRootServices()
+            return
+        }
+
+        state = state.copy(actionRunningId = item.id, actionMessage = "正在保护 ${item.appName}…")
+        lifecycleScope.launch {
+            try {
+                val next = withContext(Dispatchers.IO) {
+                    val remote = runCatching { parsePackageWhitelist(service.getWhitelistPackages()) }
+                        .getOrDefault(emptySet())
+                    (remote + state.protectedPackages + packageName).toSortedSet()
+                }
+                val result = withContext(Dispatchers.IO) {
+                    JSONObject(service.saveWhitelistPackages(JSONArray(next.toList()).toString()))
+                }
+                if (!result.optBoolean("success")) {
+                    throw IllegalStateException(
+                        result.optString("message", result.optString("error", "白名单保存失败"))
+                    )
+                }
+                preferences.edit().putStringSet(PREF_PACKAGE_WHITELIST, next).apply()
+                state = state.copy(
+                    actionRunningId = "",
+                    protectedPackages = next,
+                    actionMessage = "已保护 ${item.appName}；下一次扫描会跳过该应用相关候选"
+                )
+            } catch (throwable: Throwable) {
+                state = state.copy(
+                    actionRunningId = "",
+                    actionMessage = "保护应用失败：${throwable.message ?: throwable.javaClass.simpleName}"
+                )
+            }
+        }
+    }
+
+    private fun protectPath(item: CleanResultItem) {
+        if (!settingsCanChange()) {
+            state = state.copy(actionMessage = "当前事务仍有剩余项目，请先完成或放弃清理计划，再修改白名单")
+            return
+        }
+        if (!item.canProtectPath) {
+            state = state.copy(actionMessage = "该路径不允许加入自定义保护列表")
+            return
+        }
+        val path = item.path.trimEnd('/').ifBlank { "/" }
+        if (!path.startsWith("/") || path.length !in 2..4096 || path.contains('\u0000')) {
+            state = state.copy(actionMessage = "路径格式无效，未修改白名单")
+            return
+        }
+        if (path in state.protectedPaths) {
+            state = state.copy(actionMessage = "该路径已经受到保护")
+            return
+        }
+        val next = (state.protectedPaths + path).toSortedSet()
+        preferences.edit().putStringSet(PREF_PATH_WHITELIST, next).apply()
+        state = state.copy(
+            protectedPaths = next,
+            actionMessage = "已保护此路径及其子项；下一次智能扫描立即生效"
+        )
+    }
+
+    private fun settingsCanChange(): Boolean = !state.live || state.remainingCandidates <= 0
 
     private fun parseItems(array: JSONArray?): List<CleanResultItem> {
         if (array == null) return emptyList()
         return buildList {
             for (index in 0 until array.length()) {
                 val item = array.optJSONObject(index) ?: continue
+                val packageName = item.optString("packageName").trim()
                 add(
                     CleanResultItem(
                         id = item.optString("id", item.optString("path")),
                         path = item.optString("path"),
+                        packageName = packageName,
+                        appName = resolveAppName(packageName),
                         category = item.optString("category", "other"),
                         risk = item.optString("risk", "low"),
                         action = item.optString("action", "changed"),
                         reason = item.optString("reason"),
+                        reasonCode = item.optString("reasonCode", "state_changed"),
+                        ruleId = item.optString("ruleId", "generic-clean-candidate"),
+                        ruleLabel = item.optString("ruleLabel", "清理候选"),
+                        ruleSource = item.optString("ruleSource", "扫描快照"),
+                        matchReason = item.optString("matchReason", "该路径在扫描时满足对应清理条件。"),
+                        protectionHint = item.optString("protectionHint"),
+                        canProtectPackage = item.optBoolean("canProtectPackage", packageName.isNotBlank()),
+                        canProtectPath = item.optBoolean("canProtectPath", false),
                         estimatedBytes = item.optLong("estimatedBytes").coerceAtLeast(0L),
                         deletedBytes = item.optLong("deletedBytes").coerceAtLeast(0L),
                         deletedFiles = item.optLong("deletedFiles").coerceAtLeast(0L),
@@ -205,25 +373,74 @@ class CleanResultActivity : ComponentActivity() {
         }
     }
 
+    private fun resolveAppName(packageName: String): String {
+        if (packageName.isBlank()) return "系统与共享存储"
+        return runCatching {
+            val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getApplicationInfo(
+                    packageName,
+                    android.content.pm.PackageManager.ApplicationInfoFlags.of(0)
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                packageManager.getApplicationInfo(packageName, 0)
+            }
+            packageManager.getApplicationLabel(info).toString().ifBlank { packageName }
+        }.getOrDefault(packageName)
+    }
+
+    private fun parsePackageWhitelist(raw: String?): Set<String> {
+        if (raw.isNullOrBlank()) return emptySet()
+        return runCatching {
+            val array = JSONArray(raw)
+            buildSet {
+                for (index in 0 until array.length()) {
+                    val value = array.optString(index).trim()
+                    if (PACKAGE_NAME.matches(value)) add(value)
+                }
+            }
+        }.getOrDefault(emptySet())
+    }
+
     override fun onDestroy() {
-        if (binding) runCatching { RootService.unbind(connection) }
+        if (reportBinding) runCatching { RootService.unbind(reportConnection) }
+        if (whitelistBinding) runCatching { RootService.unbind(whitelistConnection) }
         super.onDestroy()
     }
+
+    private data class LoadedReport(
+        val summary: JSONObject,
+        val page: JSONObject,
+        val items: List<CleanResultItem>
+    )
 
     companion object {
         const val EXTRA_REPORT_ID = "reportId"
         private const val PREF_LAST_REPORT_ID = "last_clean_result_id"
+        private const val PREF_PACKAGE_WHITELIST = "package_whitelist"
+        private const val PREF_PATH_WHITELIST = "path_whitelist"
         private const val PAGE_SIZE = 60
+        private val PACKAGE_NAME = Regex("^[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)+$")
     }
 }
 
 private data class CleanResultItem(
     val id: String,
     val path: String,
+    val packageName: String,
+    val appName: String,
     val category: String,
     val risk: String,
     val action: String,
     val reason: String,
+    val reasonCode: String,
+    val ruleId: String,
+    val ruleLabel: String,
+    val ruleSource: String,
+    val matchReason: String,
+    val protectionHint: String,
+    val canProtectPackage: Boolean,
+    val canProtectPath: Boolean,
     val estimatedBytes: Long,
     val deletedBytes: Long,
     val deletedFiles: Long,
@@ -232,10 +449,14 @@ private data class CleanResultItem(
 
 private data class CleanResultUiState(
     val connected: Boolean = false,
+    val whitelistConnected: Boolean = false,
     val loading: Boolean = false,
     val status: String = "正在连接清理报告引擎…",
     val message: String = "等待读取最近一次清理报告",
+    val actionMessage: String = "",
+    val actionRunningId: String = "",
     val reportId: String = "",
+    val live: Boolean = false,
     val action: String = "all",
     val authorizedCandidates: Int = 0,
     val processedCandidates: Int = 0,
@@ -251,7 +472,9 @@ private data class CleanResultUiState(
     val spaceRecoveryPercent: Int = 0,
     val items: List<CleanResultItem> = emptyList(),
     val totalItems: Int = 0,
-    val hasMore: Boolean = false
+    val hasMore: Boolean = false,
+    val protectedPackages: Set<String> = emptySet(),
+    val protectedPaths: Set<String> = emptySet()
 )
 
 @Composable
@@ -261,7 +484,9 @@ private fun CleanResultScreen(
     onReconnect: () -> Unit,
     onRefresh: () -> Unit,
     onAction: (String) -> Unit,
-    onLoadMore: () -> Unit
+    onLoadMore: () -> Unit,
+    onProtectPackage: (CleanResultItem) -> Unit,
+    onProtectPath: (CleanResultItem) -> Unit
 ) {
     val context = LocalContext.current
     val actions = listOf(
@@ -272,6 +497,8 @@ private fun CleanResultScreen(
         "partial" to "部分 ${state.partialCandidates}",
         "failed" to "失败 ${state.failedCandidates}"
     )
+    val settingsLocked = state.live && state.remainingCandidates > 0
+
     LazyColumn(
         modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
         contentPadding = PaddingValues(bottom = 34.dp),
@@ -284,9 +511,9 @@ private fun CleanResultScreen(
             ) {
                 IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
                 Column(modifier = Modifier.weight(1f)) {
-                    Text("CLEAN REPORT", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+                    Text("EXPLAINABLE CLEAN", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
                     Text("清理报告", fontSize = 30.sp, fontWeight = FontWeight.Black)
-                    Text("清理前后对比 · 逐项结果 · 原因可追踪", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("应用归属 · 规则来源 · 一键保护", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
                 IconButton(onClick = onRefresh, enabled = state.connected && !state.loading) {
                     Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
@@ -300,7 +527,7 @@ private fun CleanResultScreen(
                 shape = RoundedCornerShape(30.dp),
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
             ) {
-                Column(modifier = Modifier.padding(22.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(modifier = Modifier.padding(22.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Box(
                             modifier = Modifier.size(58.dp).background(MaterialTheme.colorScheme.primaryContainer, RoundedCornerShape(20.dp)),
@@ -322,9 +549,27 @@ private fun CleanResultScreen(
                             }
                         }
                     }
+                    if (state.actionMessage.isNotBlank()) {
+                        Text(
+                            state.actionMessage,
+                            color = if (state.actionMessage.contains("失败") || state.actionMessage.contains("无效")) {
+                                MaterialTheme.colorScheme.error
+                            } else MaterialTheme.colorScheme.primary,
+                            fontSize = 12.sp
+                        )
+                    }
+                    if (settingsLocked) {
+                        Text(
+                            "当前事务还剩 ${state.remainingCandidates} 项。为保证快照一致性，应用和路径保护将在计划完成后开放。",
+                            color = MaterialTheme.colorScheme.tertiary,
+                            fontSize = 12.sp
+                        )
+                    }
                     if (state.loading) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
                     if (!state.connected) {
-                        OutlinedButton(onClick = onReconnect, modifier = Modifier.fillMaxWidth()) { Text("重新连接 Root 引擎") }
+                        OutlinedButton(onClick = onReconnect, modifier = Modifier.fillMaxWidth()) {
+                            Text("重新连接 Root 引擎")
+                        }
                     }
                 }
             }
@@ -366,7 +611,16 @@ private fun CleanResultScreen(
         }
 
         items(state.items, key = { it.id + it.action }) { item ->
-            CleanResultItemCard(item)
+            CleanResultItemCard(
+                item = item,
+                settingsLocked = settingsLocked,
+                whitelistConnected = state.whitelistConnected,
+                actionRunning = state.actionRunningId == item.id,
+                packageProtected = item.packageName in state.protectedPackages,
+                pathProtected = item.path.trimEnd('/') in state.protectedPaths,
+                onProtectPackage = { onProtectPackage(item) },
+                onProtectPath = { onProtectPath(item) }
+            )
         }
 
         if (state.hasMore) {
@@ -384,7 +638,7 @@ private fun CleanResultScreen(
                 colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
             ) {
                 Text(
-                    "“已变化”表示扫描后目标不存在或属性变化；“受保护”表示白名单、安全边界或系统保护生效；“部分”和“失败”会继续保留在断点计划中，不会被伪装成清理成功。",
+                    "规则解释来自已经保存的清理结果，不会重新扫描。保护应用会同步写入 Root 清理引擎；保护路径会写入智能清理设置。两者都只影响下一次扫描，不会恢复已经删除的文件。",
                     modifier = Modifier.padding(18.dp),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontSize = 12.sp,
@@ -396,7 +650,16 @@ private fun CleanResultScreen(
 }
 
 @Composable
-private fun CleanResultItemCard(item: CleanResultItem) {
+private fun CleanResultItemCard(
+    item: CleanResultItem,
+    settingsLocked: Boolean,
+    whitelistConnected: Boolean,
+    actionRunning: Boolean,
+    packageProtected: Boolean,
+    pathProtected: Boolean,
+    onProtectPackage: () -> Unit,
+    onProtectPath: () -> Unit
+) {
     val context = LocalContext.current
     val actionLabel = when (item.action) {
         "cleaned" -> "已清理"
@@ -412,24 +675,81 @@ private fun CleanResultItemCard(item: CleanResultItem) {
         "fragment" -> "残留碎片"
         else -> "其他"
     }
+
     Card(
         modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
         shape = RoundedCornerShape(24.dp),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
     ) {
-        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Column(modifier = Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(actionLabel, color = if (item.action == "failed") MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold)
+                Text(
+                    actionLabel,
+                    color = if (item.action == "failed") MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
                 Spacer(Modifier.weight(1f))
                 Text("$categoryLabel · ${riskLabel(item.risk)}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
             }
-            Text(item.path, fontWeight = FontWeight.SemiBold, maxLines = 3, overflow = TextOverflow.Ellipsis)
-            Text(item.reason, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+
+            Text(item.appName, fontWeight = FontWeight.Bold, fontSize = 17.sp)
+            if (item.packageName.isNotBlank()) {
+                Text(item.packageName, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+            }
+            Text(item.path, fontWeight = FontWeight.SemiBold, maxLines = 4, overflow = TextOverflow.Ellipsis)
+
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(18.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerHigh
+            ) {
+                Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(item.ruleLabel, fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
+                    Text("${item.ruleSource} · ${item.ruleId}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                    Text(item.matchReason, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 17.sp)
+                }
+            }
+
+            Text("处理原因：${item.reason}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            Text("原因代码：${item.reasonCode}", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
             Text(
                 "预计 ${Formatter.formatFileSize(context, item.estimatedBytes)} · 实际 ${Formatter.formatFileSize(context, item.deletedBytes)} · 文件 ${item.deletedFiles} · 目录 ${item.deletedDirectories}",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 11.sp
             )
+            if (item.protectionHint.isNotBlank()) {
+                Text(item.protectionHint, color = MaterialTheme.colorScheme.tertiary, fontSize = 11.sp)
+            }
+
+            if (item.canProtectPackage || item.canProtectPath) {
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (item.canProtectPackage) {
+                        OutlinedButton(
+                            onClick = onProtectPackage,
+                            enabled = !settingsLocked && whitelistConnected && !actionRunning && !packageProtected,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(
+                                when {
+                                    packageProtected -> "应用已保护"
+                                    actionRunning -> "正在保护…"
+                                    else -> "保护整个应用"
+                                },
+                                maxLines = 1
+                            )
+                        }
+                    }
+                    if (item.canProtectPath) {
+                        OutlinedButton(
+                            onClick = onProtectPath,
+                            enabled = !settingsLocked && !actionRunning && !pathProtected,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(if (pathProtected) "路径已保护" else "保护此路径", maxLines = 1)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanResultRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanResultRootService.kt
@@ -12,9 +12,9 @@ import java.util.UUID
 /**
  * Read-only clean result archive and paging service.
  *
- * This service never discovers or accepts deletion targets. It reads the transaction journal written
- * by [CleanPlanResumeRootService], archives terminal reports before the transaction is removed, and
- * exposes compact summaries plus bounded result pages to the UI.
+ * The service never discovers or accepts deletion targets. It reads the transaction journal written
+ * by [CleanPlanResumeRootService], archives terminal reports, and enriches every result with a stable
+ * rule explanation and inferred application ownership for the report UI.
  */
 class CleanResultRootService : RootService() {
     private val binder = object : ICleanResultService.Stub() {
@@ -23,7 +23,7 @@ class CleanResultRootService : RootService() {
             return JSONObject()
                 .put("uid", Process.myUid())
                 .put("root", Process.myUid() == 0)
-                .put("engine", "clean-result-archive-v1")
+                .put("engine", "clean-result-explain-v2")
                 .put("reports", reportRoot().listFiles()?.count { it.isDirectory && summaryFile(it).isFile } ?: 0)
                 .put("latest", latestReportId())
                 .toString()
@@ -69,6 +69,7 @@ class CleanResultRootService : RootService() {
                 .put("archived", true)
                 .put("completedAt", System.currentTimeMillis())
                 .put("itemResultCount", items.size)
+                .put("explanationSchema", EXPLANATION_SCHEMA)
             val rows = items.joinToString(
                 separator = "\n",
                 postfix = if (items.isEmpty()) "" else "\n"
@@ -104,6 +105,7 @@ class CleanResultRootService : RootService() {
                 .put("success", true)
                 .put("live", live != null)
                 .put("archived", live == null)
+                .put("explanationSchema", EXPLANATION_SCHEMA)
                 .toString()
         }
 
@@ -134,11 +136,15 @@ class CleanResultRootService : RootService() {
                     query.isBlank() ||
                         it.optString("path").lowercase().contains(query) ||
                         it.optString("reason").lowercase().contains(query) ||
-                        it.optString("category").lowercase().contains(query)
+                        it.optString("packageName").lowercase().contains(query) ||
+                        it.optString("ruleLabel").lowercase().contains(query) ||
+                        it.optString("ruleSource").lowercase().contains(query) ||
+                        it.optString("matchReason").lowercase().contains(query)
                 }
                 .sortedWith(
                     compareBy<JSONObject> { actionPriority(normalizeAction(it.optString("action"))) }
                         .thenByDescending { it.optLong("deletedBytes") }
+                        .thenBy { it.optString("packageName") }
                         .thenBy { it.optString("path") }
                 )
                 .toList()
@@ -155,6 +161,7 @@ class CleanResultRootService : RootService() {
                 .put("limit", pageSize)
                 .put("total", filtered.size)
                 .put("hasMore", end < filtered.size)
+                .put("explanationSchema", EXPLANATION_SCHEMA)
                 .put("items", page)
                 .toString()
         }
@@ -209,7 +216,8 @@ class CleanResultRootService : RootService() {
         return buildList {
             file.useLines { lines ->
                 lines.take(MAX_RESULT_ITEMS).forEach { line ->
-                    parseJson(line).takeIf { it.length() > 0 }?.let(::add)
+                    val source = parseJson(line)
+                    if (source.length() > 0) add(enrichItem(source))
                 }
             }
         }
@@ -222,23 +230,178 @@ class CleanResultRootService : RootService() {
             val source = states.optJSONObject(keys.next()) ?: continue
             val path = source.optString("path")
             if (!path.startsWith("/")) continue
-            val action = normalizeAction(source.optString("action"))
-            val reason = source.optString("reason").ifBlank { defaultReason(action) }
-            val deletedBytes = source.optLong("deletedBytes", 0L).coerceAtLeast(0L)
-            val estimatedBytes = source.optLong(
-                "estimatedBytes",
-                if (action == "cleaned") deletedBytes else 0L
-            ).coerceAtLeast(0L)
-            values += JSONObject(source.toString())
-                .put("action", action)
-                .put("reason", reason)
-                .put("category", normalizeCategory(source.optString("category")))
-                .put("risk", normalizeRisk(source.optString("risk")))
-                .put("estimatedBytes", estimatedBytes)
-                .put("deletedBytes", deletedBytes)
-                .put("remainingEstimatedBytes", (estimatedBytes - deletedBytes).coerceAtLeast(0L))
+            values += enrichItem(source)
         }
         return values
+    }
+
+    private fun enrichItem(source: JSONObject): JSONObject {
+        val path = source.optString("path")
+        val action = normalizeAction(source.optString("action"))
+        val reason = source.optString("reason").ifBlank { defaultReason(action) }
+        val category = normalizeCategory(source.optString("category"))
+        val risk = normalizeRisk(source.optString("risk"))
+        val deletedBytes = source.optLong("deletedBytes", 0L).coerceAtLeast(0L)
+        val estimatedBytes = source.optLong(
+            "estimatedBytes",
+            if (action == "cleaned") deletedBytes else 0L
+        ).coerceAtLeast(0L)
+        val packageName = source.optString("packageName").trim()
+            .takeIf(::validPackageName)
+            ?: inferPackageName(path)
+        val explanation = explainRule(source, category, path)
+        val canProtectPath = protectablePath(path)
+        return JSONObject(source.toString())
+            .put("action", action)
+            .put("reason", reason)
+            .put("reasonCode", reasonCode(action, reason))
+            .put("category", category)
+            .put("risk", risk)
+            .put("packageName", packageName)
+            .put("ruleId", explanation.id)
+            .put("ruleLabel", explanation.label)
+            .put("ruleSource", explanation.source)
+            .put("matchReason", explanation.matchReason)
+            .put("estimatedBytes", estimatedBytes)
+            .put("deletedBytes", deletedBytes)
+            .put("remainingEstimatedBytes", (estimatedBytes - deletedBytes).coerceAtLeast(0L))
+            .put("canProtectPackage", packageName.isNotBlank())
+            .put("canProtectPath", canProtectPath)
+            .put("protectionTarget", if (packageName.isNotBlank()) "package" else if (canProtectPath) "path" else "none")
+            .put(
+                "protectionHint",
+                when {
+                    packageName.isNotBlank() -> "可保护整个应用，下一次扫描会跳过该应用相关候选"
+                    canProtectPath -> "可保护此路径及其子项，下一次扫描会跳过"
+                    else -> "此系统路径已经处于固定安全策略内"
+                }
+            )
+    }
+
+    private fun explainRule(source: JSONObject, category: String, path: String): RuleExplanation {
+        val lower = path.lowercase()
+        return when (category) {
+            "cache" -> {
+                val kind = when {
+                    lower.contains("/code_cache") -> "代码缓存"
+                    lower.contains("/external_cache") -> "外部缓存"
+                    else -> "应用缓存"
+                }
+                RuleExplanation(
+                    id = "cache-directory",
+                    label = kind,
+                    source = "内置缓存规则",
+                    matchReason = "目标位于应用缓存目录，扫描快照记录了其中可安全删除的缓存文件。"
+                )
+            }
+            "empty" -> RuleExplanation(
+                id = "empty-item",
+                label = "空文件或空目录",
+                source = "空项目规则",
+                matchReason = "扫描时文件大小为 0，或目录没有任何子项；清理前会再次确认仍为空。"
+            )
+            "fragment" -> fragmentExplanation(lower)
+            "rules" -> rulePathExplanation(lower, source.optString("ruleLabel"))
+            else -> when {
+                lower.contains("/android/data/") || lower.contains("/android/obb/") -> RuleExplanation(
+                    id = "android-app-storage",
+                    label = "Android 应用存储",
+                    source = "应用路径识别",
+                    matchReason = "路径属于 Android 应用专属目录，应用包名由标准目录结构解析。"
+                )
+                else -> RuleExplanation(
+                    id = "generic-clean-candidate",
+                    label = "清理候选",
+                    source = "扫描快照",
+                    matchReason = "该路径在扫描时满足对应清理条件，并被固化进不可变清理计划。"
+                )
+            }
+        }
+    }
+
+    private fun fragmentExplanation(lowerPath: String): RuleExplanation {
+        val name = lowerPath.substringAfterLast('/')
+        return when {
+            name.endsWith(".tmp") || name.endsWith(".temp") -> RuleExplanation(
+                "fragment-temp", "过期临时文件", "碎片文件规则", "文件名使用临时扩展名，并且修改时间超过设置的保留天数。"
+            )
+            name.endsWith(".part") || name.endsWith(".partial") || name.endsWith(".download") || name.endsWith(".crdownload") -> RuleExplanation(
+                "fragment-download", "中断下载碎片", "碎片文件规则", "文件名符合未完成下载格式，并且已经超过保留期限。"
+            )
+            name.contains("tombstone") || name.contains("minidump") || name.contains("heapdump") ||
+                name.contains("crash") || name.contains("trace") || name.contains("dump") -> RuleExplanation(
+                "fragment-crash", "崩溃与转储碎片", "崩溃文件规则", "文件名表明它是崩溃、跟踪或内存转储产物，并且已经过期。"
+            )
+            else -> RuleExplanation(
+                "fragment-aged", "过期残留碎片", "碎片文件规则", "文件名符合碎片模式，且最后修改时间早于当前保留期限。"
+            )
+        }
+    }
+
+    private fun rulePathExplanation(lowerPath: String, existingLabel: String): RuleExplanation {
+        val known = when {
+            lowerPath == "/data/anr" || lowerPath.startsWith("/data/anr/") -> Triple("system-anr", "系统 ANR", "系统诊断规则")
+            lowerPath == "/data/tombstones" || lowerPath.startsWith("/data/tombstones/") -> Triple("system-tombstone", "Tombstone", "系统诊断规则")
+            lowerPath == "/data/system/dropbox" || lowerPath.startsWith("/data/system/dropbox/") -> Triple("system-dropbox", "系统 Dropbox", "系统诊断规则")
+            lowerPath == "/data/system/heapdump" || lowerPath.startsWith("/data/system/heapdump/") -> Triple("system-heapdump", "系统 Heapdump", "系统诊断规则")
+            lowerPath == "/data/misc/logd" || lowerPath.startsWith("/data/misc/logd/") -> Triple("system-logd", "系统日志", "系统日志规则")
+            lowerPath == "/data/vendor/log" || lowerPath.startsWith("/data/vendor/log/") -> Triple("vendor-log", "厂商日志", "厂商日志规则")
+            lowerPath == "/data/log" || lowerPath.startsWith("/data/log/") -> Triple("system-log", "系统日志", "系统日志规则")
+            lowerPath.substringAfterLast('/') in HIDDEN_TRASH_NAMES -> Triple("hidden-trash", "隐藏垃圾目录", "共享存储启发式规则")
+            else -> null
+        }
+        if (known != null) {
+            return RuleExplanation(
+                known.first,
+                known.second,
+                known.third,
+                "目标路径命中 ${known.second} 的受控清理范围；删除前仍会检查白名单、挂载点和符号链接。"
+            )
+        }
+        val label = existingLabel.takeIf { it.isNotBlank() } ?: "扩展路径规则"
+        return RuleExplanation(
+            "extended-path-rule",
+            label,
+            "模块扩展规则",
+            "目标路径命中模块内置或用户扩展的绝对路径规则；报告只解释命中来源，不会重新执行规则发现。"
+        )
+    }
+
+    private fun reasonCode(action: String, reason: String): String {
+        val value = reason.lowercase()
+        return when {
+            value.contains("白名单") -> "whitelist"
+            value.contains("安全边界") || value.contains("路径格式") -> "safety_boundary"
+            value.contains("不存在") -> "missing"
+            value.contains("符号链接") -> "symlink"
+            value.contains("挂载点") -> "mount_point"
+            value.contains("风险") -> "risk_policy"
+            value.contains("发生变化") || value.contains("不再") -> "changed_after_scan"
+            action == "cleaned" -> "deleted"
+            action == "partial" -> "partial_delete"
+            action == "failed" -> "delete_failed"
+            action == "protected" -> "protected"
+            else -> "state_changed"
+        }
+    }
+
+    private fun inferPackageName(path: String): String {
+        for (pattern in PACKAGE_PATH_PATTERNS) {
+            val value = pattern.find(path)?.groupValues?.getOrNull(1).orEmpty()
+            if (validPackageName(value)) return value
+        }
+        return ""
+    }
+
+    private fun validPackageName(value: String): Boolean = PACKAGE_NAME.matches(value)
+
+    private fun protectablePath(path: String): Boolean {
+        val normalized = path.trimEnd('/').ifBlank { "/" }
+        if (normalized.length !in 2..4096 || normalized.contains('\u0000')) return false
+        if (HARD_EXACT.contains(normalized)) return false
+        if (READ_ONLY.any { normalized == it || normalized.startsWith("$it/") }) return false
+        if (normalized == "/data/adb" || normalized.startsWith("/data/adb/")) return false
+        return MUTABLE_ROOTS.any { normalized == it || normalized.startsWith("$it/") }
     }
 
     private fun transactionState(id: String): JSONObject? {
@@ -368,11 +531,39 @@ class CleanResultRootService : RootService() {
         .put("message", message)
         .toString()
 
+    private data class RuleExplanation(
+        val id: String,
+        val label: String,
+        val source: String,
+        val matchReason: String
+    )
+
     companion object {
-        private const val REPORT_VERSION = 1
+        private const val REPORT_VERSION = 2
+        private const val EXPLANATION_SCHEMA = "rule-explanation-v1"
         private const val REPORT_TTL_MS = 30L * 24L * 60L * 60_000L
         private const val MAX_REPORTS = 50
         private const val MAX_RESULT_ITEMS = 20_000
         private const val MAX_PAGE_SIZE = 100
+
+        private val PACKAGE_NAME = Regex("^[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)+$")
+        private val PACKAGE_PATH_PATTERNS = listOf(
+            Regex("^/data/user/[0-9]+/([A-Za-z0-9_.]+)(?:/|$)"),
+            Regex("^/data/data/([A-Za-z0-9_.]+)(?:/|$)"),
+            Regex("^/storage/emulated/[0-9]+/Android/(?:data|obb|media)/([A-Za-z0-9_.]+)(?:/|$)"),
+            Regex("^/sdcard/Android/(?:data|obb|media)/([A-Za-z0-9_.]+)(?:/|$)")
+        )
+        private val HIDDEN_TRASH_NAMES = setOf(".cache", ".thumbnails", ".tmp", ".temp", ".logs", ".debug")
+        private val HARD_EXACT = setOf(
+            "/", "/data", "/data/adb", "/data/system", "/data/misc", "/storage", "/storage/emulated", "/sdcard"
+        )
+        private val READ_ONLY = setOf(
+            "/system", "/vendor", "/product", "/odm", "/apex", "/proc", "/sys", "/dev", "/metadata"
+        )
+        private val MUTABLE_ROOTS = setOf(
+            "/data/user", "/data/data", "/data/anr", "/data/tombstones", "/data/system/dropbox",
+            "/data/system/heapdump", "/data/misc/logd", "/data/vendor/log", "/data/log",
+            "/storage/emulated", "/sdcard"
+        )
     }
 }

--- a/v2/tests/test-clean-plan-persistence.py
+++ b/v2/tests/test-clean-plan-persistence.py
@@ -71,4 +71,5 @@ for method in ("scanSafe", "getPage", "cleanSafe", "getTaskState", "cancelCurren
 
 runpy.run_path(str(ROOT / "v2/tests/test-candidate-selection-plan.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-clean-result-report.py"), run_name="__main__")
+runpy.run_path(str(ROOT / "v2/tests/test-explainable-rules-whitelist.py"), run_name="__main__")
 print("clean plan persistence contract: ok")

--- a/v2/tests/test-clean-result-report.py
+++ b/v2/tests/test-clean-result-report.py
@@ -34,7 +34,7 @@ require("items.ndjson" in SERVICE and "MAX_RESULT_ITEMS" in SERVICE,
         "item outcomes must be stored outside the compact summary")
 
 for marker in (
-    "BEFORE / AFTER", "清理前后对比", "逐项结果", "受保护", "已变化",
+    "BEFORE / AFTER", "清理前后对比", "CleanResultItemCard", "受保护", "已变化",
     "getSummary", "getPage", "FilterChip", "加载更多"
 ):
     require(marker in ACTIVITY, f"result UI contract missing: {marker}")

--- a/v2/tests/test-explainable-rules-whitelist.py
+++ b/v2/tests/test-explainable-rules-whitelist.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+# Sixth-stage contract: reports explain matches and mutate only explicit whitelist settings.
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
+ACTIVITY = (APP / "CleanResultActivity.kt").read_text(encoding="utf-8")
+SERVICE = (APP / "root/CleanResultRootService.kt").read_text(encoding="utf-8")
+PROFILE_AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl").read_text(encoding="utf-8")
+
+
+def require(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+for marker in (
+    "EXPLANATION_SCHEMA", "rule-explanation-v1", "enrichItem", "inferPackageName",
+    "explainRule", "fragmentExplanation", "rulePathExplanation", "reasonCode",
+    "ruleId", "ruleLabel", "ruleSource", "matchReason", "protectionTarget",
+    "canProtectPackage", "canProtectPath", "PACKAGE_PATH_PATTERNS"
+):
+    require(marker in SERVICE, f"explainable result primitive missing: {marker}")
+
+require("add(enrichItem(source))" in SERVICE,
+        "old archived result rows must be enriched when read")
+require("scanCandidates(" not in SERVICE and "scanSafe(" not in SERVICE and "engine.scan(" not in SERVICE,
+        "rule explanation service must remain read-only and must not discover candidates")
+require("MUTABLE_ROOTS" in SERVICE and "HARD_EXACT" in SERVICE and "READ_ONLY" in SERVICE,
+        "path whitelist suggestions must respect fixed safety roots")
+
+for marker in (
+    "BaiZeProfileRootService", "IProfileRootService", "saveWhitelistPackages",
+    "getWhitelistPackages", "protectPackage", "protectPath", "resolveAppName",
+    "package_whitelist", "path_whitelist", "保护整个应用", "保护此路径",
+    "规则来源", "应用归属", "settingsCanChange", "state.live && state.remainingCandidates > 0"
+):
+    require(marker in ACTIVITY, f"report whitelist or app UI contract missing: {marker}")
+
+require("String saveWhitelistPackages(String packagesJson);" in PROFILE_AIDL,
+        "package whitelist must be written through the Root profile service")
+require("preferences.edit().putStringSet(PREF_PACKAGE_WHITELIST" in ACTIVITY,
+        "successful Root package whitelist writes must synchronize local plan options")
+require("preferences.edit().putStringSet(PREF_PATH_WHITELIST" in ACTIVITY,
+        "path protection must persist into smart-clean options")
+require("scanCandidates(" not in ACTIVITY and "scanSafe(" not in ACTIVITY and "cleanSelected(" not in ACTIVITY,
+        "report UI actions must not scan or clean")
+
+save_pos = ACTIVITY.index("service.saveWhitelistPackages")
+local_package_pos = ACTIVITY.index("preferences.edit().putStringSet(PREF_PACKAGE_WHITELIST", save_pos)
+require(save_pos < local_package_pos,
+        "package whitelist must be accepted by Root before local options are updated")
+
+print("explainable rule and whitelist contract: ok")


### PR DESCRIPTION
## 第六阶段：规则解释、应用归属与快捷保护

- 为每条清理结果补齐规则编号、规则名称、规则来源、命中原因和处理原因代码。
- 从标准 Android 路径解析应用包名，并在报告页显示真实应用名称。
- 兼容第五阶段旧归档：读取旧 NDJSON 时即时补充解释字段，无需重新扫描或重新清理。
- 报告搜索同时覆盖路径、包名、规则名称、规则来源和命中原因。
- 报告页新增“保护整个应用”和“保护此路径”快捷操作。
- 应用保护先通过 Root 白名单服务写入，成功后再同步本地智能清理选项。
- 路径保护只允许可变数据目录，拒绝系统只读根目录、挂载根和 `/data/adb` 等固定安全路径。
- 活跃事务仍有剩余项目时锁定白名单修改，避免当前快照因设置变化失效。
- 报告服务和报告 UI 均不包含扫描或删除调用。

## 堆叠关系

本 PR 基于第五阶段 `agent/clean-result-explanation`，已经整理为 1 个干净提交、5 个第六阶段文件；没有修改扫描器、删除器或清理事务格式。

## 验证结果

完整工作流 `BaiZe v2.4.1 Verify and Release #46` 已全部通过：

- 第六阶段规则解释、旧归档兼容、应用归属和白名单写入契约：通过
- 前五阶段清理计划、断点恢复、真实统计、候选选择和报告归档回归：通过
- Root Shell、调度公平性、增量索引和归类事务回归：通过
- Android Release、Debug Kotlin、Lint 和 Macrobenchmark：通过
- ARM64 原生扫描器：通过
- 模块封包、内置 APK 一致性和签名产物校验：通过

最终分支只保留报告 RootService、报告 Activity 和 3 个契约测试文件。