### PR TITLE
feat(rules): add signed rule pack management

### DIFF
--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         <activity android:name=".ResumableSmartScanActivity" android:exported="false" />
         <activity android:name=".CandidateSmartScanActivity" android:exported="false" />
         <activity android:name=".CleanResultActivity" android:exported="false" />
+        <activity android:name=".RulePackActivity" android:exported="false" />
         <activity-alias
             android:name=".SmartScanActivity"
             android:exported="false"
@@ -75,6 +76,10 @@
             tools:ignore="Instantiatable" />
         <service
             android:name=".root.CleanResultRootService"
+            android:exported="false"
+            tools:ignore="Instantiatable" />
+        <service
+            android:name=".root.RulePackRootService"
             android:exported="false"
             tools:ignore="Instantiatable" />
     </application>

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IRulePackService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IRulePackService.aidl
@@ -1,0 +1,10 @@
+package io.github.xgl34222220.baize.root;
+
+interface IRulePackService {
+    String ping();
+    String getCurrent();
+    String previewPackage(String packagePath);
+    String applyPreview(String previewId);
+    String rollback();
+    String getHistory(int limit);
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt
@@ -115,7 +115,8 @@ class CleanCenterActivity : ComponentActivity() {
                             },
                             onSmartScan = { startActivity(Intent(this, SmartScanActivity::class.java)) },
                             onOpenCache = { startActivity(Intent(this, CacheActivity::class.java)) },
-                            onOpenProfile = ::openProfile
+                            onOpenProfile = ::openProfile,
+                            onRulePack = { startActivity(Intent(this, RulePackActivity::class.java)) }
                         )
                     )
                 }
@@ -136,7 +137,8 @@ private data class CleanCenterActions(
     val onQuickClean: () -> Unit,
     val onSmartScan: () -> Unit,
     val onOpenCache: () -> Unit,
-    val onOpenProfile: (String) -> Unit
+    val onOpenProfile: (String) -> Unit,
+    val onRulePack: () -> Unit
 )
 
 private data class CleanCenterItem(
@@ -207,6 +209,7 @@ private fun CleanCenterMaterial(
         CleanCenterItem(Icons.Rounded.Apps, "残留碎片", "过期临时文件、旋转日志与中断下载", "保留期", profile = "fragments")
     )
     val advanced = listOf(
+        CleanCenterItem(Icons.Rounded.Rule, "规则管理中心", "版本、签名、更新预览与回滚", "已签名", directAction = actions.onRulePack),
         CleanCenterItem(Icons.Rounded.DeleteForever, "卸载残留", "核对 data、obb、media 与应用私有目录", "二次确认", profile = "corpses", dangerous = true),
         CleanCenterItem(Icons.Rounded.DeleteSweep, "完整深度清理", "完整规则库扫描并按风险分级", "二次确认", profile = "deep", dangerous = true)
     )
@@ -432,6 +435,7 @@ private fun CleanCenterMiuix(
         CleanCenterItem(Icons.Rounded.Apps, "残留碎片", "临时文件与中断下载", "保留期", profile = "fragments")
     )
     val advanced = listOf(
+        CleanCenterItem(Icons.Rounded.Rule, "规则管理中心", "签名校验、预览与回滚", "已签名", directAction = actions.onRulePack),
         CleanCenterItem(Icons.Rounded.DeleteForever, "卸载残留", "核对无主应用目录", "确认", profile = "corpses", dangerous = true),
         CleanCenterItem(Icons.Rounded.DeleteSweep, "完整深度清理", "4,714 条规则风险分级", "确认", profile = "deep", dangerous = true)
     )

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/RulePackActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/RulePackActivity.kt
@@ -1,0 +1,681 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.net.Uri
+import android.os.Bundle
+import android.os.IBinder
+import android.text.format.Formatter
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Rule
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.IRulePackService
+import io.github.xgl34222220.baize.root.RulePackRootService
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
+
+class RulePackActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private var service: IRulePackService? = null
+    private var bindingRequested = false
+    private var showApplyConfirm by mutableStateOf(false)
+    private var showRollbackConfirm by mutableStateOf(false)
+    private var state by mutableStateOf(RulePackUiState())
+
+    private val openDocument = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        if (uri != null) importPackage(uri)
+    }
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            service = IRulePackService.Stub.asInterface(binder)
+            bindingRequested = true
+            state = state.copy(connected = true, message = "签名验证与回滚引擎已连接")
+            refresh()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            service = null
+            bindingRequested = false
+            state = state.copy(connected = false, working = false, message = "Root 规则服务已断开")
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContent {
+            val appearance = appearanceViewModel.settings.collectAsStateWithLifecycle().value
+            BaiZeTheme(appearance) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    RulePackScreen(
+                        state = state,
+                        onBack = ::finish,
+                        onImport = {
+                            openDocument.launch(
+                                arrayOf(
+                                    "application/java-archive",
+                                    "application/zip",
+                                    "application/octet-stream"
+                                )
+                            )
+                        },
+                        onRefresh = ::refresh,
+                        onApply = { showApplyConfirm = true },
+                        onRollback = { showRollbackConfirm = true },
+                        onReconnect = ::bindService
+                    )
+                    if (showApplyConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showApplyConfirm = false },
+                            title = { Text("安装已验证规则包？") },
+                            text = {
+                                Text(
+                                    "安装前会备份当前托管规则，并原子替换 app、external、hidden 与 deep 规则。custom.rules 不会被修改。"
+                                )
+                            },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    showApplyConfirm = false
+                                    applyPreview()
+                                }) { Text("安装更新") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showApplyConfirm = false }) { Text("取消") }
+                            }
+                        )
+                    }
+                    if (showRollbackConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showRollbackConfirm = false },
+                            title = { Text("回滚到上一版规则？") },
+                            text = { Text("将恢复最近一次安装前的完整规则备份。正在执行扫描或清理时不会允许回滚。") },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    showRollbackConfirm = false
+                                    rollback()
+                                }) { Text("立即回滚") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showRollbackConfirm = false }) { Text("取消") }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        bindService()
+    }
+
+    private fun bindService() {
+        if (service != null || bindingRequested) return
+        state = state.copy(message = "正在连接 Root 规则服务…")
+        runCatching {
+            RootService.bind(
+                Intent(this, RulePackRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                connection
+            )
+            bindingRequested = true
+        }.onFailure {
+            bindingRequested = false
+            state = state.copy(message = "Root 规则服务启动失败：${it.message ?: it.javaClass.simpleName}")
+        }
+    }
+
+    private fun refresh() {
+        val root = service ?: run {
+            bindService()
+            return
+        }
+        state = state.copy(working = true, message = "正在读取当前规则包与回滚记录…")
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching {
+                    JSONObject(root.getCurrent()) to JSONObject(root.getHistory(12))
+                }
+            }
+            result.onSuccess { (current, history) ->
+                state = state.copy(
+                    connected = true,
+                    working = false,
+                    current = parseCurrent(current),
+                    history = parseHistory(history.optJSONArray("items")),
+                    message = if (state.preview == null) "规则包状态已更新" else state.message
+                )
+            }.onFailure {
+                state = state.copy(working = false, message = "读取规则包状态失败：${it.message}")
+            }
+        }
+    }
+
+    private fun importPackage(uri: Uri) {
+        val root = service ?: run {
+            state = state.copy(message = "Root 规则服务尚未连接")
+            bindService()
+            return
+        }
+        state = state.copy(working = true, preview = null, message = "正在复制并验证签名规则包…")
+        lifecycleScope.launch {
+            var localFile: File? = null
+            val result = withContext(Dispatchers.IO) {
+                runCatching {
+                    localFile = copyImport(uri)
+                    JSONObject(root.previewPackage(localFile!!.absolutePath))
+                }
+            }
+            runCatching { localFile?.delete() }
+            result.onSuccess { json ->
+                if (json.has("error")) {
+                    state = state.copy(
+                        working = false,
+                        message = "规则包验证失败：${json.optString("message", json.optString("error"))}"
+                    )
+                } else {
+                    state = state.copy(
+                        working = false,
+                        preview = parsePreview(json),
+                        message = "签名与规则内容验证通过，请核对更新差异"
+                    )
+                }
+            }.onFailure {
+                state = state.copy(working = false, message = "导入失败：${it.message ?: it.javaClass.simpleName}")
+            }
+        }
+    }
+
+    private fun applyPreview() {
+        val root = service ?: return
+        val previewId = state.preview?.previewId.orEmpty()
+        if (previewId.isBlank()) return
+        state = state.copy(working = true, message = "正在备份当前规则并原子安装更新…")
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) { runCatching { JSONObject(root.applyPreview(previewId)) } }
+            result.onSuccess { json ->
+                if (json.has("error")) {
+                    state = state.copy(working = false, message = "安装失败：${json.optString("message")}")
+                } else {
+                    state = state.copy(
+                        working = false,
+                        preview = null,
+                        current = parseCurrent(json),
+                        message = "规则包 ${json.optString("version")} 已安装，可一键回滚"
+                    )
+                    refresh()
+                }
+            }.onFailure {
+                state = state.copy(working = false, message = "安装失败：${it.message}")
+            }
+        }
+    }
+
+    private fun rollback() {
+        val root = service ?: return
+        state = state.copy(working = true, message = "正在恢复上一版规则…")
+        lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) { runCatching { JSONObject(root.rollback()) } }
+            result.onSuccess { json ->
+                if (json.has("error")) {
+                    state = state.copy(working = false, message = "回滚失败：${json.optString("message")}")
+                } else {
+                    state = state.copy(
+                        working = false,
+                        preview = null,
+                        current = parseCurrent(json),
+                        message = "已回滚到 ${json.optString("version", "上一版规则")}"
+                    )
+                    refresh()
+                }
+            }.onFailure {
+                state = state.copy(working = false, message = "回滚失败：${it.message}")
+            }
+        }
+    }
+
+    private fun copyImport(uri: Uri): File {
+        val directory = File(cacheDir, "rule-pack-imports").apply { mkdirs() }
+        directory.listFiles()?.filter { it.isFile && System.currentTimeMillis() - it.lastModified() > IMPORT_TTL_MS }
+            ?.forEach { it.delete() }
+        val target = File(directory, "${UUID.randomUUID()}.jar")
+        val input = contentResolver.openInputStream(uri) ?: error("无法读取所选文件")
+        input.use { source ->
+            FileOutputStream(target).use { output ->
+                val buffer = ByteArray(64 * 1024)
+                var total = 0L
+                while (true) {
+                    val read = source.read(buffer)
+                    if (read <= 0) break
+                    total += read
+                    if (total > MAX_IMPORT_BYTES) error("规则包超过 ${MAX_IMPORT_BYTES / 1024 / 1024}MB")
+                    output.write(buffer, 0, read)
+                }
+                output.fd.sync()
+            }
+        }
+        return target
+    }
+
+    private fun parseCurrent(json: JSONObject): CurrentRulePack = CurrentRulePack(
+        packId = json.optString("packId", "baize-bundled"),
+        version = json.optString("version", "bundled"),
+        digest = json.optString("digest"),
+        totalRules = json.optInt("totalRules", 0),
+        totalBytes = json.optLong("totalBytes", 0L),
+        installedAt = json.optLong("installedAt", 0L),
+        signerSha256 = json.optString("signerSha256"),
+        rollbackAvailable = json.optBoolean("rollbackAvailable")
+    )
+
+    private fun parsePreview(json: JSONObject): RulePackPreview {
+        val files = buildList {
+            val array = json.optJSONArray("files") ?: JSONArray()
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                add(
+                    RuleFileDiff(
+                        name = item.optString("name"),
+                        status = item.optString("status"),
+                        currentRules = item.optInt("currentRules"),
+                        incomingRules = item.optInt("incomingRules"),
+                        ruleDelta = item.optInt("ruleDelta")
+                    )
+                )
+            }
+        }
+        return RulePackPreview(
+            previewId = json.optString("previewId"),
+            packId = json.optString("packId"),
+            version = json.optString("version"),
+            releaseNotes = json.optString("releaseNotes"),
+            signerSha256 = json.optString("signerSha256"),
+            currentVersion = json.optString("currentVersion"),
+            currentRules = json.optInt("currentRules"),
+            incomingRules = json.optInt("incomingRules"),
+            files = files
+        )
+    }
+
+    private fun parseHistory(array: JSONArray?): List<RulePackHistory> = buildList {
+        if (array == null) return@buildList
+        for (index in 0 until array.length()) {
+            val item = array.optJSONObject(index) ?: continue
+            add(
+                RulePackHistory(
+                    action = item.optString("action"),
+                    version = item.optString("version"),
+                    time = item.optLong("time"),
+                    digest = item.optString("digest")
+                )
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        if (bindingRequested) runCatching { RootService.unbind(connection) }
+        super.onDestroy()
+    }
+
+    companion object {
+        private const val MAX_IMPORT_BYTES = 32L * 1024L * 1024L
+        private const val IMPORT_TTL_MS = 60L * 60_000L
+    }
+}
+
+private data class RulePackUiState(
+    val connected: Boolean = false,
+    val working: Boolean = false,
+    val message: String = "正在连接 Root 规则服务…",
+    val current: CurrentRulePack = CurrentRulePack(),
+    val preview: RulePackPreview? = null,
+    val history: List<RulePackHistory> = emptyList()
+)
+
+private data class CurrentRulePack(
+    val packId: String = "baize-bundled",
+    val version: String = "bundled",
+    val digest: String = "",
+    val totalRules: Int = 0,
+    val totalBytes: Long = 0L,
+    val installedAt: Long = 0L,
+    val signerSha256: String = "",
+    val rollbackAvailable: Boolean = false
+)
+
+private data class RulePackPreview(
+    val previewId: String,
+    val packId: String,
+    val version: String,
+    val releaseNotes: String,
+    val signerSha256: String,
+    val currentVersion: String,
+    val currentRules: Int,
+    val incomingRules: Int,
+    val files: List<RuleFileDiff>
+)
+
+private data class RuleFileDiff(
+    val name: String,
+    val status: String,
+    val currentRules: Int,
+    val incomingRules: Int,
+    val ruleDelta: Int
+)
+
+private data class RulePackHistory(
+    val action: String,
+    val version: String,
+    val time: Long,
+    val digest: String
+)
+
+@Composable
+private fun RulePackScreen(
+    state: RulePackUiState,
+    onBack: () -> Unit,
+    onImport: () -> Unit,
+    onRefresh: () -> Unit,
+    onApply: () -> Unit,
+    onRollback: () -> Unit,
+    onReconnect: () -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
+                Spacer(Modifier.width(8.dp))
+                Column(Modifier.weight(1f)) {
+                    Text("RULE PACK", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.3.sp)
+                    Text("规则管理中心", fontSize = 32.sp, fontWeight = FontWeight.Black)
+                    Text("证书校验 · 更新预览 · 原子安装 · 一键回滚", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(28.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+            ) {
+                Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Surface(
+                            modifier = Modifier.size(58.dp),
+                            shape = RoundedCornerShape(20.dp),
+                            color = if (state.connected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.errorContainer
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(
+                                    if (state.connected) Icons.Rounded.Security else Icons.Rounded.Warning,
+                                    contentDescription = null,
+                                    tint = if (state.connected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(29.dp)
+                                )
+                            }
+                        }
+                        Spacer(Modifier.width(14.dp))
+                        Column(Modifier.weight(1f)) {
+                            Text(if (state.connected) "受信任规则引擎" else "规则引擎未连接", fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                            Text(state.message, color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 3, overflow = TextOverflow.Ellipsis)
+                        }
+                    }
+                    if (state.working) LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                    if (!state.connected) {
+                        OutlinedButton(onClick = onReconnect, modifier = Modifier.fillMaxWidth()) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text("重新连接 Root 服务")
+                        }
+                    }
+                }
+            }
+        }
+
+        item { CurrentRulePackCard(state.current) }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                shape = RoundedCornerShape(26.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+            ) {
+                Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Text("规则包操作", fontWeight = FontWeight.Black, fontSize = 20.sp)
+                    Text(
+                        "仅接受由当前白泽 APK 同一证书签名的完整 JAR/ZIP 规则包。导入后先显示差异，不会立即覆盖。",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp
+                    )
+                    Button(
+                        onClick = onImport,
+                        enabled = state.connected && !state.working,
+                        modifier = Modifier.fillMaxWidth().height(54.dp),
+                        shape = RoundedCornerShape(18.dp)
+                    ) {
+                        Icon(Icons.Rounded.Rule, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("导入已签名规则包", fontWeight = FontWeight.Bold)
+                    }
+                    OutlinedButton(
+                        onClick = onRollback,
+                        enabled = state.connected && !state.working && state.current.rollbackAvailable,
+                        modifier = Modifier.fillMaxWidth().height(50.dp),
+                        shape = RoundedCornerShape(17.dp)
+                    ) {
+                        Icon(Icons.Rounded.Refresh, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text(if (state.current.rollbackAvailable) "回滚到上一版规则" else "暂无可回滚版本")
+                    }
+                }
+            }
+        }
+
+        state.preview?.let { preview ->
+            item { PreviewCard(preview, state.working, onApply) }
+        }
+
+        if (state.history.isNotEmpty()) {
+            item {
+                Column(Modifier.padding(horizontal = 20.dp)) {
+                    Text("HISTORY", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+                    Text("安装与回滚记录", fontSize = 24.sp, fontWeight = FontWeight.Black)
+                }
+            }
+            item { HistoryCard(state.history) }
+        }
+
+        item {
+            OutlinedButton(
+                onClick = onRefresh,
+                enabled = state.connected && !state.working,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding()
+            ) {
+                Icon(Icons.Rounded.Refresh, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("刷新规则状态")
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentRulePackCard(current: CurrentRulePack) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(7.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Rounded.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(8.dp))
+                Text("当前规则包", fontWeight = FontWeight.Black, fontSize = 19.sp)
+            }
+            Text(current.version, fontSize = 28.sp, fontWeight = FontWeight.Black)
+            Text(
+                "${current.totalRules} 条有效规则 · ${Formatter.formatFileSize(context, current.totalBytes)}",
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Text("规则集指纹 ${current.digest.take(16).ifBlank { "尚未生成" }}", fontSize = 12.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
+            if (current.signerSha256.isNotBlank()) {
+                Text("签名证书 ${current.signerSha256.take(16)}", fontSize = 12.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
+            } else {
+                Text("模块内置规则 · 尚未通过管理中心安装", fontSize = 12.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewCard(preview: RulePackPreview, working: Boolean, onApply: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
+    ) {
+        Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("SIGNED PREVIEW", color = MaterialTheme.colorScheme.secondary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+            Text("${preview.currentVersion} → ${preview.version}", fontSize = 25.sp, fontWeight = FontWeight.Black)
+            Text(
+                "证书 ${preview.signerSha256.take(16)} · 规则 ${preview.currentRules} → ${preview.incomingRules}",
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                fontSize = 12.sp
+            )
+            if (preview.releaseNotes.isNotBlank()) {
+                Text(preview.releaseNotes, color = MaterialTheme.colorScheme.onSecondaryContainer)
+            }
+            HorizontalDivider()
+            preview.files.forEach { file -> RuleDiffRow(file) }
+            FilledTonalButton(
+                onClick = onApply,
+                enabled = !working,
+                modifier = Modifier.fillMaxWidth().height(54.dp),
+                shape = RoundedCornerShape(18.dp)
+            ) {
+                Icon(Icons.Rounded.CheckCircle, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("备份并安装此规则包", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RuleDiffRow(file: RuleFileDiff) {
+    val label = when (file.status) {
+        "added" -> "新增"
+        "removed" -> "移除"
+        "changed" -> "更新"
+        else -> "不变"
+    }
+    Row(Modifier.fillMaxWidth().padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) {
+            Text(file.name, fontWeight = FontWeight.Bold)
+            Text("${file.currentRules} → ${file.incomingRules} 条", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+        }
+        Text(
+            if (file.ruleDelta == 0) label else "$label ${if (file.ruleDelta > 0) "+" else ""}${file.ruleDelta}",
+            color = MaterialTheme.colorScheme.secondary,
+            fontWeight = FontWeight.Bold,
+            fontSize = 12.sp
+        )
+    }
+}
+
+@Composable
+private fun HistoryCard(history: List<RulePackHistory>) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(25.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(Modifier.padding(horizontal = 18.dp, vertical = 8.dp)) {
+            history.forEachIndexed { index, item ->
+                Row(Modifier.fillMaxWidth().padding(vertical = 11.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        if (item.action == "rollback") Icons.Rounded.Refresh else Icons.Rounded.CheckCircle,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(22.dp)
+                    )
+                    Spacer(Modifier.width(11.dp))
+                    Column(Modifier.weight(1f)) {
+                        Text(if (item.action == "rollback") "规则回滚" else "规则安装", fontWeight = FontWeight.Bold)
+                        Text(item.version.ifBlank { "未知版本" }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                    }
+                    Text(item.digest.take(8), color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                }
+                if (index != history.lastIndex) HorizontalDivider()
+            }
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RulePackRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RulePackRootService.kt
@@ -1,0 +1,648 @@
+package io.github.xgl34222220.baize.root
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.IBinder
+import android.os.Process
+import com.topjohnwu.superuser.ipc.RootService
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.security.MessageDigest
+import java.util.UUID
+import java.util.jar.JarFile
+
+/**
+ * Signed rule-pack manager.
+ *
+ * Imported packs are ordinary JAR/ZIP files signed with the same certificate as the installed APK.
+ * The service verifies every payload entry, stages a bounded preview, creates a root-only backup and
+ * atomically replaces only BaiZe's managed rule files. It never scans or deletes user data.
+ */
+class RulePackRootService : RootService() {
+    private val lock = Any()
+
+    private val binder = object : IRulePackService.Stub() {
+        override fun ping(): String = synchronized(lock) {
+            pruneState()
+            JSONObject()
+                .put("uid", Process.myUid())
+                .put("root", Process.myUid() == 0)
+                .put("engine", "signed-rule-pack-v1")
+                .put("trustedSignerSha256", JSONArray(trustedSignerFingerprints().sorted()))
+                .put("rollbackAvailable", latestBackup() != null)
+                .toString()
+        }
+
+        override fun getCurrent(): String = synchronized(lock) {
+            pruneState()
+            JSONObject(currentInfo().toString())
+                .put("success", true)
+                .put("rollbackAvailable", latestBackup() != null)
+                .toString()
+        }
+
+        override fun previewPackage(packagePath: String?): String = synchronized(lock) {
+            guarded {
+                pruneState()
+                val source = validateImportPath(packagePath.orEmpty())
+                val verified = inspectSignedPackage(source)
+                val previewId = UUID.randomUUID().toString()
+                val directory = File(previewRoot(), previewId).apply { mkdirs() }
+                val stagedRules = File(directory, "rules").apply { mkdirs() }
+                verified.files.forEach { (name, bytes) ->
+                    atomicWrite(File(stagedRules, name), bytes)
+                }
+
+                val current = currentRuleFiles()
+                val incoming = verified.files.mapValues { (_, bytes) -> fileInfo(bytes) }
+                val differences = diffFiles(current, incoming)
+                val manifest = JSONObject(verified.manifest.toString())
+                val preview = JSONObject()
+                    .put("success", true)
+                    .put("previewId", previewId)
+                    .put("createdAt", System.currentTimeMillis())
+                    .put("expiresAt", System.currentTimeMillis() + PREVIEW_TTL_MS)
+                    .put("trusted", true)
+                    .put("signerSha256", verified.signerFingerprint)
+                    .put("packId", manifest.optString("packId"))
+                    .put("version", manifest.optString("version"))
+                    .put("createdBy", manifest.optString("createdBy", "BaiZe"))
+                    .put("releaseNotes", manifest.optString("releaseNotes"))
+                    .put("minAppVersionCode", manifest.optLong("minAppVersionCode", 0L))
+                    .put("currentVersion", currentInfo().optString("version", "bundled"))
+                    .put("currentDigest", digestRuleSet(current))
+                    .put("incomingDigest", digestRuleSet(incoming))
+                    .put("currentRules", current.values.sumOf { it.rules })
+                    .put("incomingRules", incoming.values.sumOf { it.rules })
+                    .put("files", differences)
+                    .put("manifest", manifest)
+                atomicWrite(File(directory, "preview.json"), preview.toString().toByteArray(Charsets.UTF_8))
+                runCatching { source.delete() }
+                preview.toString()
+            }
+        }
+
+        override fun applyPreview(previewId: String?): String = synchronized(lock) {
+            guarded {
+                if (cleanerBusy()) throw PackException("busy", "扫描、清理或归类任务正在运行，暂不能更新规则")
+                val directory = validPreview(previewId.orEmpty())
+                val preview = readJson(File(directory, "preview.json"))
+                if (preview.optBoolean("trusted") != true) {
+                    throw PackException("preview_untrusted", "规则包预览未通过签名校验")
+                }
+                val manifest = preview.optJSONObject("manifest")
+                    ?: throw PackException("manifest_missing", "规则包清单丢失")
+                val staged = File(directory, "rules")
+                val expected = manifestFiles(manifest)
+                if (expected.isEmpty()) throw PackException("empty_pack", "规则包没有可安装文件")
+
+                expected.forEach { (name, expectedInfo) ->
+                    val file = File(staged, name)
+                    if (!file.isFile || sha256(file) != expectedInfo.sha256) {
+                        throw PackException("preview_changed", "预览缓存已变化，请重新导入规则包")
+                    }
+                }
+                val backup = backupCurrent("before-update")
+                applyRuleSet(staged, expected.keys)
+                val installedAt = System.currentTimeMillis()
+                val metadata = JSONObject(manifest.toString())
+                    .put("installedAt", installedAt)
+                    .put("digest", preview.optString("incomingDigest"))
+                    .put("signerSha256", preview.optString("signerSha256"))
+                    .put("source", "signed-import")
+                atomicWrite(currentMetadataFile(), metadata.toString().toByteArray(Charsets.UTF_8))
+                appendHistory(
+                    JSONObject()
+                        .put("time", installedAt)
+                        .put("action", "install")
+                        .put("version", metadata.optString("version"))
+                        .put("digest", metadata.optString("digest"))
+                        .put("backupId", backup?.name.orEmpty())
+                )
+                deleteTree(directory)
+                pruneBackups()
+                JSONObject(currentInfo().toString())
+                    .put("success", true)
+                    .put("installed", true)
+                    .put("rollbackAvailable", latestBackup() != null)
+                    .toString()
+            }
+        }
+
+        override fun rollback(): String = synchronized(lock) {
+            guarded {
+                if (cleanerBusy()) throw PackException("busy", "扫描、清理或归类任务正在运行，暂不能回滚规则")
+                val backup = latestBackup()
+                    ?: throw PackException("backup_missing", "没有可回滚的规则版本")
+                val rules = File(backup, "rules")
+                MANAGED_RULES.forEach { name ->
+                    val source = File(rules, name)
+                    val target = File(rulesDirectory(), name)
+                    if (source.isFile) atomicCopy(source, target) else target.delete()
+                }
+                val metadata = File(backup, "current.json")
+                if (metadata.isFile) atomicCopy(metadata, currentMetadataFile()) else currentMetadataFile().delete()
+                val restored = currentInfo()
+                appendHistory(
+                    JSONObject()
+                        .put("time", System.currentTimeMillis())
+                        .put("action", "rollback")
+                        .put("version", restored.optString("version"))
+                        .put("digest", restored.optString("digest"))
+                        .put("backupId", backup.name)
+                )
+                deleteTree(backup)
+                JSONObject(restored.toString())
+                    .put("success", true)
+                    .put("rolledBack", true)
+                    .put("rollbackAvailable", latestBackup() != null)
+                    .toString()
+            }
+        }
+
+        override fun getHistory(limit: Int): String = synchronized(lock) {
+            pruneState()
+            val entries = historyFile().takeIf { it.isFile }
+                ?.readLines()
+                .orEmpty()
+                .asReversed()
+                .asSequence()
+                .mapNotNull { line -> runCatching { JSONObject(line) }.getOrNull() }
+                .take(limit.coerceIn(1, MAX_HISTORY))
+                .toList()
+            JSONObject()
+                .put("success", true)
+                .put("items", JSONArray(entries))
+                .toString()
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+
+    private inline fun guarded(block: () -> String): String = try {
+        block()
+    } catch (error: PackException) {
+        failure(error.code, error.message ?: error.code)
+    } catch (error: Throwable) {
+        failure("rule_pack_failed", error.message ?: error.javaClass.simpleName)
+    }
+
+    private data class PackException(val code: String, override val message: String) : IllegalArgumentException(message)
+
+    private data class RuleInfo(
+        val sha256: String,
+        val rules: Int,
+        val bytes: Long
+    )
+
+    private data class VerifiedPack(
+        val manifest: JSONObject,
+        val files: Map<String, ByteArray>,
+        val signerFingerprint: String
+    )
+
+    private fun validateImportPath(raw: String): File {
+        val base = File(cacheDir, "rule-pack-imports").apply { mkdirs() }.canonicalFile
+        val candidate = File(raw).canonicalFile
+        if (!candidate.isFile || candidate.length() !in 1..MAX_PACKAGE_BYTES) {
+            throw PackException("package_missing", "导入文件不存在或超过 ${MAX_PACKAGE_BYTES / 1024 / 1024}MB")
+        }
+        if (!candidate.path.startsWith(base.path + File.separator)) {
+            throw PackException("package_path_denied", "只能读取应用通过系统选择器导入的规则包")
+        }
+        return candidate
+    }
+
+    private fun inspectSignedPackage(file: File): VerifiedPack {
+        val trusted = trustedSignerFingerprints()
+        if (trusted.isEmpty()) throw PackException("signer_unavailable", "无法读取当前 APK 签名证书")
+        val payloads = LinkedHashMap<String, ByteArray>()
+        val signerFingerprints = LinkedHashSet<String>()
+        JarFile(file, true).use { jar ->
+            val entries = jar.entries()
+            var totalBytes = 0L
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                if (entry.isDirectory) continue
+                val name = entry.name
+                if (name.startsWith("META-INF/", ignoreCase = true)) continue
+                if (name != MANIFEST_NAME && !isAllowedRuleEntry(name)) {
+                    throw PackException("entry_denied", "规则包包含不允许的文件：$name")
+                }
+                if (payloads.containsKey(name)) throw PackException("duplicate_entry", "规则包包含重复文件：$name")
+                val bytes = readLimited(jar.getInputStream(entry), MAX_ENTRY_BYTES)
+                totalBytes += bytes.size
+                if (totalBytes > MAX_EXPANDED_BYTES) throw PackException("package_too_large", "规则包解压后体积过大")
+                val certificates = entry.certificates.orEmpty()
+                if (certificates.isEmpty()) throw PackException("entry_unsigned", "规则文件未被 JAR 签名：$name")
+                val entryFingerprints = certificates.map { sha256(it.encoded) }.toSet()
+                val trustedEntrySigner = entryFingerprints.firstOrNull { it in trusted }
+                    ?: throw PackException("signer_mismatch", "规则包签名证书与当前 APK 不一致")
+                signerFingerprints += trustedEntrySigner
+                payloads[name] = bytes
+            }
+        }
+        if (signerFingerprints.size != 1) throw PackException("mixed_signers", "规则包包含多个不一致的签名者")
+        val manifestBytes = payloads[MANIFEST_NAME]
+            ?: throw PackException("manifest_missing", "规则包缺少 $MANIFEST_NAME")
+        val manifest = runCatching { JSONObject(manifestBytes.toString(Charsets.UTF_8)) }
+            .getOrElse { throw PackException("manifest_invalid", "规则包清单不是有效 JSON") }
+        validateManifest(manifest, payloads)
+        val files = LinkedHashMap<String, ByteArray>()
+        manifestFiles(manifest).keys.forEach { name ->
+            files[name] = payloads["rules/$name"]
+                ?: throw PackException("rule_missing", "规则文件缺失：$name")
+        }
+        return VerifiedPack(manifest, files, signerFingerprints.first())
+    }
+
+    private fun validateManifest(manifest: JSONObject, payloads: Map<String, ByteArray>) {
+        if (manifest.optInt("schema", 0) != PACK_SCHEMA) {
+            throw PackException("schema_unsupported", "规则包格式版本不受支持")
+        }
+        if (manifest.optString("mode") != "full") {
+            throw PackException("mode_unsupported", "规则包必须是完整包，不能使用增量覆盖")
+        }
+        val packId = manifest.optString("packId").trim()
+        if (!PACK_ID.matches(packId)) throw PackException("pack_id_invalid", "规则包编号无效")
+        val version = manifest.optString("version").trim()
+        if (version.isBlank() || version.length > 80) throw PackException("version_invalid", "规则包版本无效")
+        val minVersion = manifest.optLong("minAppVersionCode", 0L).coerceAtLeast(0L)
+        if (minVersion > appVersionCode()) {
+            throw PackException("app_too_old", "此规则包需要更高版本的白泽")
+        }
+        val listed = manifestFiles(manifest)
+        if (listed.isEmpty()) throw PackException("empty_pack", "规则包没有托管规则文件")
+        val actualEntries = payloads.keys.filter { it.startsWith("rules/") }.toSet()
+        val expectedEntries = listed.keys.map { "rules/$it" }.toSet()
+        if (actualEntries != expectedEntries) {
+            throw PackException("manifest_mismatch", "规则包清单与实际文件不一致")
+        }
+        listed.forEach { (name, info) ->
+            val bytes = payloads["rules/$name"] ?: throw PackException("rule_missing", "规则文件缺失：$name")
+            val actual = validateRuleBytes(name, bytes)
+            if (actual.sha256 != info.sha256 || actual.rules != info.rules || actual.bytes != info.bytes) {
+                throw PackException("rule_hash_mismatch", "规则文件校验失败：$name")
+            }
+        }
+    }
+
+    private fun manifestFiles(manifest: JSONObject): LinkedHashMap<String, RuleInfo> {
+        val array = manifest.optJSONArray("files") ?: JSONArray()
+        val result = LinkedHashMap<String, RuleInfo>()
+        for (index in 0 until array.length()) {
+            val item = array.optJSONObject(index) ?: throw PackException("manifest_invalid", "规则文件清单格式错误")
+            val path = item.optString("path")
+            if (!path.startsWith("rules/") || path.count { it == '/' } != 1) {
+                throw PackException("rule_path_invalid", "规则文件路径无效：$path")
+            }
+            val name = path.substringAfter("rules/")
+            if (name !in MANAGED_RULES || result.containsKey(name)) {
+                throw PackException("rule_file_denied", "不允许管理规则文件：$name")
+            }
+            val hash = item.optString("sha256").lowercase()
+            if (!SHA256.matches(hash)) throw PackException("rule_hash_invalid", "规则文件哈希无效：$name")
+            result[name] = RuleInfo(
+                sha256 = hash,
+                rules = item.optInt("rules", -1),
+                bytes = item.optLong("bytes", -1L)
+            )
+            if (result[name]!!.rules < 0 || result[name]!!.bytes < 0L) {
+                throw PackException("rule_metrics_invalid", "规则文件统计无效：$name")
+            }
+        }
+        return result
+    }
+
+    private fun validateRuleBytes(name: String, bytes: ByteArray): RuleInfo {
+        if (bytes.size > MAX_RULE_FILE_BYTES) throw PackException("rule_file_large", "规则文件过大：$name")
+        val text = runCatching { bytes.toString(Charsets.UTF_8) }
+            .getOrElse { throw PackException("rule_encoding_invalid", "规则文件不是 UTF-8：$name") }
+        if ('\u0000' in text) throw PackException("rule_nul", "规则文件包含非法字符：$name")
+        var rules = 0
+        text.lineSequence().forEachIndexed { index, raw ->
+            if (raw.length > MAX_RULE_LINE_LENGTH) throw PackException("rule_line_large", "$name 第 ${index + 1} 行过长")
+            val line = raw.trim()
+            if (line.isBlank() || line.startsWith("#") || line.startsWith("//")) return@forEachIndexed
+            if (!safeRuleSyntax(line)) throw PackException("rule_syntax_invalid", "$name 第 ${index + 1} 行规则不安全")
+            rules += 1
+            if (rules > MAX_RULES_PER_FILE) throw PackException("rule_count_large", "$name 规则数量超过限制")
+        }
+        return RuleInfo(sha256(bytes), rules, bytes.size.toLong())
+    }
+
+    private fun safeRuleSyntax(raw: String): Boolean {
+        val path = raw.substringBefore('|').substringBefore('#').trim()
+        if (!path.startsWith("/") || path.length !in 2..MAX_RULE_LINE_LENGTH) return false
+        if (path.split('/').any { it == ".." }) return false
+        if (FORBIDDEN_RULE_ROOTS.any { path == it || path.startsWith("$it/") }) return false
+        val segments = path.split('/').filter { it.isNotEmpty() }
+        if (segments.isEmpty() || segments.take(2).any { it == "*" || it == "**" || it == "?" }) return false
+        return true
+    }
+
+    private fun currentInfo(): JSONObject {
+        val metadata = readJson(currentMetadataFile())
+        val files = currentRuleFiles()
+        val fileArray = JSONArray()
+        files.toSortedMap().forEach { (name, info) ->
+            fileArray.put(
+                JSONObject()
+                    .put("name", name)
+                    .put("sha256", info.sha256)
+                    .put("rules", info.rules)
+                    .put("bytes", info.bytes)
+            )
+        }
+        return JSONObject()
+            .put("packId", metadata.optString("packId", "baize-bundled"))
+            .put("version", metadata.optString("version", "bundled"))
+            .put("installedAt", metadata.optLong("installedAt", 0L))
+            .put("source", metadata.optString("source", "module"))
+            .put("signerSha256", metadata.optString("signerSha256"))
+            .put("digest", digestRuleSet(files))
+            .put("totalRules", files.values.sumOf { it.rules })
+            .put("totalBytes", files.values.sumOf { it.bytes })
+            .put("files", fileArray)
+    }
+
+    private fun currentRuleFiles(): LinkedHashMap<String, RuleInfo> {
+        val result = LinkedHashMap<String, RuleInfo>()
+        MANAGED_RULES.sorted().forEach { name ->
+            val file = File(rulesDirectory(), name)
+            if (file.isFile && file.length() <= MAX_RULE_FILE_BYTES) {
+                runCatching { fileInfo(file.readBytes()) }.getOrNull()?.let { result[name] = it }
+            }
+        }
+        return result
+    }
+
+    private fun fileInfo(bytes: ByteArray): RuleInfo {
+        val rules = bytes.toString(Charsets.UTF_8).lineSequence().count { raw ->
+            val line = raw.trim()
+            line.isNotBlank() && !line.startsWith("#") && !line.startsWith("//")
+        }
+        return RuleInfo(sha256(bytes), rules, bytes.size.toLong())
+    }
+
+    private fun diffFiles(current: Map<String, RuleInfo>, incoming: Map<String, RuleInfo>): JSONArray {
+        val array = JSONArray()
+        MANAGED_RULES.sorted().forEach { name ->
+            val before = current[name]
+            val after = incoming[name]
+            val status = when {
+                before == null && after != null -> "added"
+                before != null && after == null -> "removed"
+                before?.sha256 == after?.sha256 -> "unchanged"
+                else -> "changed"
+            }
+            array.put(
+                JSONObject()
+                    .put("name", name)
+                    .put("status", status)
+                    .put("currentRules", before?.rules ?: 0)
+                    .put("incomingRules", after?.rules ?: 0)
+                    .put("ruleDelta", (after?.rules ?: 0) - (before?.rules ?: 0))
+                    .put("currentBytes", before?.bytes ?: 0L)
+                    .put("incomingBytes", after?.bytes ?: 0L)
+                    .put("currentSha256", before?.sha256.orEmpty())
+                    .put("incomingSha256", after?.sha256.orEmpty())
+            )
+        }
+        return array
+    }
+
+    private fun digestRuleSet(files: Map<String, RuleInfo>): String {
+        val canonical = files.toSortedMap().entries.joinToString("\n") { (name, info) ->
+            "$name:${info.sha256}:${info.rules}:${info.bytes}"
+        }
+        return sha256(canonical.toByteArray(Charsets.UTF_8))
+    }
+
+    private fun backupCurrent(reason: String): File? {
+        val files = currentRuleFiles()
+        val metadata = currentMetadataFile()
+        if (files.isEmpty() && !metadata.isFile) return null
+        val id = "%013d-%s".format(System.currentTimeMillis(), UUID.randomUUID().toString().take(8))
+        val directory = File(backupRoot(), id).apply { mkdirs() }
+        val rules = File(directory, "rules").apply { mkdirs() }
+        files.keys.forEach { name -> atomicCopy(File(rulesDirectory(), name), File(rules, name)) }
+        if (metadata.isFile) atomicCopy(metadata, File(directory, "current.json"))
+        atomicWrite(
+            File(directory, "backup.json"),
+            JSONObject()
+                .put("createdAt", System.currentTimeMillis())
+                .put("reason", reason)
+                .put("current", currentInfo())
+                .toString()
+                .toByteArray(Charsets.UTF_8)
+        )
+        return directory
+    }
+
+    private fun applyRuleSet(stagedRules: File, incomingNames: Set<String>) {
+        rulesDirectory().mkdirs()
+        MANAGED_RULES.forEach { name ->
+            val target = File(rulesDirectory(), name)
+            if (name in incomingNames) {
+                val source = File(stagedRules, name)
+                if (!source.isFile) throw PackException("staged_rule_missing", "待安装规则缺失：$name")
+                atomicCopy(source, target)
+            } else {
+                target.delete()
+            }
+        }
+    }
+
+    private fun validPreview(raw: String): File {
+        val id = runCatching { UUID.fromString(raw).toString() }.getOrNull()
+            ?: throw PackException("preview_invalid", "规则包预览编号无效")
+        val directory = File(previewRoot(), id)
+        val preview = readJson(File(directory, "preview.json"))
+        val createdAt = preview.optLong("createdAt", 0L)
+        if (!directory.isDirectory || createdAt <= 0L || System.currentTimeMillis() - createdAt !in 0..PREVIEW_TTL_MS) {
+            deleteTree(directory)
+            throw PackException("preview_expired", "规则包预览已过期，请重新导入")
+        }
+        return directory
+    }
+
+    private fun latestBackup(): File? = backupRoot().listFiles()
+        ?.filter { it.isDirectory && File(it, "backup.json").isFile }
+        ?.maxByOrNull { it.name }
+
+    private fun pruneState() {
+        val now = System.currentTimeMillis()
+        previewRoot().listFiles()?.filter { it.isDirectory }?.forEach { directory ->
+            val created = readJson(File(directory, "preview.json")).optLong("createdAt", 0L)
+            if (created <= 0L || now - created > PREVIEW_TTL_MS) deleteTree(directory)
+        }
+        pruneBackups()
+    }
+
+    private fun pruneBackups() {
+        backupRoot().listFiles()
+            ?.filter { it.isDirectory && File(it, "backup.json").isFile }
+            ?.sortedByDescending { it.name }
+            ?.drop(MAX_BACKUPS)
+            ?.forEach(::deleteTree)
+    }
+
+    private fun appendHistory(entry: JSONObject) {
+        managerRoot().mkdirs()
+        val lines = historyFile().takeIf { it.isFile }?.readLines().orEmpty().takeLast(MAX_HISTORY - 1)
+        atomicWrite(
+            historyFile(),
+            (lines + entry.toString()).joinToString("\n", postfix = "\n").toByteArray(Charsets.UTF_8)
+        )
+    }
+
+    private fun trustedSignerFingerprints(): Set<String> = runCatching {
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+        }
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.signingInfo?.apkContentsSigners.orEmpty()
+        } else {
+            @Suppress("DEPRECATION")
+            info.signatures.orEmpty()
+        }
+        signatures.map { sha256(it.toByteArray()) }.toSet()
+    }.getOrDefault(emptySet())
+
+    private fun appVersionCode(): Long = runCatching {
+        val info = packageManager.getPackageInfo(packageName, 0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }.getOrDefault(0L)
+
+    private fun cleanerBusy(): Boolean {
+        val file = File(RootPaths.STATE_DIR, "running.env")
+        return file.isFile && file.length() > 0L && file.readText().isNotBlank()
+    }
+
+    private fun isAllowedRuleEntry(name: String): Boolean =
+        name.startsWith("rules/") && name.substringAfter("rules/") in MANAGED_RULES && name.count { it == '/' } == 1
+
+    private fun readLimited(input: InputStream, maxBytes: Long): ByteArray = input.use { stream ->
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(64 * 1024)
+        var total = 0L
+        while (true) {
+            val read = stream.read(buffer)
+            if (read <= 0) break
+            total += read
+            if (total > maxBytes) throw PackException("entry_too_large", "规则包文件解压后超过限制")
+            output.write(buffer, 0, read)
+        }
+        output.toByteArray()
+    }
+
+    private fun atomicCopy(source: File, target: File) {
+        if (!source.isFile) throw PackException("copy_source_missing", "规则文件源不存在：${source.name}")
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        FileInputStream(source).use { input ->
+            FileOutputStream(temporary).use { output ->
+                input.copyTo(output, 64 * 1024)
+                output.fd.sync()
+            }
+        }
+        if (!temporary.renameTo(target)) {
+            temporary.copyTo(target, overwrite = true)
+            temporary.delete()
+        }
+        restrict(target)
+    }
+
+    private fun atomicWrite(target: File, bytes: ByteArray) {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        FileOutputStream(temporary).use { output ->
+            output.write(bytes)
+            output.fd.sync()
+        }
+        if (!temporary.renameTo(target)) {
+            temporary.copyTo(target, overwrite = true)
+            temporary.delete()
+        }
+        restrict(target)
+    }
+
+    private fun restrict(file: File) {
+        file.setReadable(false, false)
+        file.setWritable(false, false)
+        file.setExecutable(false, false)
+        file.setReadable(true, true)
+        file.setWritable(true, true)
+    }
+
+    private fun deleteTree(file: File): Boolean = runCatching {
+        if (!file.exists()) return@runCatching true
+        file.walkBottomUp().forEach { it.delete() }
+        !file.exists()
+    }.getOrDefault(false)
+
+    private fun readJson(file: File): JSONObject = if (!file.isFile) JSONObject() else
+        runCatching { JSONObject(file.readText()) }.getOrDefault(JSONObject())
+
+    private fun sha256(file: File): String = FileInputStream(file).use { input ->
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(64 * 1024)
+        while (true) {
+            val read = input.read(buffer)
+            if (read <= 0) break
+            digest.update(buffer, 0, read)
+        }
+        digest.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+
+    private fun failure(code: String, message: String): String = JSONObject()
+        .put("success", false)
+        .put("error", code)
+        .put("message", message)
+        .toString()
+
+    private fun rulesDirectory(): File = File(RootPaths.MODULE_DIR, "config").apply { mkdirs() }
+    private fun managerRoot(): File = File(RootPaths.STATE_DIR, "rule-pack-manager").apply { mkdirs() }
+    private fun previewRoot(): File = File(managerRoot(), "previews").apply { mkdirs() }
+    private fun backupRoot(): File = File(managerRoot(), "backups").apply { mkdirs() }
+    private fun currentMetadataFile(): File = File(managerRoot(), "current.json")
+    private fun historyFile(): File = File(managerRoot(), "history.ndjson")
+
+    companion object {
+        private const val PACK_SCHEMA = 1
+        private const val MANIFEST_NAME = "rule-pack.json"
+        private const val PREVIEW_TTL_MS = 30L * 60_000L
+        private const val MAX_PACKAGE_BYTES = 32L * 1024L * 1024L
+        private const val MAX_EXPANDED_BYTES = 48L * 1024L * 1024L
+        private const val MAX_ENTRY_BYTES = 16L * 1024L * 1024L
+        private const val MAX_RULE_FILE_BYTES = 16L * 1024L * 1024L
+        private const val MAX_RULES_PER_FILE = 20_000
+        private const val MAX_RULE_LINE_LENGTH = 4096
+        private const val MAX_BACKUPS = 3
+        private const val MAX_HISTORY = 30
+        private val MANAGED_RULES = setOf("app.rules", "external.rules", "hidden.rules", "deep.rules")
+        private val PACK_ID = Regex("^[A-Za-z0-9._-]{1,80}$")
+        private val SHA256 = Regex("^[0-9a-f]{64}$")
+        private val FORBIDDEN_RULE_ROOTS = setOf(
+            "/", "/data", "/data/adb", "/metadata", "/proc", "/sys", "/dev",
+            "/system", "/vendor", "/product", "/odm", "/apex"
+        )
+    }
+}

--- a/v2/docs/rule-pack-format.md
+++ b/v2/docs/rule-pack-format.md
@@ -1,0 +1,77 @@
+# BaiZe signed rule packs
+
+BaiZe rule packs are complete JAR files. They are imported through Android's system file picker and must be signed with the same certificate as the installed BaiZe APK.
+
+## Contents
+
+```text
+META-INF/MANIFEST.MF
+META-INF/<SIGNER>.SF
+META-INF/<SIGNER>.RSA
+rule-pack.json
+rules/app.rules          optional
+rules/external.rules     optional
+rules/hidden.rules       optional
+rules/deep.rules         required for official full packs
+```
+
+`custom.rules` is user-owned and is never replaced by the rule-pack manager.
+
+## Manifest
+
+```json
+{
+  "schema": 1,
+  "mode": "full",
+  "packId": "baize-official",
+  "version": "2026.07.1",
+  "createdBy": "BaiZe GitHub Actions",
+  "releaseNotes": "Improve OEM log and fragment coverage.",
+  "minAppVersionCode": 24001,
+  "files": [
+    {
+      "path": "rules/deep.rules",
+      "sha256": "<64 lowercase hexadecimal characters>",
+      "rules": 4714,
+      "bytes": 123456
+    }
+  ]
+}
+```
+
+The manifest must list every payload under `rules/`. Extra payload files, duplicate entries, path traversal, unsigned entries, mixed signers and certificate mismatches are rejected.
+
+## Build and sign
+
+```bash
+python3 v2/tools/build-rule-pack.py \
+  --rules-dir <module-config-directory> \
+  --version 2026.07.1 \
+  --release-notes "Rule maintenance update" \
+  --output BaiZe-Rules-2026.07.1-unsigned.jar
+
+jarsigner \
+  -keystore <production-keystore> \
+  -signedjar BaiZe-Rules-2026.07.1.jar \
+  BaiZe-Rules-2026.07.1-unsigned.jar \
+  <production-alias>
+
+jarsigner -verify -strict -certs BaiZe-Rules-2026.07.1.jar
+```
+
+The key alias must resolve to the same signer certificate used for the production APK. Pull-request APKs use a temporary certificate, so production rule packs intentionally do not validate in PR builds.
+
+## Installation safety
+
+Before installation, the Root service:
+
+1. Reads the selected file only from the app's private import cache.
+2. Verifies the JAR signature of `rule-pack.json` and every rule entry.
+3. Compares the signer SHA-256 fingerprint with the installed APK signer.
+4. Verifies manifest hashes, byte sizes and effective rule counts.
+5. Rejects unsafe roots, top-level wildcards, traversal, oversized entries and ZIP bombs.
+6. Shows added, changed, removed and unchanged files before mutation.
+7. Saves a root-only complete backup.
+8. Atomically replaces only managed rule files.
+
+The manager keeps at most three backups and exposes the latest one through one-click rollback. Active scans, cleans and organizer tasks block installation and rollback.

--- a/v2/tests/test-clean-plan-persistence.py
+++ b/v2/tests/test-clean-plan-persistence.py
@@ -72,4 +72,5 @@ for method in ("scanSafe", "getPage", "cleanSafe", "getTaskState", "cancelCurren
 runpy.run_path(str(ROOT / "v2/tests/test-candidate-selection-plan.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-clean-result-report.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-explainable-rules-whitelist.py"), run_name="__main__")
+runpy.run_path(str(ROOT / "v2/tests/test-rule-pack-management.py"), run_name="__main__")
 print("clean plan persistence contract: ok")

--- a/v2/tests/test-rule-pack-management.py
+++ b/v2/tests/test-rule-pack-management.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+# Stage seven contract: imports are signer-bound, previewed, atomic and rollback-capable.
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
+SERVICE = (APP / "root/RulePackRootService.kt").read_text(encoding="utf-8")
+ACTIVITY = (APP / "RulePackActivity.kt").read_text(encoding="utf-8")
+AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IRulePackService.aidl").read_text(encoding="utf-8")
+MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
+CENTER = (APP / "CleanCenterActivity.kt").read_text(encoding="utf-8")
+BUILDER = (ROOT / "v2/tools/build-rule-pack.py").read_text(encoding="utf-8")
+DOC = (ROOT / "v2/docs/rule-pack-format.md").read_text(encoding="utf-8")
+
+
+def require(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+for method in ("getCurrent", "previewPackage", "applyPreview", "rollback", "getHistory"):
+    require(method in AIDL, f"rule pack binder method missing: {method}")
+
+for marker in (
+    "JarFile(file, true)", "entry.certificates", "trustedSignerFingerprints",
+    "GET_SIGNING_CERTIFICATES", "signer_mismatch", "entry_unsigned", "mixed_signers",
+    "validateImportPath", "rule-pack-imports", "MAX_EXPANDED_BYTES", "MAX_ENTRY_BYTES",
+    "validateManifest", "rule_hash_mismatch", "safeRuleSyntax", "FORBIDDEN_RULE_ROOTS",
+    "backupCurrent", "applyRuleSet", "atomicCopy", "rollbackAvailable", "MAX_BACKUPS = 3",
+    "running.env"
+):
+    require(marker in SERVICE, f"signed rule pack safety primitive missing: {marker}")
+
+require("scanProfile(" not in SERVICE and "scanSafe(" not in SERVICE and "cleanSelected(" not in SERVICE,
+        "rule pack service must not scan or clean user data")
+require("http://" not in SERVICE and "https://" not in SERVICE,
+        "rule pack service must not fetch untrusted remote content")
+require('setOf("app.rules", "external.rules", "hidden.rules", "deep.rules")' in SERVICE,
+        "only managed official rule files may be replaced")
+require("custom.rules" not in SERVICE,
+        "user-owned custom rules must not enter the managed replacement set")
+
+for marker in (
+    "ActivityResultContracts.OpenDocument", "copyImport", "previewPackage", "applyPreview",
+    "rollback", "签名验证", "更新预览", "custom.rules 不会被修改"
+):
+    require(marker in ACTIVITY, f"rule pack UI contract missing: {marker}")
+
+require('android:name=".RulePackActivity"' in MANIFEST, "rule pack activity is not registered")
+require('android:name=".root.RulePackRootService"' in MANIFEST, "rule pack Root service is not registered")
+require("RulePackActivity::class.java" in CENTER, "clean center must expose the rule pack manager")
+require("规则管理中心" in CENTER, "rule pack manager label is missing")
+
+for marker in (
+    "build-rule-pack", "rule-pack.json", "META-INF/MANIFEST.MF", "deep.rules",
+    "jarsigner", "same certificate"
+):
+    require(marker in BUILDER or marker in DOC, f"rule pack publishing contract missing: {marker}")
+
+require("custom.rules" in DOC and "never replaced" in DOC,
+        "documentation must preserve user-owned custom rules")
+
+print("signed rule pack management contract: ok")

--- a/v2/tools/build-rule-pack.py
+++ b/v2/tools/build-rule-pack.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Build a deterministic BaiZe rule-pack JAR before jarsigner signing."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import zipfile
+
+MANAGED = ("app.rules", "external.rules", "hidden.rules", "deep.rules")
+FORBIDDEN = (
+    "/data/adb", "/metadata", "/proc", "/sys", "/dev", "/system",
+    "/vendor", "/product", "/odm", "/apex",
+)
+PACK_ID = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+FIXED_TIME = (2026, 1, 1, 0, 0, 0)
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def effective_rules(text: str, name: str) -> int:
+    count = 0
+    for number, raw in enumerate(text.splitlines(), 1):
+        if len(raw) > 4096:
+            raise ValueError(f"{name}:{number}: line exceeds 4096 characters")
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("//"):
+            continue
+        path = line.split("|", 1)[0].split("#", 1)[0].strip()
+        if not path.startswith("/") or "\x00" in path or any(part == ".." for part in path.split("/")):
+            raise ValueError(f"{name}:{number}: unsafe rule syntax")
+        if path in ("/", "/data") or any(path == root or path.startswith(root + "/") for root in FORBIDDEN):
+            raise ValueError(f"{name}:{number}: forbidden rule root {path}")
+        segments = [part for part in path.split("/") if part]
+        if not segments or any(part in {"*", "**", "?"} for part in segments[:2]):
+            raise ValueError(f"{name}:{number}: top-level wildcard is forbidden")
+        count += 1
+        if count > 20_000:
+            raise ValueError(f"{name}: more than 20,000 effective rules")
+    return count
+
+
+def write_entry(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
+    info = zipfile.ZipInfo(name, FIXED_TIME)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o100644 << 16
+    archive.writestr(info, data)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rules-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    parser.add_argument("--pack-id", default="baize-official")
+    parser.add_argument("--created-by", default="BaiZe GitHub Actions")
+    parser.add_argument("--release-notes", default="")
+    parser.add_argument("--min-app-version-code", type=int, default=24001)
+    args = parser.parse_args()
+
+    if not PACK_ID.fullmatch(args.pack_id):
+        raise SystemExit("invalid --pack-id")
+    if not args.version.strip() or len(args.version) > 80:
+        raise SystemExit("invalid --version")
+    if not args.rules_dir.is_dir():
+        raise SystemExit("--rules-dir is not a directory")
+
+    payloads: dict[str, bytes] = {}
+    files: list[dict[str, object]] = []
+    for name in MANAGED:
+        source = args.rules_dir / name
+        if not source.is_file():
+            continue
+        data = source.read_bytes()
+        if len(data) > 16 * 1024 * 1024:
+            raise SystemExit(f"{name} exceeds 16MB")
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise SystemExit(f"{name} is not UTF-8: {error}") from error
+        count = effective_rules(text, name)
+        payloads[name] = data
+        files.append(
+            {
+                "path": f"rules/{name}",
+                "sha256": sha256(data),
+                "rules": count,
+                "bytes": len(data),
+            }
+        )
+
+    if "deep.rules" not in payloads:
+        raise SystemExit("deep.rules is required for an official full pack")
+
+    manifest = {
+        "schema": 1,
+        "mode": "full",
+        "packId": args.pack_id,
+        "version": args.version.strip(),
+        "createdBy": args.created_by.strip(),
+        "releaseNotes": args.release_notes.strip(),
+        "minAppVersionCode": max(0, args.min_app_version_code),
+        "files": files,
+    }
+    manifest_bytes = json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(args.output, "w") as archive:
+        write_entry(archive, "META-INF/MANIFEST.MF", b"Manifest-Version: 1.0\r\nCreated-By: BaiZe Rule Pack Builder\r\n\r\n")
+        write_entry(archive, "rule-pack.json", manifest_bytes)
+        for name, data in payloads.items():
+            write_entry(archive, f"rules/{name}", data)
+
+    print(f"built unsigned rule pack: {args.output}")
+    print(f"manifest sha256: {sha256(manifest_bytes)}")
+    print("sign with the same keystore alias used for the production BaiZe APK:")
+    print(f"jarsigner -keystore <keystore> -signedjar <signed.jar> {args.output} <alias>")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(2) from error


### PR DESCRIPTION
## 第七阶段：规则管理中心、签名更新与回滚

- 通过 Android 系统文件选择器导入规则包，不接受任意 Root 路径。
- 使用 JAR 签名校验 `rule-pack.json` 和每个规则条目。
- 规则包签名证书必须与当前 BaiZe APK 签名证书一致。
- 校验清单、SHA-256、字节数、有效规则数、最低应用版本和规则安全语法。
- 拒绝未签名条目、混合签名者、路径穿越、未知文件、危险根规则、顶层通配符和 ZIP 体积攻击。
- 安装前显示文件级新增、更新、移除和规则数量变化。
- 安装前保存完整 root-only 备份，并原子替换托管规则。
- 最多保留 3 份备份，支持一键回滚和安装/回滚历史。
- `custom.rules` 始终归用户所有，不参与规则包覆盖。
- 扫描、清理或归类任务运行时禁止安装和回滚。
- 提供确定性规则包构建工具与 `jarsigner` 签名格式文档。

## 堆叠关系

本 PR 基于第六阶段 `agent/explainable-rules-whitelist`，已整理为 1 个干净提交、9 个第七阶段文件。没有修改扫描器、删除器或清理事务格式。

## 验证结果

完整工作流 `BaiZe v2.4.1 Verify and Release #54` 已全部通过：

- 第七阶段证书绑定、逐条目签名、导入路径、规则安全、预览、原子安装和回滚契约：通过
- 前六阶段清理计划、断点恢复、真实统计、候选选择、结果报告与快捷白名单回归：通过
- Root Shell、调度公平性、增量索引与归类事务回归：通过
- Android Release、Debug Kotlin、Lint 和 Macrobenchmark：通过
- ARM64 原生扫描器：通过
- 模块封包、内置 APK 一致性和签名产物校验：通过

最终分支只保留 Manifest、清理中心入口、规则包 AIDL、RootService、管理页面、构建工具、格式文档和 2 个测试接线文件。