### PR TITLE
feat(rules): add trusted online update channel

### DIFF
--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions" />
     <uses-permission
@@ -33,6 +35,7 @@
         <activity android:name=".CandidateSmartScanActivity" android:exported="false" />
         <activity android:name=".CleanResultActivity" android:exported="false" />
         <activity android:name=".RulePackActivity" android:exported="false" />
+        <activity android:name=".RuleUpdateActivity" android:exported="false" />
         <activity-alias
             android:name=".SmartScanActivity"
             android:exported="false"
@@ -80,6 +83,10 @@
             tools:ignore="Instantiatable" />
         <service
             android:name=".root.RulePackRootService"
+            android:exported="false"
+            tools:ignore="Instantiatable" />
+        <service
+            android:name=".root.RuleIndexRootService"
             android:exported="false"
             tools:ignore="Instantiatable" />
     </application>

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IRuleIndexService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IRuleIndexService.aidl
@@ -1,0 +1,7 @@
+package io.github.xgl34222220.baize.root;
+
+interface IRuleIndexService {
+    String ping();
+    String verifyIndex(String indexPath, String channel, long currentVersionCode);
+    String getCheckpoint(String channel);
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeApplication.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeApplication.kt
@@ -10,6 +10,7 @@ class BaiZeApplication : Application() {
         CrashRecorder.install(this)
         ThemeManager.install(this)
         NativeNotifier.ensureChannel(this)
+        RuleUpdateWorker.ensureScheduled(this)
         DisplayPerformanceController.install(this)
         Shell.enableVerboseLogging = BuildConfig.DEBUG
         Shell.setDefaultBuilder(

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Apps
 import androidx.compose.material.icons.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.material.icons.rounded.DeleteForever
 import androidx.compose.material.icons.rounded.DeleteSweep
@@ -116,7 +117,8 @@ class CleanCenterActivity : ComponentActivity() {
                             onSmartScan = { startActivity(Intent(this, SmartScanActivity::class.java)) },
                             onOpenCache = { startActivity(Intent(this, CacheActivity::class.java)) },
                             onOpenProfile = ::openProfile,
-                            onRulePack = { startActivity(Intent(this, RulePackActivity::class.java)) }
+                            onRulePack = { startActivity(Intent(this, RulePackActivity::class.java)) },
+                            onRuleUpdate = { startActivity(Intent(this, RuleUpdateActivity::class.java)) }
                         )
                     )
                 }
@@ -138,7 +140,8 @@ private data class CleanCenterActions(
     val onSmartScan: () -> Unit,
     val onOpenCache: () -> Unit,
     val onOpenProfile: (String) -> Unit,
-    val onRulePack: () -> Unit
+    val onRulePack: () -> Unit,
+    val onRuleUpdate: () -> Unit
 )
 
 private data class CleanCenterItem(
@@ -209,6 +212,7 @@ private fun CleanCenterMaterial(
         CleanCenterItem(Icons.Rounded.Apps, "残留碎片", "过期临时文件、旋转日志与中断下载", "保留期", profile = "fragments")
     )
     val advanced = listOf(
+        CleanCenterItem(Icons.Rounded.CloudDownload, "官方规则更新", "签名索引、断点续传与自动策略", "在线", directAction = actions.onRuleUpdate),
         CleanCenterItem(Icons.Rounded.Rule, "规则管理中心", "版本、签名、更新预览与回滚", "已签名", directAction = actions.onRulePack),
         CleanCenterItem(Icons.Rounded.DeleteForever, "卸载残留", "核对 data、obb、media 与应用私有目录", "二次确认", profile = "corpses", dangerous = true),
         CleanCenterItem(Icons.Rounded.DeleteSweep, "完整深度清理", "完整规则库扫描并按风险分级", "二次确认", profile = "deep", dangerous = true)
@@ -435,6 +439,7 @@ private fun CleanCenterMiuix(
         CleanCenterItem(Icons.Rounded.Apps, "残留碎片", "临时文件与中断下载", "保留期", profile = "fragments")
     )
     val advanced = listOf(
+        CleanCenterItem(Icons.Rounded.CloudDownload, "官方规则更新", "防回放、断点下载与自动策略", "在线", directAction = actions.onRuleUpdate),
         CleanCenterItem(Icons.Rounded.Rule, "规则管理中心", "签名校验、预览与回滚", "已签名", directAction = actions.onRulePack),
         CleanCenterItem(Icons.Rounded.DeleteForever, "卸载残留", "核对无主应用目录", "确认", profile = "corpses", dangerous = true),
         CleanCenterItem(Icons.Rounded.DeleteSweep, "完整深度清理", "4,714 条规则风险分级", "确认", profile = "deep", dangerous = true)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/NativeNotifier.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/NativeNotifier.kt
@@ -15,13 +15,22 @@ import androidx.core.content.ContextCompat
 
 object NativeNotifier {
     private const val CHANNEL_TASKS = "baize_clean_tasks"
+    private const val CHANNEL_RULES = "baize_rule_updates"
     private const val NOTIFICATION_ID = 2101
+    private const val RULE_NOTIFICATION_ID = 2102
 
     fun ensureChannel(context: Context) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        context.getSystemService(NotificationManager::class.java)?.createNotificationChannel(
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        manager.createNotificationChannel(
             NotificationChannel(CHANNEL_TASKS, "白泽清理任务", NotificationManager.IMPORTANCE_DEFAULT).apply {
                 description = "显示手动清理与扫描任务的完成结果"
+                enableVibration(false)
+            }
+        )
+        manager.createNotificationChannel(
+            NotificationChannel(CHANNEL_RULES, "白泽规则更新", NotificationManager.IMPORTANCE_DEFAULT).apply {
+                description = "显示已通过签名验证的规则版本和自动更新结果"
                 enableVibration(false)
             }
         )
@@ -55,6 +64,36 @@ object NativeNotifier {
             .build()
         try {
             NotificationManagerCompat.from(context).notify("baize-app-task", NOTIFICATION_ID, notification)
+        } catch (_: SecurityException) {
+            // Permission or OEM policy changed after the explicit permission check.
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun showRuleUpdate(context: Context, title: String, summary: String, details: String) {
+        if (!canPost(context)) return
+        ensureChannel(context)
+        val contentIntent = PendingIntent.getActivity(
+            context,
+            RULE_NOTIFICATION_ID,
+            Intent(context, RuleUpdateActivity::class.java)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_RULES)
+            .setSmallIcon(R.drawable.ic_baize)
+            .setContentTitle(title)
+            .setContentText(summary)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(details))
+            .setContentIntent(contentIntent)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .build()
+        try {
+            NotificationManagerCompat.from(context)
+                .notify("baize-rule-update", RULE_NOTIFICATION_ID, notification)
         } catch (_: SecurityException) {
             // Permission or OEM policy changed after the explicit permission check.
         }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateActivity.kt
@@ -1,0 +1,555 @@
+package io.github.xgl34222220.baize
+
+import android.os.Bundle
+import android.text.format.Formatter
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CloudDownload
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.SystemUpdate
+import androidx.compose.material.icons.rounded.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.text.DateFormat
+import java.util.Date
+
+class RuleUpdateActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private var showInstallConfirm by mutableStateOf(false)
+    private var state by mutableStateOf(RuleUpdateUiState())
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        val settings = RuleUpdateClient.loadSettings(this)
+        state = state.copy(settings = settings, message = settings.lastResult)
+        setContent {
+            val appearance = appearanceViewModel.settings.collectAsStateWithLifecycle().value
+            BaiZeTheme(appearance) {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    RuleUpdateScreen(
+                        state = state,
+                        onBack = ::finish,
+                        onRefresh = ::refreshCurrent,
+                        onCheck = ::checkUpdate,
+                        onDownload = ::downloadAndPreview,
+                        onInstall = { showInstallConfirm = true },
+                        onChannel = ::changeChannel,
+                        onPolicy = ::changePolicy
+                    )
+                    if (showInstallConfirm) {
+                        AlertDialog(
+                            onDismissRequest = { showInstallConfirm = false },
+                            title = { Text("安装在线规则更新？") },
+                            text = {
+                                Text(
+                                    "签名索引和规则包均已通过当前 APK 同证书校验。安装前仍会创建 Root 私有备份，可在规则管理中心一键回滚。"
+                                )
+                            },
+                            confirmButton = {
+                                TextButton(onClick = {
+                                    showInstallConfirm = false
+                                    installPreview()
+                                }) { Text("立即安装") }
+                            },
+                            dismissButton = {
+                                TextButton(onClick = { showInstallConfirm = false }) { Text("取消") }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        refreshCurrent()
+    }
+
+    private fun refreshCurrent() {
+        if (state.working) return
+        state = state.copy(working = true, message = "正在读取当前规则与签名索引检查点…")
+        lifecycleScope.launch {
+            val session = runCatching { RuleUpdateClient.connect(this@RuleUpdateActivity) }.getOrElse {
+                state = state.copy(working = false, connected = false, message = "Root 规则服务连接失败：${it.message}")
+                return@launch
+            }
+            try {
+                val result = withContext(Dispatchers.IO) {
+                    val current = JSONObject(session.pack.getCurrent())
+                    val checkpoint = JSONObject(session.index.getCheckpoint(state.settings.channel))
+                    current to checkpoint
+                }
+                state = state.copy(
+                    working = false,
+                    connected = true,
+                    currentVersion = result.first.optString("version", "bundled"),
+                    currentVersionCode = result.first.optLong("versionCode", 0L),
+                    currentRules = result.first.optInt("totalRules", 0),
+                    checkpointAt = result.second.optLong("generatedAt", 0L),
+                    message = state.settings.lastResult
+                )
+            } catch (error: Throwable) {
+                state = state.copy(working = false, connected = false, message = "读取规则状态失败：${error.message}")
+            } finally {
+                session.close()
+            }
+        }
+    }
+
+    private fun checkUpdate() {
+        if (state.working) return
+        state = state.copy(
+            working = true,
+            progress = 0f,
+            release = null,
+            previewId = "",
+            message = "正在断点下载并验证 ${RuleUpdateWorker.channelLabel(state.settings.channel)} 签名索引…"
+        )
+        lifecycleScope.launch {
+            val session = runCatching { RuleUpdateClient.connect(this@RuleUpdateActivity) }.getOrElse {
+                state = state.copy(working = false, connected = false, message = "Root 规则服务连接失败：${it.message}")
+                return@launch
+            }
+            try {
+                val check = RuleUpdateClient.check(
+                    this@RuleUpdateActivity,
+                    session,
+                    state.settings.channel
+                ) { progress -> updateProgress(progress, "正在下载签名索引") }
+                val text = if (check.release == null) {
+                    "${RuleUpdateWorker.channelLabel(check.channel)}规则已是最新版本 ${check.currentVersion}"
+                } else {
+                    "发现可信规则 ${check.release.version}，索引和下载地址已通过 Root 签名校验"
+                }
+                RuleUpdateClient.recordResult(this@RuleUpdateActivity, text)
+                val settings = RuleUpdateClient.loadSettings(this@RuleUpdateActivity)
+                state = state.copy(
+                    working = false,
+                    connected = true,
+                    progress = 1f,
+                    currentVersion = check.currentVersion,
+                    currentVersionCode = check.currentVersionCode,
+                    currentRules = check.currentRules,
+                    indexGeneratedAt = check.generatedAt,
+                    indexExpiresAt = check.expiresAt,
+                    signerSha256 = check.signerSha256,
+                    release = check.release,
+                    settings = settings,
+                    message = text
+                )
+            } catch (error: Throwable) {
+                val text = "在线规则检查失败：${error.message ?: error.javaClass.simpleName}"
+                RuleUpdateClient.recordResult(this@RuleUpdateActivity, text)
+                state = state.copy(working = false, progress = 0f, message = text)
+            } finally {
+                session.close()
+            }
+        }
+    }
+
+    private fun downloadAndPreview() {
+        if (state.working) return
+        val release = state.release ?: return
+        state = state.copy(working = true, progress = 0f, previewId = "", message = "正在断点下载 ${release.version}…")
+        lifecycleScope.launch {
+            val session = runCatching { RuleUpdateClient.connect(this@RuleUpdateActivity) }.getOrElse {
+                state = state.copy(working = false, message = "Root 规则服务连接失败：${it.message}")
+                return@launch
+            }
+            try {
+                val ready = RuleUpdateClient.downloadRelease(
+                    this@RuleUpdateActivity,
+                    release
+                ) { progress -> updateProgress(progress, if (progress.resumed) "正在续传规则包" else "正在下载规则包") }
+                state = state.copy(message = "下载 SHA-256 通过，正在执行 APK 同证书复验…")
+                val preview = RuleUpdateClient.previewRelease(this@RuleUpdateActivity, session, release, ready)
+                val text = "${release.version} 已下载并通过签名索引、SHA-256 与 APK 同证书复验"
+                RuleUpdateClient.recordResult(this@RuleUpdateActivity, text)
+                state = state.copy(
+                    working = false,
+                    connected = true,
+                    progress = 1f,
+                    previewId = preview.optString("previewId"),
+                    incomingRules = preview.optInt("incomingRules", 0),
+                    message = text,
+                    settings = RuleUpdateClient.loadSettings(this@RuleUpdateActivity)
+                )
+            } catch (error: Throwable) {
+                val text = "规则包下载或复验失败：${error.message ?: error.javaClass.simpleName}"
+                RuleUpdateClient.recordResult(this@RuleUpdateActivity, text)
+                state = state.copy(working = false, progress = 0f, previewId = "", message = text)
+            } finally {
+                session.close()
+            }
+        }
+    }
+
+    private fun installPreview() {
+        if (state.working || state.previewId.isBlank()) return
+        state = state.copy(working = true, message = "正在备份当前规则并原子安装更新…")
+        lifecycleScope.launch {
+            val session = runCatching { RuleUpdateClient.connect(this@RuleUpdateActivity) }.getOrElse {
+                state = state.copy(working = false, message = "Root 规则服务连接失败：${it.message}")
+                return@launch
+            }
+            try {
+                val result = withContext(Dispatchers.IO) { JSONObject(session.pack.applyPreview(state.previewId)) }
+                if (result.has("error")) error(result.optString("message", result.optString("error")))
+                val version = result.optString("version", state.release?.version.orEmpty())
+                val text = "规则 $version 已安装，旧版本已进入 Root 回滚备份"
+                RuleUpdateClient.recordResult(this@RuleUpdateActivity, text)
+                state = state.copy(
+                    working = false,
+                    progress = 1f,
+                    previewId = "",
+                    release = null,
+                    currentVersion = version,
+                    currentVersionCode = result.optLong("versionCode", state.currentVersionCode),
+                    currentRules = result.optInt("totalRules", state.incomingRules),
+                    message = text,
+                    settings = RuleUpdateClient.loadSettings(this@RuleUpdateActivity)
+                )
+            } catch (error: Throwable) {
+                state = state.copy(working = false, message = "规则安装失败：${error.message}")
+            } finally {
+                session.close()
+            }
+        }
+    }
+
+    private fun changeChannel(channel: String) {
+        if (state.working) return
+        val normalized = if (channel == "beta") "beta" else "stable"
+        val policy = if (normalized == "beta" && state.settings.policy == "install") "download" else state.settings.policy
+        val settings = state.settings.copy(channel = normalized, policy = policy)
+        RuleUpdateWorker.configure(this, settings)
+        state = state.copy(
+            settings = RuleUpdateClient.loadSettings(this),
+            release = null,
+            previewId = "",
+            progress = 0f,
+            message = "已切换到 ${RuleUpdateWorker.channelLabel(normalized)}，请重新检查签名索引"
+        )
+    }
+
+    private fun changePolicy(policy: String) {
+        if (state.working) return
+        val normalized = when (policy) {
+            "notify", "download", "install" -> policy
+            else -> "manual"
+        }
+        if (state.settings.channel == "beta" && normalized == "install") {
+            state = state.copy(message = "Beta 通道禁止静默安装，可选择自动下载后人工确认")
+            return
+        }
+        RuleUpdateWorker.configure(this, state.settings.copy(policy = normalized))
+        state = state.copy(
+            settings = RuleUpdateClient.loadSettings(this),
+            message = "自动更新策略：${RuleUpdateWorker.policyLabel(normalized)}"
+        )
+    }
+
+    private fun updateProgress(progress: RuleDownloadProgress, phase: String) {
+        val ratio = if (progress.total > 0L) {
+            (progress.downloaded.toFloat() / progress.total.toFloat()).coerceIn(0f, 1f)
+        } else 0f
+        runOnUiThread {
+            state = state.copy(
+                progress = ratio,
+                downloadedBytes = progress.downloaded,
+                totalBytes = progress.total,
+                message = "$phase · ${Formatter.formatFileSize(this, progress.downloaded)}" +
+                    if (progress.total > 0L) " / ${Formatter.formatFileSize(this, progress.total)}" else ""
+            )
+        }
+    }
+}
+
+private data class RuleUpdateUiState(
+    val connected: Boolean = false,
+    val working: Boolean = false,
+    val progress: Float = 0f,
+    val downloadedBytes: Long = 0L,
+    val totalBytes: Long = 0L,
+    val message: String = "正在读取在线规则更新状态…",
+    val currentVersion: String = "bundled",
+    val currentVersionCode: Long = 0L,
+    val currentRules: Int = 0,
+    val checkpointAt: Long = 0L,
+    val indexGeneratedAt: Long = 0L,
+    val indexExpiresAt: Long = 0L,
+    val signerSha256: String = "",
+    val release: RuleRelease? = null,
+    val previewId: String = "",
+    val incomingRules: Int = 0,
+    val settings: RuleUpdateSettings = RuleUpdateSettings()
+)
+
+@Composable
+private fun RuleUpdateScreen(
+    state: RuleUpdateUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onCheck: () -> Unit,
+    onDownload: () -> Unit,
+    onInstall: () -> Unit,
+    onChannel: (String) -> Unit,
+    onPolicy: (String) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
+                Spacer(Modifier.width(8.dp))
+                Column(Modifier.weight(1f)) {
+                    Text("TRUSTED UPDATE", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.3.sp)
+                    Text("官方规则更新", fontSize = 32.sp, fontWeight = FontWeight.Black)
+                    Text("签名索引 · 防回放 · 断点续传 · 双重 Root 复验", color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+
+        item { RuleUpdateStatusCard(state, onRefresh) }
+        item { CurrentOnlineRuleCard(state) }
+        item { ChannelPolicyCard(state, onChannel, onPolicy) }
+        item {
+            Button(
+                onClick = onCheck,
+                enabled = !state.working,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).height(54.dp),
+                shape = RoundedCornerShape(18.dp)
+            ) {
+                Icon(Icons.Rounded.SystemUpdate, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("检查签名规则索引", fontWeight = FontWeight.Bold)
+            }
+        }
+
+        state.release?.let { release ->
+            item { ReleaseCard(state, release, onDownload, onInstall) }
+        }
+
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).navigationBarsPadding(),
+                shape = RoundedCornerShape(24.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+            ) {
+                Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(5.dp)) {
+                    Text("更新安全边界", fontWeight = FontWeight.Black, fontSize = 17.sp)
+                    Text("• 在线索引与规则包必须由当前 APK 同一证书签名。", fontSize = 12.sp)
+                    Text("• Root 保存通道最高索引时间，拒绝旧索引回放和同时间不同内容。", fontSize = 12.sp)
+                    Text("• 下载只允许官方 HTTPS 域名，并校验索引声明的体积与 SHA-256。", fontSize = 12.sp)
+                    Text("• 自动安装仅限稳定通道、Wi-Fi、充电且设备空闲；Root 忙时会延后。", fontSize = 12.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RuleUpdateStatusCard(state: RuleUpdateUiState, onRefresh: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    modifier = Modifier.size(56.dp),
+                    shape = RoundedCornerShape(19.dp),
+                    color = if (state.connected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.errorContainer
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            if (state.connected) Icons.Rounded.Security else Icons.Rounded.Warning,
+                            contentDescription = null,
+                            tint = if (state.connected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
+                Spacer(Modifier.width(13.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(if (state.connected) "可信更新引擎" else "更新引擎未连接", fontWeight = FontWeight.Black, fontSize = 18.sp)
+                    Text(state.message, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                }
+            }
+            if (state.working) {
+                if (state.progress > 0f) LinearProgressIndicator(progress = { state.progress }, modifier = Modifier.fillMaxWidth())
+                else LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+            OutlinedButton(onClick = onRefresh, enabled = !state.working, modifier = Modifier.fillMaxWidth()) {
+                Icon(Icons.Rounded.Refresh, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("刷新当前状态")
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentOnlineRuleCard(state: RuleUpdateUiState) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(26.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Column(Modifier.padding(19.dp), verticalArrangement = Arrangement.spacedBy(5.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Rounded.CheckCircle, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Spacer(Modifier.width(8.dp))
+                Text("当前规则", fontWeight = FontWeight.Black, fontSize = 18.sp)
+            }
+            Text(state.currentVersion, fontWeight = FontWeight.Black, fontSize = 27.sp)
+            Text("版本序号 ${state.currentVersionCode} · ${state.currentRules} 条规则", color = MaterialTheme.colorScheme.onPrimaryContainer)
+            if (state.checkpointAt > 0L) {
+                Text("防回放检查点 ${formatTime(state.checkpointAt)}", fontSize = 12.sp, color = MaterialTheme.colorScheme.onPrimaryContainer)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChannelPolicyCard(
+    state: RuleUpdateUiState,
+    onChannel: (String) -> Unit,
+    onPolicy: (String) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(26.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+    ) {
+        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("更新通道", fontWeight = FontWeight.Black, fontSize = 19.sp)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(selected = state.settings.channel == "stable", onClick = { onChannel("stable") }, label = { Text("稳定版") })
+                FilterChip(selected = state.settings.channel == "beta", onClick = { onChannel("beta") }, label = { Text("Beta") })
+            }
+            Text("自动更新策略", fontWeight = FontWeight.Bold)
+            Column(verticalArrangement = Arrangement.spacedBy(7.dp)) {
+                listOf("manual", "notify", "download", "install").forEach { policy ->
+                    FilterChip(
+                        selected = state.settings.policy == policy,
+                        onClick = { onPolicy(policy) },
+                        enabled = policy != "install" || state.settings.channel == "stable",
+                        label = { Text(RuleUpdateWorker.policyLabel(policy)) },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+            Text("后台每 12 小时检查一次；下载策略仅使用非计费网络。", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+        }
+    }
+}
+
+@Composable
+private fun ReleaseCard(
+    state: RuleUpdateUiState,
+    release: RuleRelease,
+    onDownload: () -> Unit,
+    onInstall: () -> Unit
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        shape = RoundedCornerShape(28.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (release.mandatory) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Rounded.CloudDownload, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(if (release.mandatory) "重要规则更新" else "发现可信规则更新", fontWeight = FontWeight.Black, fontSize = 19.sp)
+            }
+            Text("${state.currentVersion} → ${release.version}", fontWeight = FontWeight.Black, fontSize = 25.sp)
+            Text("版本序号 ${release.versionCode} · ${Formatter.formatFileSize(context, release.bytes)}")
+            Text(release.releaseNotes.ifBlank { "此版本未提供额外说明" }, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("发布时间 ${formatTime(release.publishedAt)}", fontSize = 12.sp)
+            Text("包指纹 ${release.sha256.take(16)}", fontSize = 12.sp)
+            if (state.signerSha256.isNotBlank()) Text("索引签名 ${state.signerSha256.take(16)}", fontSize = 12.sp)
+            Button(
+                onClick = onDownload,
+                enabled = !state.working,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                shape = RoundedCornerShape(17.dp)
+            ) {
+                Icon(Icons.Rounded.CloudDownload, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(if (state.previewId.isBlank()) "断点下载并双重验证" else "重新下载并验证")
+            }
+            OutlinedButton(
+                onClick = onInstall,
+                enabled = !state.working && state.previewId.isNotBlank(),
+                modifier = Modifier.fillMaxWidth().height(50.dp),
+                shape = RoundedCornerShape(17.dp)
+            ) {
+                Icon(Icons.Rounded.SystemUpdate, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(if (state.previewId.isNotBlank()) "安装已验证规则" else "下载验证后可安装")
+            }
+        }
+    }
+}
+
+private fun formatTime(value: Long): String = if (value <= 0L) "未知" else
+    DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(Date(value))

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateClient.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateClient.kt
@@ -1,0 +1,499 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.IRuleIndexService
+import io.github.xgl34222220.baize.root.IRulePackService
+import io.github.xgl34222220.baize.root.RuleIndexRootService
+import io.github.xgl34222220.baize.root.RulePackRootService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.json.JSONObject
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+import java.security.MessageDigest
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+internal data class RuleUpdateSettings(
+    val channel: String = "stable",
+    val policy: String = "manual",
+    val lastCheckAt: Long = 0L,
+    val lastResult: String = "尚未检查在线规则更新"
+)
+
+internal data class RuleRelease(
+    val channel: String,
+    val packId: String,
+    val version: String,
+    val versionCode: Long,
+    val minAppVersionCode: Long,
+    val url: String,
+    val sha256: String,
+    val bytes: Long,
+    val publishedAt: Long,
+    val mandatory: Boolean,
+    val releaseNotes: String
+)
+
+internal data class RuleIndexCheck(
+    val currentVersion: String,
+    val currentVersionCode: Long,
+    val currentRules: Int,
+    val channel: String,
+    val generatedAt: Long,
+    val expiresAt: Long,
+    val signerSha256: String,
+    val release: RuleRelease?
+)
+
+internal data class RuleDownloadProgress(
+    val downloaded: Long,
+    val total: Long,
+    val resumed: Boolean
+)
+
+internal class RuleRootSession(
+    val index: IRuleIndexService,
+    val pack: IRulePackService,
+    private val indexConnection: ServiceConnection,
+    private val packConnection: ServiceConnection
+) {
+    suspend fun close() = withContext(Dispatchers.Main.immediate) {
+        runCatching { RootService.unbind(indexConnection) }
+        runCatching { RootService.unbind(packConnection) }
+    }
+}
+
+internal object RuleUpdateClient {
+    private const val PREFS = "rule_update_settings"
+    private const val KEY_CHANNEL = "channel"
+    private const val KEY_POLICY = "policy"
+    private const val KEY_LAST_CHECK = "last_check_at"
+    private const val KEY_LAST_RESULT = "last_result"
+    private const val ROOT_BIND_TIMEOUT_MS = 20_000L
+    private const val MAX_INDEX_BYTES = 2L * 1024L * 1024L
+    private const val MAX_PACK_BYTES = 32L * 1024L * 1024L
+    private const val MAX_REDIRECTS = 5
+    private const val BUFFER_SIZE = 64 * 1024
+
+    private val INDEX_URLS = mapOf(
+        "stable" to "https://github.com/xgl34222220-ops/BaiZe/releases/download/rules-index/BaiZe-Rules-Index-stable.jar",
+        "beta" to "https://github.com/xgl34222220-ops/BaiZe/releases/download/rules-index/BaiZe-Rules-Index-beta.jar"
+    )
+    private val ALLOWED_HOSTS = setOf(
+        "github.com",
+        "objects.githubusercontent.com",
+        "release-assets.githubusercontent.com",
+        "raw.githubusercontent.com"
+    )
+
+    fun loadSettings(context: Context): RuleUpdateSettings {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        return RuleUpdateSettings(
+            channel = normalizeChannel(prefs.getString(KEY_CHANNEL, "stable").orEmpty()),
+            policy = normalizePolicy(prefs.getString(KEY_POLICY, "manual").orEmpty()),
+            lastCheckAt = prefs.getLong(KEY_LAST_CHECK, 0L),
+            lastResult = prefs.getString(KEY_LAST_RESULT, "尚未检查在线规则更新")
+                ?: "尚未检查在线规则更新"
+        )
+    }
+
+    fun saveSettings(context: Context, settings: RuleUpdateSettings) {
+        val channel = normalizeChannel(settings.channel)
+        var policy = normalizePolicy(settings.policy)
+        if (channel == "beta" && policy == "install") policy = "download"
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+            .putString(KEY_CHANNEL, channel)
+            .putString(KEY_POLICY, policy)
+            .apply()
+    }
+
+    fun recordResult(context: Context, text: String) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit()
+            .putLong(KEY_LAST_CHECK, System.currentTimeMillis())
+            .putString(KEY_LAST_RESULT, text.take(500))
+            .apply()
+    }
+
+    suspend fun connect(context: Context): RuleRootSession {
+        val index = bind(
+            context,
+            Intent(context, RuleIndexRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE)
+        ) { IRuleIndexService.Stub.asInterface(it) }
+        return try {
+            val pack = bind(
+                context,
+                Intent(context, RulePackRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE)
+            ) { IRulePackService.Stub.asInterface(it) }
+            RuleRootSession(index.first, pack.first, index.second, pack.second)
+        } catch (error: Throwable) {
+            withContext(Dispatchers.Main.immediate) { runCatching { RootService.unbind(index.second) } }
+            throw error
+        }
+    }
+
+    suspend fun check(
+        context: Context,
+        session: RuleRootSession,
+        channel: String,
+        onProgress: (RuleDownloadProgress) -> Unit = {}
+    ): RuleIndexCheck {
+        val normalized = normalizeChannel(channel)
+        val current = JSONObject(session.pack.getCurrent())
+        if (current.has("error")) error(current.optString("message", current.optString("error")))
+        val indexUrl = INDEX_URLS.getValue(normalized)
+        val downloaded = download(
+            context = context,
+            url = indexUrl,
+            key = "index-$normalized",
+            expectedSha256 = "",
+            expectedBytes = 0L,
+            maxBytes = MAX_INDEX_BYTES,
+            forceFreshFinal = true,
+            onProgress = onProgress
+        )
+        val importDirectory = File(context.cacheDir, "rule-index-imports").apply { mkdirs() }
+        val imported = File(importDirectory, "${UUID.randomUUID()}.jar")
+        downloaded.copyTo(imported, overwrite = true)
+        val verified = JSONObject(
+            session.index.verifyIndex(
+                imported.absolutePath,
+                normalized,
+                current.optLong("versionCode", 0L)
+            )
+        )
+        if (verified.has("error")) error(verified.optString("message", verified.optString("error")))
+        val release = verified.optJSONObject("release")?.let(::parseRelease)
+        return RuleIndexCheck(
+            currentVersion = current.optString("version", "bundled"),
+            currentVersionCode = current.optLong("versionCode", 0L),
+            currentRules = current.optInt("totalRules", 0),
+            channel = normalized,
+            generatedAt = verified.optLong("generatedAt"),
+            expiresAt = verified.optLong("expiresAt"),
+            signerSha256 = verified.optString("signerSha256"),
+            release = release
+        )
+    }
+
+    suspend fun downloadRelease(
+        context: Context,
+        release: RuleRelease,
+        onProgress: (RuleDownloadProgress) -> Unit = {}
+    ): File {
+        require(release.bytes in 1..MAX_PACK_BYTES) { "规则包体积超出限制" }
+        val downloaded = download(
+            context = context,
+            url = release.url,
+            key = "pack-${release.sha256}",
+            expectedSha256 = release.sha256,
+            expectedBytes = release.bytes,
+            maxBytes = MAX_PACK_BYTES,
+            forceFreshFinal = false,
+            onProgress = onProgress
+        )
+        val readyDirectory = File(context.filesDir, "rule-update-ready").apply { mkdirs() }
+        val ready = File(readyDirectory, "${release.sha256}.jar")
+        if (!ready.isFile || ready.length() != release.bytes || sha256(ready) != release.sha256) {
+            downloaded.copyTo(ready, overwrite = true)
+        }
+        pruneReady(readyDirectory, keep = ready.name)
+        return ready
+    }
+
+    suspend fun previewRelease(
+        context: Context,
+        session: RuleRootSession,
+        release: RuleRelease,
+        readyFile: File
+    ): JSONObject = withContext(Dispatchers.IO) {
+        if (!readyFile.isFile || readyFile.length() != release.bytes || sha256(readyFile) != release.sha256) {
+            error("已下载规则包校验失败，请重新下载")
+        }
+        val importDirectory = File(context.cacheDir, "rule-pack-imports").apply { mkdirs() }
+        val imported = File(importDirectory, "${UUID.randomUUID()}.jar")
+        readyFile.copyTo(imported, overwrite = true)
+        val preview = JSONObject(session.pack.previewPackage(imported.absolutePath))
+        if (preview.has("error")) error(preview.optString("message", preview.optString("error")))
+        val manifest = preview.optJSONObject("manifest") ?: JSONObject()
+        if (
+            preview.optString("packId") != release.packId ||
+            preview.optString("version") != release.version ||
+            manifest.optLong("versionCode", 0L) != release.versionCode
+        ) {
+            error("签名规则包与签名索引描述不一致")
+        }
+        preview
+    }
+
+    fun readyFile(context: Context, release: RuleRelease): File =
+        File(context.filesDir, "rule-update-ready/${release.sha256}.jar")
+
+    private suspend fun <T> bind(
+        context: Context,
+        intent: Intent,
+        convert: (IBinder?) -> T?
+    ): Pair<T, ServiceConnection> = withTimeout(ROOT_BIND_TIMEOUT_MS) {
+        withContext(Dispatchers.Main.immediate) {
+            suspendCancellableCoroutine { continuation ->
+                val mainHandler = Handler(Looper.getMainLooper())
+                lateinit var connection: ServiceConnection
+                fun unbind() {
+                    val action = Runnable { runCatching { RootService.unbind(connection) } }
+                    if (Looper.myLooper() == Looper.getMainLooper()) action.run() else mainHandler.post(action)
+                }
+                connection = object : ServiceConnection {
+                    override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                        val service = convert(binder)
+                        if (service == null) {
+                            if (continuation.isActive) continuation.resumeWithException(IllegalStateException("Root Binder 为空"))
+                            unbind()
+                        } else if (continuation.isActive) {
+                            continuation.resume(service to connection)
+                        } else unbind()
+                    }
+
+                    override fun onServiceDisconnected(name: ComponentName?) {
+                        if (continuation.isActive) continuation.resumeWithException(IllegalStateException("Root 服务已断开"))
+                    }
+
+                    override fun onBindingDied(name: ComponentName?) {
+                        if (continuation.isActive) continuation.resumeWithException(IllegalStateException("Root 服务绑定失效"))
+                        unbind()
+                    }
+
+                    override fun onNullBinding(name: ComponentName?) {
+                        if (continuation.isActive) continuation.resumeWithException(IllegalStateException("Root 服务未返回 Binder"))
+                        unbind()
+                    }
+                }
+                continuation.invokeOnCancellation { unbind() }
+                runCatching { RootService.bind(intent, connection) }
+                    .onFailure { if (continuation.isActive) continuation.resumeWithException(it) }
+            }
+        }
+    }
+
+    private suspend fun download(
+        context: Context,
+        url: String,
+        key: String,
+        expectedSha256: String,
+        expectedBytes: Long,
+        maxBytes: Long,
+        forceFreshFinal: Boolean,
+        onProgress: (RuleDownloadProgress) -> Unit
+    ): File = withContext(Dispatchers.IO) {
+        val directory = File(context.filesDir, "rule-update-downloads").apply { mkdirs() }
+        val safeKey = key.replace(Regex("[^A-Za-z0-9._-]"), "_").take(120)
+        val part = File(directory, "$safeKey.part")
+        val final = File(directory, "$safeKey.jar")
+        val metadataFile = File(directory, "$safeKey.json")
+        if (forceFreshFinal) final.delete()
+        if (!forceFreshFinal && final.isFile && verifyDownloaded(final, expectedSha256, expectedBytes, maxBytes)) {
+            onProgress(RuleDownloadProgress(final.length(), expectedBytes.takeIf { it > 0L } ?: final.length(), false))
+            return@withContext final
+        }
+        if (final.exists()) final.delete()
+
+        var metadata = readJson(metadataFile)
+        if (
+            metadata.optString("url") != url ||
+            metadata.optString("expectedSha256") != expectedSha256 ||
+            metadata.optLong("expectedBytes", 0L) != expectedBytes
+        ) {
+            part.delete()
+            metadataFile.delete()
+            metadata = JSONObject()
+        }
+        var offset = part.takeIf { it.isFile }?.length() ?: 0L
+        if (offset > maxBytes || (expectedBytes > 0L && offset > expectedBytes)) {
+            part.delete()
+            offset = 0L
+        }
+
+        val connection = openConnection(
+            rawUrl = url,
+            offset = offset,
+            ifRange = metadata.optString("etag").ifBlank { metadata.optString("lastModified") }
+        )
+        try {
+            val code = connection.responseCode
+            if (code == 416 &&
+                offset > 0L && verifyDownloaded(part, expectedSha256, expectedBytes, maxBytes)
+            ) {
+                if (!part.renameTo(final)) part.copyTo(final, overwrite = true).also { part.delete() }
+                metadataFile.delete()
+                return@withContext final
+            }
+            if (code !in setOf(HttpURLConnection.HTTP_OK, HttpURLConnection.HTTP_PARTIAL)) {
+                throw IllegalStateException("下载失败：HTTP $code")
+            }
+            val append = code == HttpURLConnection.HTTP_PARTIAL && offset > 0L
+            if (!append) {
+                offset = 0L
+                part.delete()
+            }
+            val responseLength = connection.contentLengthLong.coerceAtLeast(0L)
+            val announcedTotal = when {
+                expectedBytes > 0L -> expectedBytes
+                append -> offset + responseLength
+                else -> responseLength
+            }
+            if (announcedTotal > maxBytes) throw IllegalStateException("下载内容超过允许体积")
+            val etag = connection.getHeaderField("ETag").orEmpty()
+            val modified = connection.getHeaderField("Last-Modified").orEmpty()
+            atomicJson(
+                metadataFile,
+                JSONObject()
+                    .put("url", url)
+                    .put("expectedSha256", expectedSha256)
+                    .put("expectedBytes", expectedBytes)
+                    .put("etag", etag)
+                    .put("lastModified", modified)
+            )
+            FileOutputStream(part, append).use { output ->
+                connection.inputStream.use { input ->
+                    val buffer = ByteArray(BUFFER_SIZE)
+                    var total = offset
+                    while (true) {
+                        val read = input.read(buffer)
+                        if (read <= 0) break
+                        total += read
+                        if (total > maxBytes || (expectedBytes > 0L && total > expectedBytes)) {
+                            throw IllegalStateException("下载内容超过签名索引声明的体积")
+                        }
+                        output.write(buffer, 0, read)
+                        onProgress(RuleDownloadProgress(total, announcedTotal, append))
+                    }
+                }
+                output.fd.sync()
+            }
+        } finally {
+            connection.disconnect()
+        }
+        if (!verifyDownloaded(part, expectedSha256, expectedBytes, maxBytes)) {
+            throw IllegalStateException("下载完成后的体积或 SHA-256 校验失败")
+        }
+        if (!part.renameTo(final)) {
+            part.copyTo(final, overwrite = true)
+            part.delete()
+        }
+        metadataFile.delete()
+        final
+    }
+
+    private fun openConnection(rawUrl: String, offset: Long, ifRange: String): HttpURLConnection {
+        var current = validateUrl(rawUrl)
+        repeat(MAX_REDIRECTS + 1) { redirect ->
+            val connection = (URL(current.toASCIIString()).openConnection() as HttpURLConnection).apply {
+                instanceFollowRedirects = false
+                connectTimeout = 15_000
+                readTimeout = 30_000
+                requestMethod = "GET"
+                setRequestProperty("Accept", "application/java-archive, application/zip, application/octet-stream")
+                setRequestProperty("User-Agent", "BaiZe/${BuildConfig.VERSION_NAME} rule-updater")
+                if (offset > 0L) {
+                    setRequestProperty("Range", "bytes=$offset-")
+                    if (ifRange.isNotBlank()) setRequestProperty("If-Range", ifRange)
+                }
+            }
+            val code = connection.responseCode
+            if (code !in 300..399) return connection
+            val location = connection.getHeaderField("Location").orEmpty()
+            connection.disconnect()
+            if (redirect >= MAX_REDIRECTS || location.isBlank()) throw IllegalStateException("规则下载重定向过多或缺少地址")
+            current = validateUrl(current.resolve(location))
+        }
+        error("规则下载重定向失败")
+    }
+
+    private fun validateUrl(raw: String): URI = validateUrl(
+        runCatching { URI(raw.trim()) }.getOrElse { throw IllegalStateException("规则下载地址无效") }
+    )
+
+    private fun validateUrl(uri: URI): URI {
+        val normalized = uri.normalize()
+        val host = normalized.host?.lowercase().orEmpty()
+        if (normalized.scheme?.lowercase() != "https" || host !in ALLOWED_HOSTS) {
+            throw IllegalStateException("规则下载重定向离开官方 HTTPS 域名")
+        }
+        if (normalized.userInfo != null || normalized.fragment != null || normalized.port !in setOf(-1, 443)) {
+            throw IllegalStateException("规则下载地址包含不允许的组成部分")
+        }
+        return normalized
+    }
+
+    private fun verifyDownloaded(file: File, expectedSha256: String, expectedBytes: Long, maxBytes: Long): Boolean {
+        if (!file.isFile || file.length() !in 1..maxBytes) return false
+        if (expectedBytes > 0L && file.length() != expectedBytes) return false
+        if (expectedSha256.isNotBlank() && sha256(file) != expectedSha256.lowercase()) return false
+        return true
+    }
+
+    private fun parseRelease(json: JSONObject): RuleRelease = RuleRelease(
+        channel = normalizeChannel(json.optString("channel")),
+        packId = json.optString("packId"),
+        version = json.optString("version"),
+        versionCode = json.optLong("versionCode"),
+        minAppVersionCode = json.optLong("minAppVersionCode"),
+        url = json.optString("url"),
+        sha256 = json.optString("sha256").lowercase(),
+        bytes = json.optLong("bytes"),
+        publishedAt = json.optLong("publishedAt"),
+        mandatory = json.optBoolean("mandatory"),
+        releaseNotes = json.optString("releaseNotes")
+    )
+
+    private fun normalizeChannel(raw: String): String = if (raw.trim().lowercase() == "beta") "beta" else "stable"
+
+    private fun normalizePolicy(raw: String): String = when (raw.trim().lowercase()) {
+        "notify", "download", "install" -> raw.trim().lowercase()
+        else -> "manual"
+    }
+
+    private fun atomicJson(file: File, json: JSONObject) {
+        file.parentFile?.mkdirs()
+        val temporary = File(file.parentFile, ".${file.name}.${System.nanoTime()}.tmp")
+        FileOutputStream(temporary).use { output ->
+            output.write(json.toString().toByteArray(Charsets.UTF_8))
+            output.fd.sync()
+        }
+        if (!temporary.renameTo(file)) {
+            temporary.copyTo(file, overwrite = true)
+            temporary.delete()
+        }
+    }
+
+    private fun readJson(file: File): JSONObject = if (!file.isFile) JSONObject() else
+        runCatching { JSONObject(file.readText()) }.getOrDefault(JSONObject())
+
+    private fun pruneReady(directory: File, keep: String) {
+        directory.listFiles()?.filter { it.isFile && it.name != keep }?.forEach { it.delete() }
+    }
+
+    private fun sha256(file: File): String = FileInputStream(file).use { input ->
+        val digest = MessageDigest.getInstance("SHA-256")
+        val buffer = ByteArray(BUFFER_SIZE)
+        while (true) {
+            val read = input.read(buffer)
+            if (read <= 0) break
+            digest.update(buffer, 0, read)
+        }
+        digest.digest().joinToString("") { "%02x".format(it) }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateWorker.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateWorker.kt
@@ -1,0 +1,154 @@
+package io.github.xgl34222220.baize
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+class RuleUpdateWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val settings = RuleUpdateClient.loadSettings(applicationContext)
+        if (settings.policy == "manual") return Result.success()
+        val session = runCatching { RuleUpdateClient.connect(applicationContext) }.getOrElse {
+            RuleUpdateClient.recordResult(applicationContext, "后台规则检查无法连接 Root：${it.message}")
+            return Result.retry()
+        }
+        return try {
+            val check = runCatching {
+                RuleUpdateClient.check(applicationContext, session, settings.channel)
+            }.getOrElse {
+                RuleUpdateClient.recordResult(applicationContext, "后台规则检查失败：${it.message}")
+                return Result.retry()
+            }
+            val release = check.release
+            if (release == null) {
+                val text = "${channelLabel(settings.channel)}规则已是最新版本 ${check.currentVersion}"
+                RuleUpdateClient.recordResult(applicationContext, text)
+                return Result.success()
+            }
+
+            when (settings.policy) {
+                "notify" -> {
+                    val text = "发现 ${release.version} · ${release.releaseNotes.ifBlank { "已通过签名索引验证" }}"
+                    RuleUpdateClient.recordResult(applicationContext, text)
+                    NativeNotifier.showRuleUpdate(
+                        applicationContext,
+                        "白泽规则有新版本",
+                        "${check.currentVersion} → ${release.version}",
+                        text
+                    )
+                    Result.success()
+                }
+
+                "download", "install" -> {
+                    val ready = runCatching {
+                        RuleUpdateClient.downloadRelease(applicationContext, release)
+                    }.getOrElse {
+                        RuleUpdateClient.recordResult(applicationContext, "规则包断点下载失败：${it.message}")
+                        return Result.retry()
+                    }
+                    val preview = runCatching {
+                        RuleUpdateClient.previewRelease(applicationContext, session, release, ready)
+                    }.getOrElse {
+                        RuleUpdateClient.recordResult(applicationContext, "已下载规则包签名复验失败：${it.message}")
+                        return Result.failure()
+                    }
+                    val canAutoInstall = settings.policy == "install" && settings.channel == "stable"
+                    if (!canAutoInstall) {
+                        val text = "${release.version} 已下载并通过 APK 同证书复验，打开规则更新页安装"
+                        RuleUpdateClient.recordResult(applicationContext, text)
+                        NativeNotifier.showRuleUpdate(
+                            applicationContext,
+                            "白泽规则更新已准备",
+                            release.version,
+                            text
+                        )
+                        return Result.success()
+                    }
+                    val applied = withContext(Dispatchers.IO) {
+                        JSONObject(session.pack.applyPreview(preview.optString("previewId")))
+                    }
+                    if (applied.has("error")) {
+                        val code = applied.optString("error")
+                        val message = applied.optString("message", code)
+                        RuleUpdateClient.recordResult(applicationContext, "自动安装暂未完成：$message")
+                        return if (code == "busy") Result.retry() else Result.failure()
+                    }
+                    val text = "已自动安装稳定规则 ${release.version}，上一版本可在管理中心回滚"
+                    RuleUpdateClient.recordResult(applicationContext, text)
+                    NativeNotifier.showRuleUpdate(
+                        applicationContext,
+                        "白泽规则已自动更新",
+                        release.version,
+                        text
+                    )
+                    Result.success()
+                }
+
+                else -> Result.success()
+            }
+        } finally {
+            session.close()
+        }
+    }
+
+    companion object {
+        private const val UNIQUE_WORK = "baize_signed_rule_update"
+        private const val INTERVAL_HOURS = 12L
+        private const val FLEX_HOURS = 2L
+
+        internal fun ensureScheduled(context: Context) {
+            configure(context, RuleUpdateClient.loadSettings(context))
+        }
+
+        internal fun configure(context: Context, settings: RuleUpdateSettings) {
+            RuleUpdateClient.saveSettings(context, settings)
+            val manager = WorkManager.getInstance(context)
+            if (settings.policy == "manual") {
+                manager.cancelUniqueWork(UNIQUE_WORK)
+                return
+            }
+            val builder = Constraints.Builder()
+                .setRequiredNetworkType(
+                    if (settings.policy in setOf("download", "install")) NetworkType.UNMETERED
+                    else NetworkType.CONNECTED
+                )
+                .setRequiresBatteryNotLow(settings.policy in setOf("download", "install"))
+            if (settings.policy == "install") {
+                builder.setRequiresCharging(true)
+                builder.setRequiresDeviceIdle(true)
+            }
+            val request = PeriodicWorkRequestBuilder<RuleUpdateWorker>(
+                INTERVAL_HOURS, TimeUnit.HOURS,
+                FLEX_HOURS, TimeUnit.HOURS
+            )
+                .setInitialDelay(30, TimeUnit.MINUTES)
+                .setConstraints(builder.build())
+                .build()
+            manager.enqueueUniquePeriodicWork(
+                UNIQUE_WORK,
+                ExistingPeriodicWorkPolicy.UPDATE,
+                request
+            )
+        }
+
+        internal fun policyLabel(policy: String): String = when (policy) {
+            "notify" -> "发现更新时提醒"
+            "download" -> "仅 Wi-Fi 自动下载并验证"
+            "install" -> "充电、空闲、Wi-Fi 时自动安装稳定版"
+            else -> "仅手动检查"
+        }
+
+        internal fun channelLabel(channel: String): String = if (channel == "beta") "Beta" else "稳定版"
+    }
+}
+
+private fun channelLabel(channel: String): String = RuleUpdateWorker.channelLabel(channel)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RuleIndexRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RuleIndexRootService.kt
@@ -1,0 +1,370 @@
+package io.github.xgl34222220.baize.root
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.IBinder
+import android.os.Process
+import com.topjohnwu.superuser.ipc.RootService
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.net.URI
+import java.security.MessageDigest
+import java.util.jar.JarFile
+
+/**
+ * Verifies the small signed index that points to official rule-pack release assets.
+ *
+ * The service never opens a network connection. The App downloads an index into its private cache,
+ * then this Root process verifies every JAR payload entry with the installed APK certificate,
+ * validates all release URLs and stores a monotonic per-channel checkpoint to reject signed replay.
+ */
+class RuleIndexRootService : RootService() {
+    private val lock = Any()
+
+    private val binder = object : IRuleIndexService.Stub() {
+        override fun ping(): String = synchronized(lock) {
+            pruneImports()
+            JSONObject()
+                .put("uid", Process.myUid())
+                .put("root", Process.myUid() == 0)
+                .put("engine", "signed-rule-index-v1")
+                .put("trustedSignerSha256", JSONArray(trustedSignerFingerprints().sorted()))
+                .put("stableCheckpoint", readCheckpoint("stable"))
+                .put("betaCheckpoint", readCheckpoint("beta"))
+                .toString()
+        }
+
+        override fun verifyIndex(
+            indexPath: String?,
+            channel: String?,
+            currentVersionCode: Long
+        ): String = synchronized(lock) {
+            guarded {
+                pruneImports()
+                val requestedChannel = normalizeChannel(channel.orEmpty())
+                val source = validateImportPath(indexPath.orEmpty())
+                try {
+                    val verified = inspectSignedIndex(source)
+                    val manifest = verified.manifest
+                    val manifestChannel = normalizeChannel(manifest.optString("channel"))
+                    if (manifestChannel != requestedChannel) {
+                        throw IndexException("channel_mismatch", "索引通道与当前选择不一致")
+                    }
+                    val now = System.currentTimeMillis()
+                    val generatedAt = manifest.optLong("generatedAt", 0L)
+                    val expiresAt = manifest.optLong("expiresAt", 0L)
+                    if (generatedAt <= 0L || generatedAt > now + MAX_CLOCK_SKEW_MS) {
+                        throw IndexException("index_time_invalid", "规则索引生成时间无效")
+                    }
+                    if (expiresAt <= now || expiresAt > generatedAt + MAX_INDEX_LIFETIME_MS) {
+                        throw IndexException("index_expired", "规则索引已过期或有效期异常")
+                    }
+
+                    val digest = sha256(verified.manifestBytes)
+                    enforceCheckpoint(requestedChannel, generatedAt, digest)
+                    val releases = validateReleases(manifest, requestedChannel)
+                    val selected = releases
+                        .filter { it.optLong("versionCode") > currentVersionCode.coerceAtLeast(0L) }
+                        .filter { it.optLong("minAppVersionCode") <= appVersionCode() }
+                        .maxByOrNull { it.optLong("versionCode") }
+                    val checkpoint = JSONObject()
+                        .put("channel", requestedChannel)
+                        .put("generatedAt", generatedAt)
+                        .put("expiresAt", expiresAt)
+                        .put("digest", digest)
+                        .put("signerSha256", verified.signerFingerprint)
+                        .put("verifiedAt", now)
+                    atomicWrite(checkpointFile(requestedChannel), checkpoint.toString())
+
+                    JSONObject()
+                        .put("success", true)
+                        .put("trusted", true)
+                        .put("channel", requestedChannel)
+                        .put("generatedAt", generatedAt)
+                        .put("expiresAt", expiresAt)
+                        .put("indexDigest", digest)
+                        .put("signerSha256", verified.signerFingerprint)
+                        .put("currentVersionCode", currentVersionCode.coerceAtLeast(0L))
+                        .put("updateAvailable", selected != null)
+                        .put("release", selected ?: JSONObject.NULL)
+                        .put("releaseCount", releases.size)
+                        .toString()
+                } finally {
+                    runCatching { source.delete() }
+                }
+            }
+        }
+
+        override fun getCheckpoint(channel: String?): String = synchronized(lock) {
+            guarded {
+                val normalized = normalizeChannel(channel.orEmpty())
+                JSONObject(readCheckpoint(normalized).toString())
+                    .put("success", true)
+                    .put("channel", normalized)
+                    .toString()
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent): IBinder = binder
+
+    private data class VerifiedIndex(
+        val manifest: JSONObject,
+        val manifestBytes: ByteArray,
+        val signerFingerprint: String
+    )
+
+    private data class IndexException(val code: String, override val message: String) :
+        IllegalArgumentException(message)
+
+    private inline fun guarded(block: () -> String): String = try {
+        block()
+    } catch (error: IndexException) {
+        failure(error.code, error.message)
+    } catch (error: Throwable) {
+        failure("rule_index_failed", error.message ?: error.javaClass.simpleName)
+    }
+
+    private fun validateImportPath(raw: String): File {
+        val base = File(cacheDir, IMPORT_DIRECTORY).apply { mkdirs() }.canonicalFile
+        val candidate = File(raw).canonicalFile
+        if (!candidate.isFile || candidate.length() !in 1..MAX_INDEX_BYTES) {
+            throw IndexException("index_missing", "规则索引不存在或超过 ${MAX_INDEX_BYTES / 1024}KB")
+        }
+        if (!candidate.path.startsWith(base.path + File.separator)) {
+            throw IndexException("index_path_denied", "只能读取应用下载到私有目录的规则索引")
+        }
+        return candidate
+    }
+
+    private fun inspectSignedIndex(file: File): VerifiedIndex {
+        val trusted = trustedSignerFingerprints()
+        if (trusted.isEmpty()) throw IndexException("signer_unavailable", "无法读取当前 APK 签名证书")
+        var manifestBytes: ByteArray? = null
+        val signerFingerprints = LinkedHashSet<String>()
+        JarFile(file, true).use { jar ->
+            val entries = jar.entries()
+            var payloadCount = 0
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                if (entry.isDirectory) continue
+                val name = entry.name
+                if (name.startsWith("META-INF/", ignoreCase = true)) continue
+                if (name != INDEX_NAME) {
+                    throw IndexException("index_entry_denied", "规则索引包含不允许的文件：$name")
+                }
+                payloadCount += 1
+                if (payloadCount > 1 || manifestBytes != null) {
+                    throw IndexException("index_duplicate", "规则索引包含重复清单")
+                }
+                val bytes = readLimited(jar.getInputStream(entry), MAX_INDEX_PAYLOAD_BYTES)
+                val certificates = entry.certificates.orEmpty()
+                if (certificates.isEmpty()) throw IndexException("index_unsigned", "规则索引未经过 JAR 签名")
+                val fingerprints = certificates.map { sha256(it.encoded) }.toSet()
+                val trustedSigner = fingerprints.firstOrNull { it in trusted }
+                    ?: throw IndexException("index_signer_mismatch", "规则索引签名证书与当前 APK 不一致")
+                signerFingerprints += trustedSigner
+                manifestBytes = bytes
+            }
+        }
+        if (signerFingerprints.size != 1) {
+            throw IndexException("index_mixed_signers", "规则索引包含多个不一致的签名者")
+        }
+        val bytes = manifestBytes ?: throw IndexException("index_manifest_missing", "规则索引缺少 $INDEX_NAME")
+        val manifest = runCatching { JSONObject(bytes.toString(Charsets.UTF_8)) }
+            .getOrElse { throw IndexException("index_manifest_invalid", "规则索引清单不是有效 JSON") }
+        if (manifest.optInt("schema", 0) != INDEX_SCHEMA) {
+            throw IndexException("index_schema_unsupported", "规则索引格式版本不受支持")
+        }
+        return VerifiedIndex(manifest, bytes, signerFingerprints.first())
+    }
+
+    private fun validateReleases(manifest: JSONObject, channel: String): List<JSONObject> {
+        val array = manifest.optJSONArray("releases") ?: JSONArray()
+        if (array.length() > MAX_RELEASES) throw IndexException("release_count_large", "规则索引版本数量超过限制")
+        val result = ArrayList<JSONObject>(array.length())
+        val seenVersionCodes = HashSet<Long>()
+        for (index in 0 until array.length()) {
+            val source = array.optJSONObject(index)
+                ?: throw IndexException("release_invalid", "规则索引版本条目格式错误")
+            val releaseChannel = normalizeChannel(source.optString("channel", channel))
+            if (releaseChannel != channel) throw IndexException("release_channel_mismatch", "规则版本通道不一致")
+            val packId = source.optString("packId").trim()
+            if (!PACK_ID.matches(packId)) throw IndexException("release_pack_id_invalid", "规则包编号无效")
+            val version = source.optString("version").trim()
+            if (version.isBlank() || version.length > 80) throw IndexException("release_version_invalid", "规则包版本无效")
+            val versionCode = source.optLong("versionCode", 0L)
+            if (versionCode <= 0L || !seenVersionCodes.add(versionCode)) {
+                throw IndexException("release_version_code_invalid", "规则包版本序号无效或重复")
+            }
+            val minAppVersionCode = source.optLong("minAppVersionCode", 0L)
+            if (minAppVersionCode < 0L) throw IndexException("release_min_app_invalid", "最低应用版本无效")
+            val bytes = source.optLong("bytes", -1L)
+            if (bytes !in 1..MAX_RULE_PACKAGE_BYTES) throw IndexException("release_size_invalid", "规则包体积无效")
+            val hash = source.optString("sha256").trim().lowercase()
+            if (!SHA256.matches(hash)) throw IndexException("release_hash_invalid", "规则包 SHA-256 无效")
+            val url = validateDownloadUrl(source.optString("url"))
+            val publishedAt = source.optLong("publishedAt", 0L)
+            if (publishedAt <= 0L || publishedAt > System.currentTimeMillis() + MAX_CLOCK_SKEW_MS) {
+                throw IndexException("release_time_invalid", "规则包发布时间无效")
+            }
+            result += JSONObject()
+                .put("channel", channel)
+                .put("packId", packId)
+                .put("version", version)
+                .put("versionCode", versionCode)
+                .put("minAppVersionCode", minAppVersionCode)
+                .put("url", url)
+                .put("sha256", hash)
+                .put("bytes", bytes)
+                .put("publishedAt", publishedAt)
+                .put("mandatory", source.optBoolean("mandatory", false))
+                .put("releaseNotes", source.optString("releaseNotes").take(MAX_RELEASE_NOTES))
+        }
+        return result
+    }
+
+    private fun validateDownloadUrl(raw: String): String {
+        val uri = runCatching { URI(raw.trim()) }.getOrNull()
+            ?: throw IndexException("release_url_invalid", "规则包下载地址无效")
+        val host = uri.host?.lowercase().orEmpty()
+        if (uri.scheme?.lowercase() != "https" || host !in ALLOWED_DOWNLOAD_HOSTS) {
+            throw IndexException("release_url_denied", "规则包下载地址不在官方 HTTPS 域名范围")
+        }
+        if (uri.userInfo != null || uri.fragment != null || uri.port !in setOf(-1, 443) || uri.path.isNullOrBlank()) {
+            throw IndexException("release_url_invalid", "规则包下载地址包含不允许的组成部分")
+        }
+        val normalized = uri.normalize()
+        if (normalized.path.split('/').any { it == ".." }) {
+            throw IndexException("release_url_invalid", "规则包下载地址包含路径穿越")
+        }
+        return normalized.toASCIIString()
+    }
+
+    private fun enforceCheckpoint(channel: String, generatedAt: Long, digest: String) {
+        val previous = readCheckpoint(channel)
+        val previousTime = previous.optLong("generatedAt", 0L)
+        val previousDigest = previous.optString("digest")
+        if (previousTime > generatedAt) {
+            throw IndexException("index_replay", "检测到旧版签名索引回放，已拒绝")
+        }
+        if (previousTime == generatedAt && previousDigest.isNotBlank() && previousDigest != digest) {
+            throw IndexException("index_equivocation", "同一索引时间出现不同内容，已拒绝")
+        }
+    }
+
+    private fun normalizeChannel(raw: String): String = when (raw.trim().lowercase()) {
+        "stable" -> "stable"
+        "beta" -> "beta"
+        else -> throw IndexException("channel_invalid", "规则更新通道无效")
+    }
+
+    private fun readCheckpoint(channel: String): JSONObject = readJson(checkpointFile(channel))
+
+    private fun pruneImports() {
+        val now = System.currentTimeMillis()
+        File(cacheDir, IMPORT_DIRECTORY).apply { mkdirs() }.listFiles()?.forEach { file ->
+            if (!file.isFile || file.length() > MAX_INDEX_BYTES || now - file.lastModified() > IMPORT_TTL_MS) {
+                file.delete()
+            }
+        }
+    }
+
+    private fun trustedSignerFingerprints(): Set<String> = runCatching {
+        val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES)
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getPackageInfo(packageName, PackageManager.GET_SIGNATURES)
+        }
+        val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.signingInfo?.apkContentsSigners.orEmpty()
+        } else {
+            @Suppress("DEPRECATION")
+            info.signatures.orEmpty()
+        }
+        signatures.map { sha256(it.toByteArray()) }.toSet()
+    }.getOrDefault(emptySet())
+
+    private fun appVersionCode(): Long = runCatching {
+        val info = packageManager.getPackageInfo(packageName, 0)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) info.longVersionCode else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+    }.getOrDefault(0L)
+
+    private fun readLimited(input: InputStream, maxBytes: Long): ByteArray = input.use { stream ->
+        val output = ByteArrayOutputStream()
+        val buffer = ByteArray(32 * 1024)
+        var total = 0L
+        while (true) {
+            val read = stream.read(buffer)
+            if (read <= 0) break
+            total += read
+            if (total > maxBytes) throw IndexException("index_payload_large", "规则索引解压后超过限制")
+            output.write(buffer, 0, read)
+        }
+        output.toByteArray()
+    }
+
+    private fun atomicWrite(target: File, content: String) {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.${System.nanoTime()}.tmp")
+        FileOutputStream(temporary).use { output ->
+            output.write(content.toByteArray(Charsets.UTF_8))
+            output.fd.sync()
+        }
+        if (!temporary.renameTo(target)) {
+            temporary.copyTo(target, overwrite = true)
+            temporary.delete()
+        }
+        target.setReadable(false, false)
+        target.setWritable(false, false)
+        target.setReadable(true, true)
+        target.setWritable(true, true)
+    }
+
+    private fun readJson(file: File): JSONObject = if (!file.isFile) JSONObject() else
+        runCatching { JSONObject(file.readText()) }.getOrDefault(JSONObject())
+
+    private fun sha256(bytes: ByteArray): String = MessageDigest.getInstance("SHA-256")
+        .digest(bytes)
+        .joinToString("") { "%02x".format(it) }
+
+    private fun failure(code: String, message: String): String = JSONObject()
+        .put("success", false)
+        .put("error", code)
+        .put("message", message)
+        .toString()
+
+    private fun checkpointFile(channel: String): File =
+        File(RootPaths.STATE_DIR, "rule-index-checkpoints/$channel.json")
+
+    companion object {
+        private const val INDEX_SCHEMA = 1
+        private const val INDEX_NAME = "rule-index.json"
+        private const val IMPORT_DIRECTORY = "rule-index-imports"
+        private const val MAX_INDEX_BYTES = 2L * 1024L * 1024L
+        private const val MAX_INDEX_PAYLOAD_BYTES = 512L * 1024L
+        private const val MAX_RULE_PACKAGE_BYTES = 32L * 1024L * 1024L
+        private const val MAX_RELEASES = 50
+        private const val MAX_RELEASE_NOTES = 4_000
+        private const val IMPORT_TTL_MS = 24L * 60L * 60_000L
+        private const val MAX_CLOCK_SKEW_MS = 24L * 60L * 60_000L
+        private const val MAX_INDEX_LIFETIME_MS = 45L * 24L * 60L * 60_000L
+        private val PACK_ID = Regex("^[A-Za-z0-9._-]{1,80}$")
+        private val SHA256 = Regex("^[0-9a-f]{64}$")
+        private val ALLOWED_DOWNLOAD_HOSTS = setOf(
+            "github.com",
+            "objects.githubusercontent.com",
+            "release-assets.githubusercontent.com",
+            "raw.githubusercontent.com"
+        )
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RulePackRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RulePackRootService.kt
@@ -72,6 +72,7 @@ class RulePackRootService : RootService() {
                     .put("signerSha256", verified.signerFingerprint)
                     .put("packId", manifest.optString("packId"))
                     .put("version", manifest.optString("version"))
+                    .put("versionCode", manifest.optLong("versionCode", 0L))
                     .put("createdBy", manifest.optString("createdBy", "BaiZe"))
                     .put("releaseNotes", manifest.optString("releaseNotes"))
                     .put("minAppVersionCode", manifest.optLong("minAppVersionCode", 0L))
@@ -273,6 +274,12 @@ class RulePackRootService : RootService() {
         if (!PACK_ID.matches(packId)) throw PackException("pack_id_invalid", "规则包编号无效")
         val version = manifest.optString("version").trim()
         if (version.isBlank() || version.length > 80) throw PackException("version_invalid", "规则包版本无效")
+        val versionCode = manifest.optLong("versionCode", 0L)
+        if (versionCode <= 0L) throw PackException("version_code_invalid", "规则包缺少单调版本序号")
+        val currentVersionCode = readJson(currentMetadataFile()).optLong("versionCode", 0L)
+        if (currentVersionCode > 0L && versionCode < currentVersionCode) {
+            throw PackException("pack_downgrade", "规则包版本序号低于当前版本；降级请使用受控回滚")
+        }
         val minVersion = manifest.optLong("minAppVersionCode", 0L).coerceAtLeast(0L)
         if (minVersion > appVersionCode()) {
             throw PackException("app_too_old", "此规则包需要更高版本的白泽")
@@ -363,6 +370,7 @@ class RulePackRootService : RootService() {
         return JSONObject()
             .put("packId", metadata.optString("packId", "baize-bundled"))
             .put("version", metadata.optString("version", "bundled"))
+            .put("versionCode", metadata.optLong("versionCode", 0L))
             .put("installedAt", metadata.optLong("installedAt", 0L))
             .put("source", metadata.optString("source", "module"))
             .put("signerSha256", metadata.optString("signerSha256"))

--- a/v2/docs/rule-update-channel.md
+++ b/v2/docs/rule-update-channel.md
@@ -1,0 +1,103 @@
+# BaiZe official rule update channel
+
+BaiZe uses two independently signed artifacts:
+
+1. a small signed index JAR containing `rule-index.json`;
+2. a full signed rule-pack JAR containing `rule-pack.json` and managed rule files.
+
+Both JARs must be signed with the same certificate as the production BaiZe APK. The App process downloads bytes, while Root services verify signatures and enforce installation policy.
+
+## Official asset locations
+
+The client checks these fixed GitHub Release assets:
+
+- stable: `BaiZe-Rules-Index-stable.jar`
+- beta: `BaiZe-Rules-Index-beta.jar`
+
+They are published under the `rules-index` release tag. Release URLs inside the signed index may use only approved GitHub HTTPS asset hosts.
+
+## Rule pack version codes
+
+Every official rule pack must include a positive, monotonically increasing `versionCode` in `rule-pack.json`. Human-readable `version` strings are display-only; update ordering uses `versionCode`.
+
+Build a rule pack:
+
+```bash
+python3 v2/tools/build-rule-pack.py \
+  --rules-dir dist/rules \
+  --version 2026.08.1 \
+  --version-code 20260801 \
+  --release-notes "Rule maintenance update" \
+  --output dist/BaiZe-Rules-2026.08.1-unsigned.jar
+
+jarsigner \
+  -keystore "$BAIZE_KEYSTORE_PATH" \
+  -signedjar dist/BaiZe-Rules-2026.08.1.jar \
+  dist/BaiZe-Rules-2026.08.1-unsigned.jar \
+  "$BAIZE_KEY_ALIAS"
+```
+
+Record the signed JAR byte length and SHA-256 in a releases JSON file:
+
+```json
+{
+  "releases": [
+    {
+      "packId": "baize-official",
+      "version": "2026.08.1",
+      "versionCode": 20260801,
+      "minAppVersionCode": 24001,
+      "url": "https://github.com/xgl34222220-ops/BaiZe/releases/download/rules-2026.08.1/BaiZe-Rules-2026.08.1.jar",
+      "sha256": "64-lowercase-hex-characters",
+      "bytes": 123456,
+      "publishedAt": 1785542400000,
+      "mandatory": false,
+      "releaseNotes": "Rule maintenance update"
+    }
+  ]
+}
+```
+
+Build and sign an index:
+
+```bash
+python3 v2/tools/build-rule-index.py \
+  --channel stable \
+  --releases-json dist/stable-releases.json \
+  --valid-days 14 \
+  --output dist/BaiZe-Rules-Index-stable-unsigned.jar
+
+jarsigner \
+  -keystore "$BAIZE_KEYSTORE_PATH" \
+  -signedjar dist/BaiZe-Rules-Index-stable.jar \
+  dist/BaiZe-Rules-Index-stable-unsigned.jar \
+  "$BAIZE_KEY_ALIAS"
+```
+
+## Root verification
+
+`RuleIndexRootService` verifies the complete JAR signature, checks the signer against the installed APK, validates timestamps, URLs, release hashes and sizes, then stores a monotonic checkpoint for each channel.
+
+An index is rejected when:
+
+- it is unsigned or signed by a different certificate;
+- its channel does not match the selected channel;
+- it is expired or has an implausible future timestamp;
+- its generated time is older than the last trusted checkpoint;
+- the same generated time is reused with different content;
+- a release uses a non-approved host, invalid SHA-256, duplicate version code or excessive size.
+
+`RulePackRootService` independently verifies the downloaded pack before preview and installation. A valid index can never make an unsigned or differently signed pack installable.
+
+## Download and automatic policy
+
+Downloads use HTTP Range and If-Range with persisted ETag or Last-Modified metadata. Final byte length and SHA-256 must match the signed index.
+
+Policies:
+
+- manual: no periodic work;
+- notify: check every 12 hours on any connected network;
+- download: use unmetered network and verify the pack, but require manual installation;
+- install: stable channel only, requiring unmetered network, charging, battery-not-low and device idle.
+
+Root refuses installation while scanning, cleaning or organizing. Every successful install still creates the normal three-generation rollback backup. Beta channel never performs silent installation.

--- a/v2/tests/test-clean-plan-persistence.py
+++ b/v2/tests/test-clean-plan-persistence.py
@@ -73,4 +73,5 @@ runpy.run_path(str(ROOT / "v2/tests/test-candidate-selection-plan.py"), run_name
 runpy.run_path(str(ROOT / "v2/tests/test-clean-result-report.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-explainable-rules-whitelist.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-rule-pack-management.py"), run_name="__main__")
+runpy.run_path(str(ROOT / "v2/tests/test-rule-update-channel.py"), run_name="__main__")
 print("clean plan persistence contract: ok")

--- a/v2/tests/test-rule-update-channel.py
+++ b/v2/tests/test-rule-update-channel.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+# Stage eight contract: both the signed index and downloaded pack must cross separate Root trust boundaries.
+ROOT = Path(__file__).resolve().parents[2]
+APP = ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize"
+INDEX_SERVICE = (APP / "root/RuleIndexRootService.kt").read_text(encoding="utf-8")
+PACK_SERVICE = (APP / "root/RulePackRootService.kt").read_text(encoding="utf-8")
+CLIENT = (APP / "RuleUpdateClient.kt").read_text(encoding="utf-8")
+WORKER = (APP / "RuleUpdateWorker.kt").read_text(encoding="utf-8")
+ACTIVITY = (APP / "RuleUpdateActivity.kt").read_text(encoding="utf-8")
+NOTIFIER = (APP / "NativeNotifier.kt").read_text(encoding="utf-8")
+APPLICATION = (APP / "BaiZeApplication.kt").read_text(encoding="utf-8")
+AIDL = (ROOT / "v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IRuleIndexService.aidl").read_text(encoding="utf-8")
+MANIFEST = (ROOT / "v2/app/src/main/AndroidManifest.xml").read_text(encoding="utf-8")
+CENTER = (APP / "CleanCenterActivity.kt").read_text(encoding="utf-8")
+PACK_BUILDER = (ROOT / "v2/tools/build-rule-pack.py").read_text(encoding="utf-8")
+INDEX_BUILDER = (ROOT / "v2/tools/build-rule-index.py").read_text(encoding="utf-8")
+DOC = (ROOT / "v2/docs/rule-update-channel.md").read_text(encoding="utf-8")
+
+
+def require(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+for method in ("ping", "verifyIndex", "getCheckpoint"):
+    require(method in AIDL, f"signed index binder method missing: {method}")
+
+for marker in (
+    "JarFile(file, true)", "entry.certificates", "trustedSignerFingerprints",
+    "index_signer_mismatch", "index_unsigned", "index_mixed_signers",
+    "enforceCheckpoint", "index_replay", "index_equivocation",
+    "generatedAt", "expiresAt", "MAX_INDEX_LIFETIME_MS",
+    "validateDownloadUrl", "ALLOWED_DOWNLOAD_HOSTS", "release_hash_invalid",
+    "rule-index-checkpoints", "rule-index-imports"
+):
+    require(marker in INDEX_SERVICE, f"signed index safety primitive missing: {marker}")
+require("openConnection(" not in INDEX_SERVICE and "HttpURLConnection" not in INDEX_SERVICE,
+        "Root index verifier must never access the network")
+
+for marker in (
+    'setRequestProperty("Range"', 'setRequestProperty("If-Range"', 'getHeaderField("ETag")',
+    'getHeaderField("Last-Modified")', "HTTP_PARTIAL", "416", "MAX_REDIRECTS",
+    "ALLOWED_HOSTS", "expectedSha256", "expectedBytes", "sha256(file)",
+    "RuleIndexRootService", "RulePackRootService", "verifyIndex", "previewPackage",
+    "BaiZe-Rules-Index-stable.jar", "BaiZe-Rules-Index-beta.jar"
+):
+    require(marker in CLIENT, f"resumable update client primitive missing: {marker}")
+
+for marker in (
+    "NetworkType.UNMETERED", "setRequiresCharging(true)", "setRequiresDeviceIdle(true)",
+    "ExistingPeriodicWorkPolicy.UPDATE", 'settings.channel == "stable"',
+    'settings.policy == "install"', "Result.retry()"
+):
+    require(marker in WORKER, f"automatic update policy missing: {marker}")
+
+for marker in (
+    "官方规则更新", "签名索引", "防回放", "断点续传", "FilterChip",
+    "稳定版", "Beta", "断点下载并双重验证", "安装已验证规则"
+):
+    require(marker in ACTIVITY, f"online update UI contract missing: {marker}")
+
+require("showRuleUpdate" in NOTIFIER and "RuleUpdateActivity::class.java" in NOTIFIER,
+        "rule update notification must open the update page")
+require("RuleUpdateWorker.ensureScheduled" in APPLICATION,
+        "application must restore the selected update policy")
+require('android.permission.INTERNET' in MANIFEST, "online update requires INTERNET permission")
+require('android.permission.ACCESS_NETWORK_STATE' in MANIFEST, "update worker requires network state permission")
+require('android:name=".RuleUpdateActivity"' in MANIFEST, "rule update activity is not registered")
+require('android:name=".root.RuleIndexRootService"' in MANIFEST, "rule index Root service is not registered")
+require("RuleUpdateActivity::class.java" in CENTER and "官方规则更新" in CENTER,
+        "clean center must expose official rule updates")
+
+require('put("versionCode"' in PACK_SERVICE and 'optLong("versionCode"' in PACK_SERVICE,
+        "installed rule metadata must expose a monotonic version code")
+require('--version-code' in PACK_BUILDER and '"versionCode"' in PACK_BUILDER,
+        "rule pack builder must emit monotonic versionCode")
+for marker in ("rule-index.json", "--channel", "generatedAt", "expiresAt", "jarsigner", "ALLOWED_HOSTS"):
+    require(marker in INDEX_BUILDER, f"rule index builder contract missing: {marker}")
+for marker in ("same certificate", "HTTP Range", "If-Range", "monotonic checkpoint", "Beta channel never"):
+    require(marker in DOC, f"rule update documentation missing: {marker}")
+
+print("signed online rule update channel contract: ok")

--- a/v2/tools/build-rule-index.py
+++ b/v2/tools/build-rule-index.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Build a deterministic BaiZe rule-index JAR before signing it with jarsigner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import time
+import urllib.parse
+import zipfile
+
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+PACK_ID = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+ALLOWED_HOSTS = {
+    "github.com",
+    "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com",
+    "raw.githubusercontent.com",
+}
+FIXED_TIME = (2026, 1, 1, 0, 0, 0)
+MAX_PACK_BYTES = 32 * 1024 * 1024
+
+
+def write_entry(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
+    info = zipfile.ZipInfo(name, FIXED_TIME)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    info.external_attr = 0o100644 << 16
+    archive.writestr(info, data)
+
+
+def validate_release(item: dict[str, object], channel: str) -> dict[str, object]:
+    pack_id = str(item.get("packId", "")).strip()
+    version = str(item.get("version", "")).strip()
+    version_code = int(item.get("versionCode", 0))
+    min_app = int(item.get("minAppVersionCode", 0))
+    size = int(item.get("bytes", 0))
+    digest = str(item.get("sha256", "")).strip().lower()
+    published = int(item.get("publishedAt", 0))
+    url = str(item.get("url", "")).strip()
+    parsed = urllib.parse.urlparse(url)
+    if not PACK_ID.fullmatch(pack_id):
+        raise ValueError(f"invalid packId: {pack_id!r}")
+    if not version or len(version) > 80:
+        raise ValueError(f"invalid version: {version!r}")
+    if version_code <= 0 or min_app < 0:
+        raise ValueError(f"invalid versionCode/minAppVersionCode for {version}")
+    if not 0 < size <= MAX_PACK_BYTES:
+        raise ValueError(f"invalid bytes for {version}")
+    if not SHA256.fullmatch(digest):
+        raise ValueError(f"invalid sha256 for {version}")
+    if published <= 0:
+        raise ValueError(f"invalid publishedAt for {version}")
+    if parsed.scheme != "https" or (parsed.hostname or "").lower() not in ALLOWED_HOSTS:
+        raise ValueError(f"non-official HTTPS URL for {version}")
+    if parsed.username or parsed.password or parsed.fragment or parsed.port not in (None, 443):
+        raise ValueError(f"unsafe URL components for {version}")
+    return {
+        "channel": channel,
+        "packId": pack_id,
+        "version": version,
+        "versionCode": version_code,
+        "minAppVersionCode": min_app,
+        "url": url,
+        "sha256": digest,
+        "bytes": size,
+        "publishedAt": published,
+        "mandatory": bool(item.get("mandatory", False)),
+        "releaseNotes": str(item.get("releaseNotes", ""))[:4000],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--channel", choices=("stable", "beta"), required=True)
+    parser.add_argument("--releases-json", type=pathlib.Path, required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--generated-at", type=int, default=0, help="Unix epoch milliseconds; defaults to now")
+    parser.add_argument("--valid-days", type=int, default=14)
+    args = parser.parse_args()
+
+    source = json.loads(args.releases_json.read_text(encoding="utf-8"))
+    raw_releases = source.get("releases", source) if isinstance(source, dict) else source
+    if not isinstance(raw_releases, list) or len(raw_releases) > 50:
+        raise SystemExit("releases JSON must contain a list of at most 50 releases")
+    releases = [validate_release(item, args.channel) for item in raw_releases]
+    codes = [int(item["versionCode"]) for item in releases]
+    if len(codes) != len(set(codes)):
+        raise SystemExit("duplicate versionCode in releases")
+    releases.sort(key=lambda item: int(item["versionCode"]), reverse=True)
+
+    generated_at = args.generated_at or int(time.time() * 1000)
+    valid_days = max(1, min(args.valid_days, 45))
+    manifest = {
+        "schema": 1,
+        "channel": args.channel,
+        "generatedAt": generated_at,
+        "expiresAt": generated_at + valid_days * 24 * 60 * 60 * 1000,
+        "releases": releases,
+    }
+    payload = json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(args.output, "w") as archive:
+        write_entry(archive, "META-INF/MANIFEST.MF", b"Manifest-Version: 1.0\r\nCreated-By: BaiZe Rule Index Builder\r\n\r\n")
+        write_entry(archive, "rule-index.json", payload)
+    print(f"built unsigned {args.channel} index: {args.output}")
+    print("sign with the same production APK certificate:")
+    print(f"jarsigner -keystore <keystore> -signedjar <signed.jar> {args.output} <alias>")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/v2/tools/build-rule-pack.py
+++ b/v2/tools/build-rule-pack.py
@@ -57,6 +57,7 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--rules-dir", required=True, type=pathlib.Path)
     parser.add_argument("--version", required=True)
+    parser.add_argument("--version-code", required=True, type=int)
     parser.add_argument("--output", required=True, type=pathlib.Path)
     parser.add_argument("--pack-id", default="baize-official")
     parser.add_argument("--created-by", default="BaiZe GitHub Actions")
@@ -68,6 +69,8 @@ def main() -> int:
         raise SystemExit("invalid --pack-id")
     if not args.version.strip() or len(args.version) > 80:
         raise SystemExit("invalid --version")
+    if args.version_code <= 0:
+        raise SystemExit("--version-code must be a positive monotonic integer")
     if not args.rules_dir.is_dir():
         raise SystemExit("--rules-dir is not a directory")
 
@@ -103,6 +106,7 @@ def main() -> int:
         "mode": "full",
         "packId": args.pack_id,
         "version": args.version.strip(),
+        "versionCode": args.version_code,
         "createdBy": args.created_by.strip(),
         "releaseNotes": args.release_notes.strip(),
         "minAppVersionCode": max(0, args.min_app_version_code),


### PR DESCRIPTION
## 第八阶段：官方规则更新通道

- 使用固定 GitHub Release 地址下载稳定版/Beta 签名索引。
- 新增独立只读 `RuleIndexRootService`，验证索引 JAR 每个载荷条目的签名证书。
- 索引证书必须与当前 BaiZe APK 完全一致。
- Root 保存每个通道的单调检查点，拒绝旧索引回放和同时间不同内容。
- 索引只允许官方 GitHub HTTPS 域名、有效 SHA-256、声明体积和单调版本号。
- 规则包下载支持 Range、If-Range、ETag、Last-Modified 和跨进程断点续传。
- 下载完成后校验签名索引声明的体积与 SHA-256，再交给规则包 Root 服务执行第二次同证书验证。
- 支持仅手动、发现提醒、Wi-Fi 自动下载、稳定版充电/空闲/Wi-Fi 自动安装四档策略。
- Beta 通道禁止静默安装。
- 正常安装拒绝低版本序号规则包；受控回滚仍可恢复备份。
- 新增确定性签名索引构建工具和发布格式文档。

## 堆叠关系

本 PR 基于第七阶段 `agent/rule-pack-management`，已整理为 1 个干净提交、15 个第八阶段文件。没有修改扫描器、删除器或清理事务格式。

## 验证结果

完整工作流 `BaiZe v2.4.1 Verify and Release #59` 已全部通过：

- 第八阶段索引同证书签名、防回放、官方 URL、断点下载、SHA-256、双 Root 复验和自动策略契约：通过
- 前七阶段清理计划、断点恢复、真实统计、候选选择、结果报告、快捷白名单和本地规则包管理回归：通过
- Root Shell、调度公平性、增量索引和归类事务回归：通过
- Android Release、Debug Kotlin、Lint 和 Macrobenchmark：通过
- ARM64 原生扫描器：通过
- 模块封包、内置 APK 一致性和签名产物校验：通过

最终分支只保留 Manifest/AIDL、索引 RootService、下载客户端、更新 Worker/页面、通知与启动接线、规则包版本序号、构建工具、文档和测试文件。