### PR TITLE
feat(rules): automate signed rule publishing

### DIFF
--- a/.github/workflows/rule-release.yml
+++ b/.github/workflows/rule-release.yml
@@ -1,0 +1,553 @@
+name: BaiZe Signed Rule Release
+
+on:
+  pull_request:
+    paths:
+      - 'config/**'
+      - 'v2/tools/build-rule-pack.py'
+      - 'v2/tools/build-rule-index.py'
+      - 'v2/tools/verify-rule-release.py'
+      - 'v2/tools/verify-signed-jar.sh'
+      - 'v2/tests/test-rule-release-automation.py'
+      - 'v2/docs/rule-release-playbook.md'
+      - '.github/workflows/rule-release.yml'
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Rule update channel
+        type: choice
+        options: [stable, beta]
+        default: stable
+        required: true
+      version:
+        description: Display version, for example 2026.08.1
+        type: string
+        required: true
+      version_code:
+        description: Positive monotonic integer, for example 20260801
+        type: string
+        required: true
+      min_app_version_code:
+        description: Minimum BaiZe app versionCode
+        type: string
+        default: '24001'
+        required: true
+      release_notes:
+        description: Rule changes shown in the app
+        type: string
+        required: true
+      mandatory:
+        description: Mark the rule update as mandatory
+        type: boolean
+        default: false
+      valid_days:
+        description: Signed index validity window, 1-45 days
+        type: string
+        default: '30'
+        required: true
+      publish:
+        description: Publish GitHub Release assets after rehearsal
+        type: boolean
+        default: false
+      confirm_publish:
+        description: Type PUBLISH when publish is enabled
+        type: string
+        default: ''
+        required: false
+  schedule:
+    - cron: '23 3 * * 1'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: baize-rule-release-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+env:
+  BAIZE_CERT_SHA256: 9efa848001ccdc168ea96753d332b1713e2668ba6a2fa22d5bfd98de65db1f0f
+
+jobs:
+  release-rehearsal:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout committed source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and validate release inputs
+        id: release
+        shell: bash
+        env:
+          INPUT_CHANNEL: ${{ inputs.channel }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_VERSION_CODE: ${{ inputs.version_code }}
+          INPUT_MIN_APP: ${{ inputs.min_app_version_code }}
+          INPUT_NOTES: ${{ inputs.release_notes }}
+          INPUT_MANDATORY: ${{ inputs.mandatory }}
+          INPUT_VALID_DAYS: ${{ inputs.valid_days }}
+          INPUT_PUBLISH: ${{ inputs.publish }}
+          INPUT_CONFIRM: ${{ inputs.confirm_publish }}
+        run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = 'pull_request' ]; then
+            CHANNEL=stable
+            VERSION="ci-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
+            VERSION_CODE=$((900000000 + GITHUB_RUN_NUMBER * 10 + GITHUB_RUN_ATTEMPT))
+            MIN_APP=24001
+            MANDATORY=false
+            VALID_DAYS=7
+            PUBLISH=false
+            printf '%s\n' 'Pull request end-to-end signed rule release rehearsal.' > release-notes.txt
+          else
+            CHANNEL=$INPUT_CHANNEL
+            VERSION=$INPUT_VERSION
+            VERSION_CODE=$INPUT_VERSION_CODE
+            MIN_APP=$INPUT_MIN_APP
+            MANDATORY=$INPUT_MANDATORY
+            VALID_DAYS=$INPUT_VALID_DAYS
+            PUBLISH=$INPUT_PUBLISH
+            printf '%s\n' "$INPUT_NOTES" > release-notes.txt
+          fi
+          case "$CHANNEL" in stable|beta) ;; *) echo 'invalid channel' >&2; exit 1 ;; esac
+          printf '%s' "$VERSION" | grep -Eq '^[A-Za-z0-9._-]{1,80}$'
+          printf '%s' "$VERSION_CODE" | grep -Eq '^[1-9][0-9]{0,17}$'
+          printf '%s' "$MIN_APP" | grep -Eq '^[0-9]{1,18}$'
+          printf '%s' "$VALID_DAYS" | grep -Eq '^[0-9]{1,2}$'
+          [ "$VALID_DAYS" -ge 1 ] && [ "$VALID_DAYS" -le 45 ]
+          test -s release-notes.txt
+          if [ "$PUBLISH" = 'true' ]; then
+            [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ]
+            [ "$GITHUB_REF" = 'refs/heads/main' ]
+            [ "$INPUT_CONFIRM" = 'PUBLISH' ]
+          fi
+          PACK_TAG="rules-${CHANNEL}-${VERSION_CODE}"
+          PACK_ASSET="BaiZe-Rules-${CHANNEL}-${VERSION}.jar"
+          INDEX_ASSET="BaiZe-Rules-Index-${CHANNEL}.jar"
+          PACK_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${PACK_TAG}/${PACK_ASSET}"
+          GENERATED_AT=$(date +%s%3N)
+          {
+            echo "channel=$CHANNEL"
+            echo "version=$VERSION"
+            echo "version_code=$VERSION_CODE"
+            echo "min_app=$MIN_APP"
+            echo "mandatory=$MANDATORY"
+            echo "valid_days=$VALID_DAYS"
+            echo "publish=$PUBLISH"
+            echo "pack_tag=$PACK_TAG"
+            echo "pack_asset=$PACK_ASSET"
+            echo "index_asset=$INDEX_ASSET"
+            echo "pack_url=$PACK_URL"
+            echo "generated_at=$GENERATED_AT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Prepare temporary rehearsal signer
+        if: steps.release.outputs.publish != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          KEYSTORE="$RUNNER_TEMP/baize-rule-ci.jks"
+          PASSWORD='baize-rule-ci-24001'
+          keytool -genkeypair -noprompt \
+            -keystore "$KEYSTORE" -storepass "$PASSWORD" -keypass "$PASSWORD" \
+            -alias baize-rule-ci -keyalg RSA -keysize 3072 -validity 3650 \
+            -dname 'CN=BaiZe Rule Release CI,O=xgl34222220-ops,C=CN'
+          CERT=$(keytool -exportcert -keystore "$KEYSTORE" -storepass "$PASSWORD" -alias baize-rule-ci -rfc \
+            | openssl x509 -noout -fingerprint -sha256 | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]')
+          {
+            echo "BAIZE_KEYSTORE_PATH=$KEYSTORE"
+            echo "BAIZE_KEYSTORE_PASSWORD=$PASSWORD"
+            echo 'BAIZE_KEY_ALIAS=baize-rule-ci'
+            echo "BAIZE_KEY_PASSWORD=$PASSWORD"
+            echo "EXPECTED_RULE_CERT_SHA256=$CERT"
+          } >> "$GITHUB_ENV"
+
+      - name: Prepare formal production signer
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        env:
+          KEYSTORE_BASE64_RAW: ${{ secrets.BAIZE_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD_RAW: ${{ secrets.BAIZE_KEYSTORE_PASSWORD }}
+          KEY_ALIAS_RAW: ${{ secrets.BAIZE_KEY_ALIAS }}
+          KEY_PASSWORD_RAW: ${{ secrets.BAIZE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          normalize_secret() {
+            secret_name=$1
+            raw_value=$2
+            value=$(printf '%s' "$raw_value" | tr -d '\r\n')
+            value=$(printf '%s' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+            case "$value" in "$secret_name="*) value=${value#*=} ;; esac
+            case "$value" in
+              \"*\") value=${value#\"}; value=${value%\"} ;;
+              \'*\') value=${value#\'}; value=${value%\'} ;;
+            esac
+            printf '%s' "$value"
+          }
+          KEYSTORE_BASE64=$(normalize_secret BAIZE_KEYSTORE_BASE64 "$KEYSTORE_BASE64_RAW" | tr -d '[:space:]')
+          KEYSTORE_PASSWORD=$(normalize_secret BAIZE_KEYSTORE_PASSWORD "$KEYSTORE_PASSWORD_RAW")
+          KEY_ALIAS=$(normalize_secret BAIZE_KEY_ALIAS "$KEY_ALIAS_RAW")
+          KEY_PASSWORD=$(normalize_secret BAIZE_KEY_PASSWORD "$KEY_PASSWORD_RAW")
+          test -n "$KEYSTORE_BASE64" && test -n "$KEYSTORE_PASSWORD" && test -n "$KEY_ALIAS" && test -n "$KEY_PASSWORD"
+          KEYSTORE="$RUNNER_TEMP/baize-rule-release.jks"
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE"
+          keytool -list -keystore "$KEYSTORE" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null
+          ACTUAL_CERT=$(keytool -exportcert -keystore "$KEYSTORE" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" -rfc \
+            | openssl x509 -noout -fingerprint -sha256 | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]')
+          test "$ACTUAL_CERT" = "$BAIZE_CERT_SHA256"
+          {
+            echo "BAIZE_KEYSTORE_PATH=$KEYSTORE"
+            echo "BAIZE_KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD"
+            echo "BAIZE_KEY_ALIAS=$KEY_ALIAS"
+            echo "BAIZE_KEY_PASSWORD=$KEY_PASSWORD"
+            echo "EXPECTED_RULE_CERT_SHA256=$ACTUAL_CERT"
+          } >> "$GITHUB_ENV"
+
+      - name: Build and sign official rule pack
+        id: pack
+        shell: bash
+        env:
+          VERSION: ${{ steps.release.outputs.version }}
+          VERSION_CODE: ${{ steps.release.outputs.version_code }}
+          MIN_APP: ${{ steps.release.outputs.min_app }}
+          PACK_ASSET: ${{ steps.release.outputs.pack_asset }}
+        run: |
+          set -euo pipefail
+          mkdir -p rule-release
+          python3 v2/tools/build-rule-pack.py \
+            --rules-dir config \
+            --version "$VERSION" \
+            --version-code "$VERSION_CODE" \
+            --min-app-version-code "$MIN_APP" \
+            --release-notes "$(cat release-notes.txt)" \
+            --output rule-release/unsigned-pack.jar
+          jarsigner -keystore "$BAIZE_KEYSTORE_PATH" -storepass "$BAIZE_KEYSTORE_PASSWORD" \
+            -keypass "$BAIZE_KEY_PASSWORD" -signedjar "rule-release/$PACK_ASSET" \
+            rule-release/unsigned-pack.jar "$BAIZE_KEY_ALIAS"
+          bash v2/tools/verify-signed-jar.sh "rule-release/$PACK_ASSET"
+          ACTUAL=$(keytool -printcert -jarfile "rule-release/$PACK_ASSET" \
+            | awk -F': ' '/SHA256:/ {print tolower($2); exit}' | tr -d ':[:space:]')
+          test "$ACTUAL" = "$EXPECTED_RULE_CERT_SHA256"
+          sha256sum "rule-release/$PACK_ASSET" > "rule-release/$PACK_ASSET.sha256"
+          PACK_SHA=$(awk '{print $1}' "rule-release/$PACK_ASSET.sha256")
+          PACK_BYTES=$(stat -c '%s' "rule-release/$PACK_ASSET")
+          PACK_ID=$(unzip -p "rule-release/$PACK_ASSET" rule-pack.json | python3 -c 'import json,sys; print(json.load(sys.stdin)["packId"])')
+          {
+            echo "sha=$PACK_SHA"
+            echo "bytes=$PACK_BYTES"
+            echo "pack_id=$PACK_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Load and validate previous signed channel index
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INDEX_ASSET: ${{ steps.release.outputs.index_asset }}
+          CHANNEL: ${{ steps.release.outputs.channel }}
+          VERSION_CODE: ${{ steps.release.outputs.version_code }}
+        run: |
+          set -euo pipefail
+          mkdir -p rule-release/previous
+          if gh release view rules-index >/dev/null 2>&1 && \
+             gh release download rules-index --pattern "$INDEX_ASSET" --dir rule-release/previous >/dev/null 2>&1; then
+            OLD="rule-release/previous/$INDEX_ASSET"
+            bash v2/tools/verify-signed-jar.sh "$OLD"
+            OLD_CERT=$(keytool -printcert -jarfile "$OLD" \
+              | awk -F': ' '/SHA256:/ {print tolower($2); exit}' | tr -d ':[:space:]')
+            test "$OLD_CERT" = "$BAIZE_CERT_SHA256"
+            unzip -p "$OLD" rule-index.json > rule-release/previous-index.json
+            python3 - "$CHANNEL" "$VERSION_CODE" <<'PY'
+          import json, pathlib, sys
+          channel, new_code = sys.argv[1], int(sys.argv[2])
+          data = json.loads(pathlib.Path('rule-release/previous-index.json').read_text())
+          assert data['schema'] == 1 and data['channel'] == channel
+          codes = [int(item['versionCode']) for item in data.get('releases', [])]
+          if codes and new_code <= max(codes):
+              raise SystemExit(f'versionCode {new_code} must be greater than published {max(codes)}')
+          PY
+          else
+            printf '%s\n' '{"schema":1,"releases":[]}' > rule-release/previous-index.json
+          fi
+
+      - name: Build merged signed channel index
+        id: index
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.release.outputs.channel }}
+          VERSION: ${{ steps.release.outputs.version }}
+          VERSION_CODE: ${{ steps.release.outputs.version_code }}
+          MIN_APP: ${{ steps.release.outputs.min_app }}
+          MANDATORY: ${{ steps.release.outputs.mandatory }}
+          VALID_DAYS: ${{ steps.release.outputs.valid_days }}
+          GENERATED_AT: ${{ steps.release.outputs.generated_at }}
+          PACK_URL: ${{ steps.release.outputs.pack_url }}
+          PACK_SHA: ${{ steps.pack.outputs.sha }}
+          PACK_BYTES: ${{ steps.pack.outputs.bytes }}
+          PACK_ID: ${{ steps.pack.outputs.pack_id }}
+          INDEX_ASSET: ${{ steps.release.outputs.index_asset }}
+        run: |
+          set -euo pipefail
+          [ -s rule-release/previous-index.json ] || printf '%s\n' '{"schema":1,"releases":[]}' > rule-release/previous-index.json
+          python3 - <<'PY'
+          import json, os, pathlib
+          source = json.loads(pathlib.Path('rule-release/previous-index.json').read_text())
+          releases = [item for item in source.get('releases', []) if int(item.get('versionCode', 0)) != int(os.environ['VERSION_CODE'])]
+          releases.append({
+              'channel': os.environ['CHANNEL'],
+              'packId': os.environ['PACK_ID'],
+              'version': os.environ['VERSION'],
+              'versionCode': int(os.environ['VERSION_CODE']),
+              'minAppVersionCode': int(os.environ['MIN_APP']),
+              'url': os.environ['PACK_URL'],
+              'sha256': os.environ['PACK_SHA'],
+              'bytes': int(os.environ['PACK_BYTES']),
+              'publishedAt': int(os.environ['GENERATED_AT']),
+              'mandatory': os.environ['MANDATORY'].lower() == 'true',
+              'releaseNotes': pathlib.Path('release-notes.txt').read_text().strip(),
+          })
+          releases.sort(key=lambda item: int(item['versionCode']), reverse=True)
+          pathlib.Path('rule-release/releases.json').write_text(
+              json.dumps({'releases': releases[:50]}, ensure_ascii=False, sort_keys=True, indent=2) + '\n'
+          )
+          PY
+          python3 v2/tools/build-rule-index.py \
+            --channel "$CHANNEL" \
+            --releases-json rule-release/releases.json \
+            --generated-at "$GENERATED_AT" \
+            --valid-days "$VALID_DAYS" \
+            --output rule-release/unsigned-index.jar
+          jarsigner -keystore "$BAIZE_KEYSTORE_PATH" -storepass "$BAIZE_KEYSTORE_PASSWORD" \
+            -keypass "$BAIZE_KEY_PASSWORD" -signedjar "rule-release/$INDEX_ASSET" \
+            rule-release/unsigned-index.jar "$BAIZE_KEY_ALIAS"
+          bash v2/tools/verify-signed-jar.sh "rule-release/$INDEX_ASSET"
+          ACTUAL=$(keytool -printcert -jarfile "rule-release/$INDEX_ASSET" \
+            | awk -F': ' '/SHA256:/ {print tolower($2); exit}' | tr -d ':[:space:]')
+          test "$ACTUAL" = "$EXPECTED_RULE_CERT_SHA256"
+          sha256sum "rule-release/$INDEX_ASSET" > "rule-release/$INDEX_ASSET.sha256"
+          echo "sha=$(awk '{print $1}' "rule-release/$INDEX_ASSET.sha256")" >> "$GITHUB_OUTPUT"
+
+      - name: End-to-end cross-check generated assets
+        shell: bash
+        env:
+          CHANNEL: ${{ steps.release.outputs.channel }}
+          VERSION: ${{ steps.release.outputs.version }}
+          VERSION_CODE: ${{ steps.release.outputs.version_code }}
+          PACK_URL: ${{ steps.release.outputs.pack_url }}
+          PACK_ASSET: ${{ steps.release.outputs.pack_asset }}
+          INDEX_ASSET: ${{ steps.release.outputs.index_asset }}
+        run: |
+          set -euo pipefail
+          python3 v2/tools/verify-rule-release.py \
+            --pack "rule-release/$PACK_ASSET" \
+            --index "rule-release/$INDEX_ASSET" \
+            --channel "$CHANNEL" --version "$VERSION" --version-code "$VERSION_CODE" \
+            --pack-url "$PACK_URL" --expected-signer-sha256 "$EXPECTED_RULE_CERT_SHA256" \
+            --output rule-release/release-verification.json
+          unzip -p "rule-release/$PACK_ASSET" rule-pack.json > rule-release/rule-pack.json
+          unzip -p "rule-release/$INDEX_ASSET" rule-index.json > rule-release/rule-index.json
+          git diff --check
+
+      - name: Upload signed rehearsal bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-Signed-Rule-Release-${{ steps.release.outputs.channel }}-${{ steps.release.outputs.version }}
+          if-no-files-found: error
+          path: |
+            rule-release/${{ steps.release.outputs.pack_asset }}
+            rule-release/${{ steps.release.outputs.pack_asset }}.sha256
+            rule-release/${{ steps.release.outputs.index_asset }}
+            rule-release/${{ steps.release.outputs.index_asset }}.sha256
+            rule-release/rule-pack.json
+            rule-release/rule-index.json
+            rule-release/release-verification.json
+            rule-release/releases.json
+
+      - name: Publish versioned rule pack before channel index
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACK_TAG: ${{ steps.release.outputs.pack_tag }}
+          PACK_ASSET: ${{ steps.release.outputs.pack_asset }}
+          VERSION: ${{ steps.release.outputs.version }}
+          CHANNEL: ${{ steps.release.outputs.channel }}
+        run: |
+          set -euo pipefail
+          if gh release view "$PACK_TAG" >/dev/null 2>&1; then
+            gh release edit "$PACK_TAG" --title "BaiZe Rules $VERSION ($CHANNEL)" --notes-file release-notes.txt --latest=false
+            gh release upload "$PACK_TAG" "rule-release/$PACK_ASSET" "rule-release/$PACK_ASSET.sha256" rule-release/rule-pack.json --clobber
+          else
+            gh release create "$PACK_TAG" "rule-release/$PACK_ASSET" "rule-release/$PACK_ASSET.sha256" rule-release/rule-pack.json \
+              --target "$GITHUB_SHA" --title "BaiZe Rules $VERSION ($CHANNEL)" \
+              --notes-file release-notes.txt --latest=false
+          fi
+
+      - name: Atomically update fixed signed channel index asset
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INDEX_ASSET: ${{ steps.release.outputs.index_asset }}
+          CHANNEL: ${{ steps.release.outputs.channel }}
+        run: |
+          set -euo pipefail
+          printf 'Signed %s rule index. Clients verify this JAR with the BaiZe APK certificate.\n' "$CHANNEL" > rule-release/index-notes.txt
+          if gh release view rules-index >/dev/null 2>&1; then
+            gh release edit rules-index --title 'BaiZe Signed Rule Indexes' --notes-file rule-release/index-notes.txt --latest=false
+            gh release upload rules-index "rule-release/$INDEX_ASSET" "rule-release/$INDEX_ASSET.sha256" \
+              rule-release/rule-index.json rule-release/release-verification.json --clobber
+          else
+            gh release create rules-index "rule-release/$INDEX_ASSET" "rule-release/$INDEX_ASSET.sha256" \
+              rule-release/rule-index.json rule-release/release-verification.json \
+              --target "$GITHUB_SHA" --title 'BaiZe Signed Rule Indexes' \
+              --notes-file rule-release/index-notes.txt --latest=false
+          fi
+
+      - name: Download published assets and verify the public path
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL: ${{ steps.release.outputs.channel }}
+          VERSION: ${{ steps.release.outputs.version }}
+          VERSION_CODE: ${{ steps.release.outputs.version_code }}
+          PACK_TAG: ${{ steps.release.outputs.pack_tag }}
+          PACK_ASSET: ${{ steps.release.outputs.pack_asset }}
+          INDEX_ASSET: ${{ steps.release.outputs.index_asset }}
+          PACK_URL: ${{ steps.release.outputs.pack_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p rule-release/public
+          gh release download "$PACK_TAG" --pattern "$PACK_ASSET" --dir rule-release/public
+          gh release download rules-index --pattern "$INDEX_ASSET" --dir rule-release/public
+          bash v2/tools/verify-signed-jar.sh "rule-release/public/$PACK_ASSET"
+          bash v2/tools/verify-signed-jar.sh "rule-release/public/$INDEX_ASSET"
+          for file in "$PACK_ASSET" "$INDEX_ASSET"; do
+            CERT=$(keytool -printcert -jarfile "rule-release/public/$file" \
+              | awk -F': ' '/SHA256:/ {print tolower($2); exit}' | tr -d ':[:space:]')
+            test "$CERT" = "$BAIZE_CERT_SHA256"
+          done
+          test "$(sha256sum "rule-release/public/$PACK_ASSET" | awk '{print $1}')" = "${{ steps.pack.outputs.sha }}"
+          test "$(sha256sum "rule-release/public/$INDEX_ASSET" | awk '{print $1}')" = "${{ steps.index.outputs.sha }}"
+          python3 v2/tools/verify-rule-release.py \
+            --pack "rule-release/public/$PACK_ASSET" --index "rule-release/public/$INDEX_ASSET" \
+            --channel "$CHANNEL" --version "$VERSION" --version-code "$VERSION_CODE" \
+            --pack-url "$PACK_URL" --expected-signer-sha256 "$BAIZE_CERT_SHA256"
+
+  refresh-signed-indexes:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: [stable, beta]
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Prepare formal production signer
+        shell: bash
+        env:
+          KEYSTORE_BASE64_RAW: ${{ secrets.BAIZE_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD_RAW: ${{ secrets.BAIZE_KEYSTORE_PASSWORD }}
+          KEY_ALIAS_RAW: ${{ secrets.BAIZE_KEY_ALIAS }}
+          KEY_PASSWORD_RAW: ${{ secrets.BAIZE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          normalize_secret() {
+            secret_name=$1
+            raw_value=$2
+            value=$(printf '%s' "$raw_value" | tr -d '\r\n')
+            value=$(printf '%s' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+            case "$value" in "$secret_name="*) value=${value#*=} ;; esac
+            case "$value" in
+              \"*\") value=${value#\"}; value=${value%\"} ;;
+              \'*\') value=${value#\'}; value=${value%\'} ;;
+            esac
+            printf '%s' "$value"
+          }
+          KEYSTORE_BASE64=$(normalize_secret BAIZE_KEYSTORE_BASE64 "$KEYSTORE_BASE64_RAW" | tr -d '[:space:]')
+          KEYSTORE_PASSWORD=$(normalize_secret BAIZE_KEYSTORE_PASSWORD "$KEYSTORE_PASSWORD_RAW")
+          KEY_ALIAS=$(normalize_secret BAIZE_KEY_ALIAS "$KEY_ALIAS_RAW")
+          KEY_PASSWORD=$(normalize_secret BAIZE_KEY_PASSWORD "$KEY_PASSWORD_RAW")
+          test -n "$KEYSTORE_BASE64" && test -n "$KEYSTORE_PASSWORD" && test -n "$KEY_ALIAS" && test -n "$KEY_PASSWORD"
+          KEYSTORE="$RUNNER_TEMP/baize-rule-refresh.jks"
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE"
+          CERT=$(keytool -exportcert -keystore "$KEYSTORE" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" -rfc \
+            | openssl x509 -noout -fingerprint -sha256 | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]')
+          test "$CERT" = "$BAIZE_CERT_SHA256"
+          {
+            echo "BAIZE_KEYSTORE_PATH=$KEYSTORE"
+            echo "BAIZE_KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD"
+            echo "BAIZE_KEY_ALIAS=$KEY_ALIAS"
+            echo "BAIZE_KEY_PASSWORD=$KEY_PASSWORD"
+          } >> "$GITHUB_ENV"
+
+      - name: Download and verify existing signed index
+        id: existing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL: ${{ matrix.channel }}
+        run: |
+          set -euo pipefail
+          ASSET="BaiZe-Rules-Index-${CHANNEL}.jar"
+          mkdir -p refresh
+          if ! gh release view rules-index >/dev/null 2>&1 || \
+             ! gh release download rules-index --pattern "$ASSET" --dir refresh >/dev/null 2>&1; then
+            echo 'available=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bash v2/tools/verify-signed-jar.sh "refresh/$ASSET"
+          CERT=$(keytool -printcert -jarfile "refresh/$ASSET" \
+            | awk -F': ' '/SHA256:/ {print tolower($2); exit}' | tr -d ':[:space:]')
+          test "$CERT" = "$BAIZE_CERT_SHA256"
+          unzip -p "refresh/$ASSET" rule-index.json > refresh/current.json
+          python3 - "$CHANNEL" <<'PY'
+          import json, pathlib, sys
+          channel = sys.argv[1]
+          data = json.loads(pathlib.Path('refresh/current.json').read_text())
+          assert data['schema'] == 1 and data['channel'] == channel and data.get('releases')
+          pathlib.Path('refresh/releases.json').write_text(
+              json.dumps({'releases': data['releases']}, ensure_ascii=False, sort_keys=True, indent=2) + '\n'
+          )
+          PY
+          echo 'available=true' >> "$GITHUB_OUTPUT"
+
+      - name: Re-sign index with a fresh validity window
+        if: steps.existing.outputs.available == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL: ${{ matrix.channel }}
+        run: |
+          set -euo pipefail
+          ASSET="BaiZe-Rules-Index-${CHANNEL}.jar"
+          GENERATED_AT=$(date +%s%3N)
+          python3 v2/tools/build-rule-index.py --channel "$CHANNEL" \
+            --releases-json refresh/releases.json --generated-at "$GENERATED_AT" --valid-days 30 \
+            --output refresh/unsigned.jar
+          jarsigner -keystore "$BAIZE_KEYSTORE_PATH" -storepass "$BAIZE_KEYSTORE_PASSWORD" \
+            -keypass "$BAIZE_KEY_PASSWORD" -signedjar "refresh/$ASSET" \
+            refresh/unsigned.jar "$BAIZE_KEY_ALIAS"
+          bash v2/tools/verify-signed-jar.sh "refresh/$ASSET"
+          CERT=$(keytool -printcert -jarfile "refresh/$ASSET" \
+            | awk -F': ' '/SHA256:/ {print tolower($2); exit}' | tr -d ':[:space:]')
+          test "$CERT" = "$BAIZE_CERT_SHA256"
+          sha256sum "refresh/$ASSET" > "refresh/$ASSET.sha256"
+          gh release upload rules-index "refresh/$ASSET" "refresh/$ASSET.sha256" --clobber

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
@@ -1,5 +1,6 @@
 package io.github.xgl34222220.baize
 
+import android.content.Intent
 import android.os.Build
 import android.text.format.Formatter
 import androidx.compose.animation.AnimatedContent
@@ -41,6 +42,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.BugReport
 import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.CleaningServices
@@ -816,6 +818,32 @@ internal fun HomeScreenMiuix(
                         title = "全部选项",
                         modifier = Modifier.weight(1f),
                         onClick = onOpenClean
+                    )
+                }
+            }
+        }
+        item {
+            GlassSurface(
+                Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
+                shape = RoundedCornerShape(30.dp),
+                shadow = 6,
+                contentPadding = PaddingValues(10.dp)
+            ) {
+                Row(
+                    Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    MiuixHomeQuickAction(
+                        icon = Icons.Rounded.Rule,
+                        title = "规则中心",
+                        modifier = Modifier.weight(1f),
+                        onClick = { context.startActivity(Intent(context, RulePackActivity::class.java)) }
+                    )
+                    MiuixHomeQuickAction(
+                        icon = Icons.Rounded.CloudDownload,
+                        title = "官方更新",
+                        modifier = Modifier.weight(1f),
+                        onClick = { context.startActivity(Intent(context, RuleUpdateActivity::class.java)) }
                     )
                 }
             }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RulePackRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RulePackRootService.kt
@@ -337,21 +337,40 @@ class RulePackRootService : RootService() {
             if (raw.length > MAX_RULE_LINE_LENGTH) throw PackException("rule_line_large", "$name 第 ${index + 1} 行过长")
             val line = raw.trim()
             if (line.isBlank() || line.startsWith("#") || line.startsWith("//")) return@forEachIndexed
-            if (!safeRuleSyntax(line)) throw PackException("rule_syntax_invalid", "$name 第 ${index + 1} 行规则不安全")
+            if (name == "deep.rules" && !line.startsWith("/")) return@forEachIndexed
+            if (!safeRuleSyntax(name, line)) throw PackException("rule_syntax_invalid", "$name 第 ${index + 1} 行规则不安全")
             rules += 1
             if (rules > MAX_RULES_PER_FILE) throw PackException("rule_count_large", "$name 规则数量超过限制")
         }
         return RuleInfo(sha256(bytes), rules, bytes.size.toLong())
     }
 
-    private fun safeRuleSyntax(raw: String): Boolean {
-        val path = raw.substringBefore('|').substringBefore('#').trim()
-        if (!path.startsWith("/") || path.length !in 2..MAX_RULE_LINE_LENGTH) return false
-        if (path.split('/').any { it == ".." }) return false
-        if (FORBIDDEN_RULE_ROOTS.any { path == it || path.startsWith("$it/") }) return false
-        val segments = path.split('/').filter { it.isNotEmpty() }
-        if (segments.isEmpty() || segments.take(2).any { it == "*" || it == "**" || it == "?" }) return false
-        return true
+    private fun safeRuleSyntax(name: String, raw: String): Boolean = when (name) {
+        "deep.rules" -> {
+            val path = raw.substringBefore('|').substringBefore('#').trim()
+            path.startsWith("/") && path.length in 2..MAX_RULE_LINE_LENGTH &&
+                path.split('/').none { it == ".." } &&
+                FORBIDDEN_RULE_ROOTS.none { path == it || path.startsWith("$it/") } &&
+                path.split('/').filter { it.isNotEmpty() }.take(2).none { it == "*" || it == "**" || it == "?" }
+        }
+        "app.rules", "external.rules" -> {
+            val parts = raw.split('|')
+            val relative = parts.getOrNull(1)?.trim().orEmpty()
+            parts.size == 3 && PACKAGE_NAME.matches(parts[0].trim()) && relative.isNotEmpty() &&
+                !relative.startsWith('/') && !relative.startsWith('\\') && '\u0000' !in relative && '\\' !in relative &&
+                relative.split('/').none { it.isEmpty() || it == "." || it == ".." } &&
+                parts[2].trim().toIntOrNull()?.let { it in 0..3650 } == true
+        }
+        "hidden.rules" -> {
+            val parts = raw.split('|')
+            val kind = parts.getOrNull(0)?.trim().orEmpty()
+            val pattern = parts.getOrNull(1)?.trim().orEmpty()
+            parts.size == 3 && kind in setOf("dir", "file") && pattern.isNotEmpty() && pattern.length <= 128 &&
+                '/' !in pattern && '\\' !in pattern && '\u0000' !in pattern && pattern !in setOf(".", "..") &&
+                (kind == "file" || pattern.none { it == '*' || it == '?' || it == '[' || it == ']' }) &&
+                parts[2].trim().toIntOrNull()?.let { it in 0..3650 } == true
+        }
+        else -> false
     }
 
     private fun currentInfo(): JSONObject {
@@ -648,6 +667,7 @@ class RulePackRootService : RootService() {
         private val MANAGED_RULES = setOf("app.rules", "external.rules", "hidden.rules", "deep.rules")
         private val PACK_ID = Regex("^[A-Za-z0-9._-]{1,80}$")
         private val SHA256 = Regex("^[0-9a-f]{64}$")
+        private val PACKAGE_NAME = Regex("^[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)+$")
         private val FORBIDDEN_RULE_ROOTS = setOf(
             "/", "/data", "/data/adb", "/metadata", "/proc", "/sys", "/dev",
             "/system", "/vendor", "/product", "/odm", "/apex"

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/CleanScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/CleanScreenMiuix.kt
@@ -1,5 +1,6 @@
 package io.github.xgl34222220.baize.ui.clean.miuix
 
+import android.content.Intent
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
@@ -30,6 +31,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.CloudDownload
 import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
@@ -61,10 +63,13 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.RulePackActivity
+import io.github.xgl34222220.baize.RuleUpdateActivity
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.clean.CleanCategoryId
 import io.github.xgl34222220.baize.ui.clean.CleanCategoryUiItem
@@ -90,6 +95,7 @@ fun CleanScreenMiuix(
     onExpandedCategoryChanged: (String) -> Unit
 ) {
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val context = LocalContext.current
     var showDailyTimeDialog by remember { mutableStateOf(false) }
     var showDailyGraceDialog by remember { mutableStateOf(false) }
 
@@ -114,13 +120,23 @@ fun CleanScreenMiuix(
     }
 
     val quickActions = listOf(
+        MiuixQuickAction(
+            Icons.Rounded.Rule,
+            "规则管理中心",
+            "版本、签名、更新预览与一键回滚"
+        ) { context.startActivity(Intent(context, RulePackActivity::class.java)) },
+        MiuixQuickAction(
+            Icons.Rounded.CloudDownload,
+            "官方规则更新",
+            "签名索引、断点下载与自动更新策略"
+        ) { context.startActivity(Intent(context, RuleUpdateActivity::class.java)) },
         MiuixQuickAction(Icons.Rounded.Search, "垃圾扫描", "生成快照，不立即删除", actions.onScan),
         MiuixQuickAction(Icons.Rounded.InstallMobile, "安装包扫描", "查找 APK / APKS / XAPK", actions.onApkScan),
         MiuixQuickAction(Icons.Rounded.Bolt, "系统即时清缓存", "手动选择应用，直接调用系统 cache-only", actions.onInstantCache),
         MiuixQuickAction(Icons.Rounded.FolderCopy, "文件归类", "扫描所有下载目录并按类型整理", actions.onFileOrganizer),
         MiuixQuickAction(Icons.Rounded.DeleteSweep, "深度清理", "日志、临时文件和常见残留", actions.onDeepClean),
         MiuixQuickAction(Icons.Rounded.FolderDelete, "卸载残留", "无主 data、obb 与 media 目录", actions.onCorpses),
-        MiuixQuickAction(Icons.Rounded.Rule, "清理明细", "规则范围和最近命中", actions.onAudit)
+        MiuixQuickAction(Icons.Rounded.Security, "更多清理工具", "规则范围、最近命中与高风险项目", actions.onAudit)
     )
 
     LazyColumn(
@@ -198,7 +214,7 @@ fun CleanScreenMiuix(
             MiuixSectionHeader(
                 eyebrow = "手动工具",
                 title = "手动清理工具",
-                subtitle = "扫描、深度清理和规则明细"
+                subtitle = "规则管理和官方更新位于最上方"
             )
         }
         item {

--- a/v2/docs/rule-release-playbook.md
+++ b/v2/docs/rule-release-playbook.md
@@ -1,0 +1,81 @@
+# BaiZe signed rule release playbook
+
+This playbook is the operational contract for `.github/workflows/rule-release.yml`.
+The workflow uses the same production keystore alias as the BaiZe APK. There is no second rule-signing key.
+
+## Published assets
+
+A rule release publishes assets in this order:
+
+1. A versioned pack release is created at tag `rules-<channel>-<versionCode>`.
+2. The signed pack is uploaded as `BaiZe-Rules-<channel>-<version>.jar`.
+3. The fixed `rules-index` release is updated with `BaiZe-Rules-Index-<channel>.jar`.
+4. The workflow downloads both public assets again and verifies their signatures, hashes, sizes and cross-links.
+
+Publishing the pack first prevents clients from observing an index that points to an asset that does not exist yet.
+The fixed index asset names match the URLs compiled into `RuleUpdateClient.kt`.
+
+## Required repository secrets
+
+The workflow reuses the formal APK signing secrets:
+
+- `BAIZE_KEYSTORE_BASE64`
+- `BAIZE_KEYSTORE_PASSWORD`
+- `BAIZE_KEY_ALIAS`
+- `BAIZE_KEY_PASSWORD`
+
+The extracted certificate SHA-256 must equal the certificate pinned in the app release workflow. A mismatch stops the job before any release asset is uploaded.
+
+## Pull request rehearsal
+
+Every pull request that changes the rule release workflow, builders, verifier, documentation or managed rules runs a complete rehearsal with a temporary certificate:
+
+- build the deterministic full rule pack from `config/`;
+- sign and strictly verify the JAR;
+- build a signed channel index pointing to the versioned pack URL;
+- verify exact pack/index linkage;
+- upload both signed rehearsal artifacts to GitHub Actions.
+
+A pull request never publishes GitHub Release assets and never reads the production keystore secrets.
+
+## Formal manual release
+
+Run **BaiZe Signed Rule Release** with `workflow_dispatch` from the `main` branch.
+
+Required inputs:
+
+- channel: `stable` or `beta`;
+- version: a display value such as `2026.08.1`;
+- version code: a positive monotonic integer such as `20260801`;
+- minimum app version code;
+- release notes;
+- signed index validity period from 1 to 45 days.
+
+To publish, enable `publish` and type `PUBLISH` in the confirmation field. The workflow rejects publishing from any ref other than `refs/heads/main`.
+
+The new version code must be greater than the highest version code already present in the signed channel index. Normal publication cannot downgrade rules. Device-side rollback remains the only supported downgrade path.
+
+## Release history and index refresh
+
+The current signed index is downloaded and verified before a new release. Existing releases are preserved, the new release is prepended, and the list is capped at 50 entries.
+
+A weekly scheduled job refreshes the validity window of existing stable and Beta indexes. It does not create a new rule pack, change release history or install anything on devices. Missing channel indexes are skipped safely.
+
+## End-to-end verification
+
+Before publication, the workflow runs:
+
+- `jarsigner -verify -strict -certs` for the pack and index;
+- `keytool -printcert -jarfile` and certificate fingerprint comparison;
+- SHA-256 and byte count calculation;
+- `verify-rule-release.py` for manifest, rule metrics, URL and index linkage validation.
+
+After publication, the workflow downloads the public pack and index through GitHub Releases and repeats the same cryptographic and structural checks. A release is considered complete only after this public-path check succeeds.
+
+## Recovery
+
+If pack publication succeeds but index publication fails, clients do not see the new version because the old signed index remains active. Re-run the same workflow inputs; versioned assets are uploaded with `--clobber`, then the fixed index is updated.
+
+If an incorrect index is published but still signed, immediately publish a higher monotonic version or a corrected index with a later `generatedAt`. The Root verifier rejects older replayed indexes and same-time equivocation.
+
+If the APK signing key is suspected to be compromised, stop rule publication. A new app release with a new pinned certificate and an explicit trust migration is required; do not bypass signature checks.

--- a/v2/tests/test-clean-plan-persistence.py
+++ b/v2/tests/test-clean-plan-persistence.py
@@ -74,4 +74,5 @@ runpy.run_path(str(ROOT / "v2/tests/test-clean-result-report.py"), run_name="__m
 runpy.run_path(str(ROOT / "v2/tests/test-explainable-rules-whitelist.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-rule-pack-management.py"), run_name="__main__")
 runpy.run_path(str(ROOT / "v2/tests/test-rule-update-channel.py"), run_name="__main__")
+runpy.run_path(str(ROOT / "v2/tests/test-rule-release-automation.py"), run_name="__main__")
 print("clean plan persistence contract: ok")

--- a/v2/tests/test-rule-release-automation.py
+++ b/v2/tests/test-rule-release-automation.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Stage nine final verification: signed release rehearsal, visible rule entry, and full repository build must pass.
+# The rule center must be visible from both the MIUIx home page and clean page.
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = (ROOT / ".github/workflows/rule-release.yml").read_text(encoding="utf-8")
+VERIFY = (ROOT / "v2/tools/verify-rule-release.py").read_text(encoding="utf-8")
+JAR_VERIFY = (ROOT / "v2/tools/verify-signed-jar.sh").read_text(encoding="utf-8")
+PACK_BUILDER = (ROOT / "v2/tools/build-rule-pack.py").read_text(encoding="utf-8")
+INDEX_BUILDER = (ROOT / "v2/tools/build-rule-index.py").read_text(encoding="utf-8")
+CLIENT = (ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize/RuleUpdateClient.kt").read_text(encoding="utf-8")
+DOC = (ROOT / "v2/docs/rule-release-playbook.md").read_text(encoding="utf-8")
+VISIBLE_HOME = (ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt").read_text(encoding="utf-8")
+VISIBLE_CLEAN = (ROOT / "v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/CleanScreenMiuix.kt").read_text(encoding="utf-8")
+
+
+def require(value: bool, message: str) -> None:
+    if not value:
+        raise AssertionError(message)
+
+
+for marker in (
+    "pull_request:", "workflow_dispatch:", "schedule:", "cron:",
+    "channel:", "version:", "version_code:", "min_app_version_code:",
+    "release_notes:", "mandatory:", "valid_days:", "publish:", "confirm_publish:",
+):
+    require(marker in WORKFLOW, f"rule release trigger/input missing: {marker}")
+
+for marker in (
+    "BAIZE_KEYSTORE_BASE64", "BAIZE_KEYSTORE_PASSWORD", "BAIZE_KEY_ALIAS", "BAIZE_KEY_PASSWORD",
+    "BAIZE_CERT_SHA256", "EXPECTED_RULE_CERT_SHA256", "Prepare temporary rehearsal signer",
+    "Prepare formal production signer", "keytool -exportcert", "openssl x509",
+):
+    require(marker in WORKFLOW, f"release signer contract missing: {marker}")
+
+require("[ \"$GITHUB_REF\" = 'refs/heads/main' ]" in WORKFLOW,
+        "formal rule publication must be restricted to main")
+require("[ \"$INPUT_CONFIRM\" = 'PUBLISH' ]" in WORKFLOW,
+        "formal publication requires an explicit confirmation word")
+require("if: steps.release.outputs.publish == 'true'" in WORKFLOW,
+        "release upload steps must be guarded by the publish output")
+require("github.event_name != 'schedule'" in WORKFLOW and "github.event_name == 'schedule'" in WORKFLOW,
+        "release and index refresh jobs must remain separated")
+
+for marker in (
+    "python3 v2/tools/build-rule-pack.py", "python3 v2/tools/build-rule-index.py",
+    "python3 v2/tools/verify-rule-release.py", "bash v2/tools/verify-signed-jar.sh",
+    "keytool -printcert -jarfile", "sha256sum", "rule-pack.json", "rule-index.json",
+):
+    require(marker in WORKFLOW, f"end-to-end release verification missing: {marker}")
+
+for marker in (
+    "jarsigner -verify -strict -certs", "jar verified", "certificate chain is invalid",
+    "signer certificate is self-signed", "unsigned entr", "disabled algorithm",
+    "certificate.*(expired|not yet valid|revoked)", "unexpected jarsigner status",
+):
+    require(marker in JAR_VERIFY, f"strict pinned JAR verifier primitive missing: {marker}")
+require("case \"$STATUS\"" in JAR_VERIFY and "0)" in JAR_VERIFY and "4)" in JAR_VERIFY,
+        "JAR verifier must distinguish success from Android self-signed chain status")
+
+pack_publish = WORKFLOW.index("Publish versioned rule pack before channel index")
+index_publish = WORKFLOW.index("Atomically update fixed signed channel index asset")
+public_verify = WORKFLOW.index("Download published assets and verify the public path")
+require(pack_publish < index_publish < public_verify,
+        "workflow must publish pack, then index, then verify public assets")
+require("gh release upload \"$PACK_TAG\"" in WORKFLOW and "--clobber" in WORKFLOW,
+        "versioned rule assets must support idempotent recovery")
+require("gh release upload rules-index" in WORKFLOW,
+        "fixed signed index release must be updated explicitly")
+require("gh release download \"$PACK_TAG\"" in WORKFLOW and "gh release download rules-index" in WORKFLOW,
+        "published assets must be downloaded again for public-path verification")
+require("--latest=false" in WORKFLOW,
+        "rule-only releases must never replace the latest BaiZe application release")
+
+for marker in (
+    "previous-index.json", "versionCode", "must be greater than published",
+    "releases[:50]", "rules-index", "matrix:", "channel: [stable, beta]",
+    "Re-sign index with a fresh validity window", "valid-days 30",
+):
+    require(marker in WORKFLOW, f"history/refresh release safety missing: {marker}")
+
+stable_asset = "BaiZe-Rules-Index-stable.jar"
+beta_asset = "BaiZe-Rules-Index-beta.jar"
+require(stable_asset in CLIENT and beta_asset in CLIENT,
+        "client fixed index assets changed unexpectedly")
+require('INDEX_ASSET="BaiZe-Rules-Index-${CHANNEL}.jar"' in WORKFLOW,
+        "workflow index asset naming must match the client")
+require('PACK_TAG="rules-${CHANNEL}-${VERSION_CODE}"' in WORKFLOW,
+        "versioned pack release tag is not deterministic")
+require('PACK_ASSET="BaiZe-Rules-${CHANNEL}-${VERSION}.jar"' in WORKFLOW,
+        "versioned pack asset name is not deterministic")
+
+for marker in (
+    "read_pack", "read_index", "payload_entries", "effective_rules",
+    "pack URL", "versionCode", "generatedAt", "expiresAt", "sorted(codes, reverse=True)",
+    "packSha256", "indexSha256", "expected-signer-sha256",
+):
+    require(marker in VERIFY, f"release cross-verifier primitive missing: {marker}")
+require("META-INF/" in VERIFY and "unexpected rule pack payload entries" in VERIFY,
+        "cross-verifier must reject unsigned payload-shaped extras")
+require("deep.rules" in VERIFY and "rule count mismatch" in VERIFY,
+        "cross-verifier must validate official managed rule metrics")
+
+require('parser.add_argument("--version-code", required=True' in PACK_BUILDER,
+        "rule pack builder must require a monotonic version code")
+require('"versionCode": args.version_code' in PACK_BUILDER,
+        "rule pack manifest must carry the monotonic version code")
+require("Historical deep.rules" in PACK_BUILDER and 'if not line.startswith("/")' in PACK_BUILDER,
+        "legacy deep annotations must be ignored, not treated as executable rules")
+require('parser.add_argument("--generated-at"' in INDEX_BUILDER and 'parser.add_argument("--valid-days"' in INDEX_BUILDER,
+        "index builder must support deterministic release timestamps")
+require("releases.sort" in INDEX_BUILDER and "duplicate versionCode" in INDEX_BUILDER,
+        "index builder must enforce ordered unique versions")
+
+for marker in (
+    "same production keystore alias", "Publishing the pack first", "Pull request rehearsal",
+    "Formal manual release", "type `PUBLISH`", "weekly scheduled job",
+    "downloads the public pack and index", "If pack publication succeeds but index publication fails",
+):
+    require(marker in DOC, f"release operations documentation missing: {marker}")
+
+for marker in ("规则中心", "官方更新", "RulePackActivity::class.java", "RuleUpdateActivity::class.java"):
+    require(marker in VISIBLE_HOME, f"home rule shortcut missing: {marker}")
+for marker in ("规则管理中心", "官方规则更新", "更多清理工具", "RulePackActivity::class.java", "RuleUpdateActivity::class.java"):
+    require(marker in VISIBLE_CLEAN, f"clean page rule entry missing: {marker}")
+
+print("signed rule release automation contract: ok")

--- a/v2/tools/build-rule-pack.py
+++ b/v2/tools/build-rule-pack.py
@@ -17,6 +17,7 @@ FORBIDDEN = (
     "/vendor", "/product", "/odm", "/apex",
 )
 PACK_ID = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+PACKAGE_NAME = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)+$")
 FIXED_TIME = (2026, 1, 1, 0, 0, 0)
 
 
@@ -32,14 +33,42 @@ def effective_rules(text: str, name: str) -> int:
         line = raw.strip()
         if not line or line.startswith("#") or line.startswith("//"):
             continue
-        path = line.split("|", 1)[0].split("#", 1)[0].strip()
-        if not path.startswith("/") or "\x00" in path or any(part == ".." for part in path.split("/")):
+        if name == "deep.rules":
+            # Historical deep.rules contains a few human annotations without a comment prefix.
+            # The runtime scanner only consumes absolute paths, so keep compatibility by ignoring
+            # non-path annotations rather than accepting them as executable rules.
+            if not line.startswith("/"):
+                continue
+            path = line.split("|", 1)[0].split("#", 1)[0].strip()
+            safe = "\x00" not in path and not any(part == ".." for part in path.split("/"))
+            safe = safe and path not in ("/", "/data") and not any(
+                path == root or path.startswith(root + "/") for root in FORBIDDEN
+            )
+            segments = [part for part in path.split("/") if part]
+            safe = safe and bool(segments) and not any(
+                part in {"*", "**", "?"} for part in segments[:2]
+            )
+        elif name in {"app.rules", "external.rules"}:
+            parts = line.split("|")
+            safe = len(parts) == 3 and bool(PACKAGE_NAME.fullmatch(parts[0].strip()))
+            relative = parts[1].strip() if len(parts) == 3 else ""
+            safe = safe and bool(relative) and not relative.startswith(("/", "\\"))
+            safe = safe and "\x00" not in relative and "\\" not in relative
+            safe = safe and all(part not in {"", ".", ".."} for part in relative.split("/"))
+            safe = safe and parts[2].strip().isdigit() and 0 <= int(parts[2].strip()) <= 3650
+        elif name == "hidden.rules":
+            parts = line.split("|")
+            pattern = parts[1].strip() if len(parts) == 3 else ""
+            kind = parts[0].strip() if len(parts) == 3 else ""
+            safe = kind in {"dir", "file"} and bool(pattern) and len(pattern) <= 128
+            safe = safe and "/" not in pattern and "\\" not in pattern
+            safe = safe and "\x00" not in pattern and pattern not in {".", ".."}
+            safe = safe and (kind == "file" or not any(char in pattern for char in "*?[]"))
+            safe = safe and parts[2].strip().isdigit() and 0 <= int(parts[2].strip()) <= 3650
+        else:
+            safe = False
+        if not safe:
             raise ValueError(f"{name}:{number}: unsafe rule syntax")
-        if path in ("/", "/data") or any(path == root or path.startswith(root + "/") for root in FORBIDDEN):
-            raise ValueError(f"{name}:{number}: forbidden rule root {path}")
-        segments = [part for part in path.split("/") if part]
-        if not segments or any(part in {"*", "**", "?"} for part in segments[:2]):
-            raise ValueError(f"{name}:{number}: top-level wildcard is forbidden")
         count += 1
         if count > 20_000:
             raise ValueError(f"{name}: more than 20,000 effective rules")
@@ -112,11 +141,17 @@ def main() -> int:
         "minAppVersionCode": max(0, args.min_app_version_code),
         "files": files,
     }
-    manifest_bytes = json.dumps(manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    manifest_bytes = json.dumps(
+        manifest, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(args.output, "w") as archive:
-        write_entry(archive, "META-INF/MANIFEST.MF", b"Manifest-Version: 1.0\r\nCreated-By: BaiZe Rule Pack Builder\r\n\r\n")
+        write_entry(
+            archive,
+            "META-INF/MANIFEST.MF",
+            b"Manifest-Version: 1.0\r\nCreated-By: BaiZe Rule Pack Builder\r\n\r\n",
+        )
         write_entry(archive, "rule-pack.json", manifest_bytes)
         for name, data in payloads.items():
             write_entry(archive, f"rules/{name}", data)

--- a/v2/tools/verify-rule-release.py
+++ b/v2/tools/verify-rule-release.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Cross-check a signed BaiZe rule pack and its signed channel index payloads.
+
+Cryptographic JAR verification is intentionally performed by jarsigner/keytool in the workflow.
+This tool verifies the payload contract after that cryptographic gate: hashes, sizes, versions,
+URLs, rule metrics, ordering, expiry and exact pack/index linkage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import time
+import urllib.parse
+import zipfile
+
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+VERSION = re.compile(r"^[A-Za-z0-9._-]{1,80}$")
+MANAGED = ("app.rules", "external.rules", "hidden.rules", "deep.rules")
+ALLOWED_HOSTS = {
+    "github.com",
+    "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com",
+    "raw.githubusercontent.com",
+}
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def effective_rules(data: bytes, name: str) -> int:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{name} is not UTF-8") from error
+    from importlib.util import module_from_spec, spec_from_file_location
+    spec = spec_from_file_location("rule_pack_builder", pathlib.Path(__file__).with_name("build-rule-pack.py"))
+    if spec is None or spec.loader is None:
+        raise ValueError("unable to load rule syntax validator")
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return int(module.effective_rules(text, name))
+
+
+def payload_entries(archive: zipfile.ZipFile) -> set[str]:
+    result: set[str] = set()
+    for info in archive.infolist():
+        name = info.filename
+        if info.is_dir() or name.upper().startswith("META-INF/"):
+            continue
+        if name.startswith("/") or ".." in pathlib.PurePosixPath(name).parts:
+            raise ValueError(f"unsafe archive entry: {name}")
+        if name in result:
+            raise ValueError(f"duplicate archive entry: {name}")
+        result.add(name)
+    return result
+
+
+def read_pack(path: pathlib.Path, expected_version: str, expected_code: int) -> tuple[dict[str, object], str, int]:
+    raw = path.read_bytes()
+    if not raw:
+        raise ValueError("rule pack is empty")
+    with zipfile.ZipFile(path) as archive:
+        entries = payload_entries(archive)
+        if "rule-pack.json" not in entries:
+            raise ValueError("rule pack manifest is missing")
+        manifest = json.loads(archive.read("rule-pack.json"))
+        files = manifest.get("files")
+        if manifest.get("schema") != 1 or manifest.get("mode") != "full" or not isinstance(files, list):
+            raise ValueError("unsupported rule pack manifest")
+        if manifest.get("version") != expected_version or int(manifest.get("versionCode", 0)) != expected_code:
+            raise ValueError("rule pack version does not match release inputs")
+        if not VERSION.fullmatch(str(manifest.get("packId", ""))):
+            raise ValueError("invalid rule pack id")
+
+        expected_entries = {"rule-pack.json"}
+        seen: set[str] = set()
+        for item in files:
+            if not isinstance(item, dict):
+                raise ValueError("invalid rule file metadata")
+            rule_path = str(item.get("path", ""))
+            if not rule_path.startswith("rules/") or rule_path.count("/") != 1:
+                raise ValueError(f"invalid rule path: {rule_path}")
+            name = rule_path.removeprefix("rules/")
+            if name not in MANAGED or name in seen:
+                raise ValueError(f"unmanaged or duplicate rule file: {name}")
+            seen.add(name)
+            expected_entries.add(rule_path)
+            data = archive.read(rule_path)
+            if digest(data) != str(item.get("sha256", "")).lower():
+                raise ValueError(f"rule hash mismatch: {name}")
+            if len(data) != int(item.get("bytes", -1)):
+                raise ValueError(f"rule byte count mismatch: {name}")
+            if effective_rules(data, name) != int(item.get("rules", -1)):
+                raise ValueError(f"rule count mismatch: {name}")
+        if "deep.rules" not in seen:
+            raise ValueError("official rule pack must contain deep.rules")
+        if entries != expected_entries:
+            raise ValueError(f"unexpected rule pack payload entries: {sorted(entries - expected_entries)}")
+    return manifest, digest(raw), len(raw)
+
+
+def validate_url(raw: str) -> None:
+    parsed = urllib.parse.urlparse(raw)
+    if parsed.scheme != "https" or (parsed.hostname or "").lower() not in ALLOWED_HOSTS:
+        raise ValueError("rule pack URL is not an approved GitHub HTTPS URL")
+    if parsed.username or parsed.password or parsed.fragment or parsed.port not in (None, 443):
+        raise ValueError("rule pack URL contains unsafe components")
+
+
+def read_index(
+    path: pathlib.Path,
+    channel: str,
+    version: str,
+    version_code: int,
+    pack_url: str,
+    pack_sha: str,
+    pack_bytes: int,
+    pack_id: str,
+) -> tuple[dict[str, object], dict[str, object], str]:
+    raw = path.read_bytes()
+    if not raw:
+        raise ValueError("rule index is empty")
+    with zipfile.ZipFile(path) as archive:
+        entries = payload_entries(archive)
+        if entries != {"rule-index.json"}:
+            raise ValueError(f"unexpected rule index payload entries: {sorted(entries)}")
+        manifest = json.loads(archive.read("rule-index.json"))
+    if manifest.get("schema") != 1 or manifest.get("channel") != channel:
+        raise ValueError("rule index channel or schema mismatch")
+    generated = int(manifest.get("generatedAt", 0))
+    expires = int(manifest.get("expiresAt", 0))
+    now = int(time.time() * 1000)
+    if generated <= 0 or expires <= generated or expires - generated > 45 * 24 * 60 * 60 * 1000:
+        raise ValueError("rule index validity window is invalid")
+    if generated > now + 10 * 60 * 1000:
+        raise ValueError("rule index generation time is in the future")
+
+    releases = manifest.get("releases")
+    if not isinstance(releases, list) or not releases or len(releases) > 50:
+        raise ValueError("rule index release list is invalid")
+    codes = [int(item.get("versionCode", 0)) for item in releases if isinstance(item, dict)]
+    if len(codes) != len(releases) or len(codes) != len(set(codes)) or codes != sorted(codes, reverse=True):
+        raise ValueError("rule index versions must be unique and descending")
+    target = next((item for item in releases if int(item.get("versionCode", 0)) == version_code), None)
+    if not isinstance(target, dict):
+        raise ValueError("new rule release is missing from the signed index")
+    validate_url(str(target.get("url", "")))
+    expected = {
+        "channel": channel,
+        "packId": pack_id,
+        "version": version,
+        "versionCode": version_code,
+        "url": pack_url,
+        "sha256": pack_sha,
+        "bytes": pack_bytes,
+    }
+    for key, value in expected.items():
+        if target.get(key) != value:
+            raise ValueError(f"index release field mismatch: {key}")
+    if not SHA256.fullmatch(str(target.get("sha256", ""))):
+        raise ValueError("index release SHA-256 is invalid")
+    return manifest, target, digest(raw)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pack", required=True, type=pathlib.Path)
+    parser.add_argument("--index", required=True, type=pathlib.Path)
+    parser.add_argument("--channel", required=True, choices=("stable", "beta"))
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--version-code", required=True, type=int)
+    parser.add_argument("--pack-url", required=True)
+    parser.add_argument("--expected-signer-sha256", default="")
+    parser.add_argument("--output", type=pathlib.Path)
+    args = parser.parse_args()
+
+    if not VERSION.fullmatch(args.version) or args.version_code <= 0:
+        raise SystemExit("invalid release version or version code")
+    validate_url(args.pack_url)
+    signer = args.expected_signer_sha256.lower().replace(":", "").strip()
+    if signer and not SHA256.fullmatch(signer):
+        raise SystemExit("invalid expected signer fingerprint")
+
+    pack_manifest, pack_sha, pack_bytes = read_pack(args.pack, args.version, args.version_code)
+    index_manifest, release, index_sha = read_index(
+        args.index,
+        args.channel,
+        args.version,
+        args.version_code,
+        args.pack_url,
+        pack_sha,
+        pack_bytes,
+        str(pack_manifest["packId"]),
+    )
+    report = {
+        "success": True,
+        "channel": args.channel,
+        "version": args.version,
+        "versionCode": args.version_code,
+        "packId": pack_manifest["packId"],
+        "packSha256": pack_sha,
+        "packBytes": pack_bytes,
+        "packUrl": args.pack_url,
+        "indexSha256": index_sha,
+        "indexGeneratedAt": index_manifest["generatedAt"],
+        "indexExpiresAt": index_manifest["expiresAt"],
+        "mandatory": bool(release.get("mandatory", False)),
+        "signerSha256": signer,
+    }
+    text = json.dumps(report, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/v2/tools/verify-signed-jar.sh
+++ b/v2/tools/verify-signed-jar.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "$#" -eq 1 ] || { echo "usage: $0 <signed.jar>" >&2; exit 2; }
+JAR=$1
+[ -s "$JAR" ] || { echo "signed JAR missing: $JAR" >&2; exit 2; }
+
+export LC_ALL=C
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+STATUS=0
+jarsigner -verify -strict -certs "$JAR" >"$LOG" 2>&1 || STATUS=$?
+cat "$LOG"
+
+grep -Fq 'jar verified' "$LOG" || {
+  echo "jarsigner did not verify the archive" >&2
+  exit 1
+}
+
+if grep -Eqi 'jar is unsigned|unsigned entr|signature.*(invalid|tampered)|digest error|disabled algorithm|certificate.*(expired|not yet valid|revoked)' "$LOG"; then
+  echo "signed JAR contains a forbidden signature error" >&2
+  exit 1
+fi
+
+case "$STATUS" in
+  0)
+    ;;
+  4)
+    # Android application signing certificates are intentionally self-signed. jarsigner -strict
+    # reports status 4 because there is no public CA chain, even though every archive entry is
+    # signed and the exact certificate fingerprint is checked separately by the workflow.
+    grep -Fq 'certificate chain is invalid' "$LOG"
+    grep -Fq 'signer certificate is self-signed' "$LOG"
+    ;;
+  *)
+    echo "unexpected jarsigner status: $STATUS" >&2
+    exit "$STATUS"
+    ;;
+esac


### PR DESCRIPTION
## 第九阶段：规则发布自动化、正式演练与可见入口

- 新增独立 `BaiZe Signed Rule Release` 工作流。
- PR 使用临时证书构建并验签规则包与索引，不读取正式 Secrets、不发布 Release。
- 正式发布仅允许 `workflow_dispatch`、`main` 分支、勾选 publish 并输入 `PUBLISH`。
- 复用正式 APK 的四个签名 Secrets 与固定证书指纹。
- 先发布版本化规则包，再更新固定 `rules-index` 索引，避免客户端看到悬空 URL。
- 发布后从公开 GitHub Release 重新下载规则包和索引，再次验证签名、证书、SHA-256、体积与交叉引用。
- 构建器、Root 安装验证器和发布校验器统一支持 app、external、hidden、deep 四类托管规则语法。
- deep.rules 中旧版非路径注释会被忽略，不会被当成可执行规则。

## 规则入口修正

用户测试发现原入口隐藏过深。本 PR 现在保证：

- MIUIx 首页“快捷操作”直接显示“规则中心”和“官方更新”。
- MIUIx 清理页“手动清理工具”前两项直接显示“规则管理中心”和“官方规则更新”。
- 原“清理明细”更名为“更多清理工具”，避免与规则管理混淆。
- 回归测试会检查两个页面都存在可点击的 Activity 入口。

## 堆叠关系

本 PR 基于第八阶段 `agent/rule-update-channel`，已整理为 1 个干净提交、10 个正式文件。临时正式签名构建工作流已移除。

## 验证结果

- `BaiZe Signed Rule Release #28`：签名规则包、索引和交叉校验全部通过。
- `BaiZe v2.4.1 Verify and Release #63`：Root 回归、ARM64、Android Release、Debug Kotlin、Lint、Macrobenchmark、模块封包和签名校验全部通过。
- `Stage Nine Visible Formal Test #1`：使用正式 APK 证书构建修复版模块与 APK，模块内嵌 APK 一致性及正式证书指纹验证通过。

未合并、未公开发布。