### PR TITLE
ui: 设计 token 化 + 去塑料感（方向 A）

### DIFF
--- a/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
@@ -1,23 +1,23 @@
-@file:Suppress("unused")
-
 package io.github.xgl34222220.baize
 
+import android.os.Build
 import android.text.format.Formatter
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -37,31 +37,55 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.BugReport
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.material.icons.rounded.DeleteSweep
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.FolderDelete
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.InstallMobile
+import androidx.compose.material.icons.rounded.Notifications
+import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Rule
 import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.Shield
 import androidx.compose.material.icons.rounded.Stop
+import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -76,53 +100,70 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.android.material.color.MaterialColors
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.clean.CleanRoute
+import io.github.xgl34222220.baize.ui.home.HomeRoute
 import io.github.xgl34222220.baize.ui.history.HistoryRoute
-import io.github.xgl34222220.baize.ui.home.material.HomeScreenMaterial
+import io.github.xgl34222220.baize.ui.settings.SettingsRoute
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidDock
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidNavItem
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidPrimaryButton
 import io.github.xgl34222220.baize.ui.miuix.MiuixOverviewHero
-import io.github.xgl34222220.baize.ui.settings.SettingsRoute
 import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import org.json.JSONObject
 import kotlin.math.roundToInt
 
-/** Compose 面板状态。 */
+@Immutable
+data class ScanPerformanceUiState(
+    val available: Boolean = false,
+    val workerPolicy: String = "auto",
+    val workerReason: String = "not_measured",
+    val actualWorkers: Int = 1,
+    val recommendedWorkers: Int = 1,
+    val parallelGainPercent: Int = 0,
+    val serialRate: Long = 0,
+    val parallelRate: Long = 0,
+    val successfulRuns: Int = 0,
+    val nextProbeRun: Int = 0,
+    val parallelBlockedUntil: Long = 0
+)
+
+@Immutable
 data class DashboardUiState(
     val connected: Boolean = false,
     val ready: Boolean = false,
     val running: Boolean = false,
-    val device: String = "",
-    val android: String = "",
-    val serviceText: String = "",
-    val taskPhase: String = "正在初始化 Root 清理服务",
-    val storagePercent: Float = 0f,
-    val storageFree: Long = 0,
-    val storageUsed: Long = 0,
+    val serviceText: String = "正在等待 Root 服务…",
+    val taskPhase: String = "等待下一次清理",
+    val schedulerText: String = "等待调度器状态",
+    val device: String = Build.MODEL,
+    val android: String = "Android ${Build.VERSION.RELEASE}",
     val storageTotal: Long = 0,
+    val storageUsed: Long = 0,
+    val storageFree: Long = 0,
+    val storagePercent: Float = 0f,
     val lastReleased: Long = 0,
     val scanCompleted: Boolean = false,
     val scanBytes: Long = 0,
-    val scanFiles: Int = 0,
-    val scanEmptyFiles: Int = 0,
-    val scanEmptyDirs: Int = 0,
-    val scanFragments: Int = 0,
-    val scanErrors: Int = 0,
+    val scanFiles: Long = 0,
+    val scanEmptyFiles: Long = 0,
+    val scanEmptyDirs: Long = 0,
+    val scanFragments: Long = 0,
+    val scanErrors: Long = 0,
     val scanElapsed: Long = 0,
     val lifetimeRuns: Long = 0,
     val lifetimeReleased: Long = 0,
@@ -132,169 +173,266 @@ data class DashboardUiState(
     val lifetimeFragments: Long = 0,
     val lifetimeElapsed: Long = 0,
     val whitelistCount: Int = 0,
-    val scanPerformance: String = "",
+    val recentApps: List<AppJunkUiItem> = emptyList(),
+    val recentJunk: List<GeneralJunkUiItem> = emptyList(),
     val rawLogName: String = "",
     val rawLog: String = "",
-    val history: List<BaiZeHistoryEntry> = emptyList(),
-    val recentApps: List<BaiZeAppEntry> = emptyList(),
-    val recentJunk: List<BaiZeJunkItem> = emptyList()
+    val lastTaskTime: String = "",
+    val protectedItems: List<ProtectedUiItem> = emptyList(),
+    val history: List<HistoryUiItem> = emptyList(),
+    val scanPerformance: ScanPerformanceUiState = ScanPerformanceUiState()
 )
 
-data class BaiZeHistoryEntry(
-    val title: String,
-    val summary: String,
-    val size: String,
+@Immutable
+data class AppJunkUiItem(
+    val packageName: String,
+    val label: String,
     val category: String,
-    val positive: Boolean
+    val files: Long,
+    val bytes: Long,
+    val errors: Long = 0,
+    val categories: List<AppJunkCategoryUiItem> = emptyList()
 )
 
-data class BaiZeAppEntry(val name: String, val packageName: String, val size: String)
-data class BaiZeJunkItem(val category: String, val path: String, val size: String)
+@Immutable
+data class AppJunkCategoryUiItem(
+    val name: String,
+    val files: Long,
+    val bytes: Long,
+    val errors: Long,
+    val samplePath: String
+)
 
+@Immutable
+data class GeneralJunkUiItem(
+    val name: String,
+    val files: Long,
+    val bytes: Long,
+    val errors: Long,
+    val samplePath: String
+)
+
+@Immutable
+data class ProtectedUiItem(
+    val id: String,
+    val category: String,
+    val path: String,
+    val reason: String,
+    val risk: String,
+    val selectable: Boolean
+)
+
+@Immutable
+data class HistoryUiItem(
+    val title: String,
+    val time: String,
+    val trigger: String,
+    val result: String,
+    val bytes: Long,
+    val files: Int,
+    val emptyDirs: Int,
+    val errors: Int,
+    val cleaned: Boolean,
+    val categories: List<HistoryCategoryUiItem> = emptyList(),
+    val apps: List<HistoryAppUiItem> = emptyList()
+)
+
+@Immutable
+data class HistoryCategoryUiItem(
+    val name: String,
+    val bytes: Long,
+    val files: Long
+)
+
+@Immutable
+data class HistoryAppUiItem(
+    val packageName: String,
+    val label: String,
+    val category: String,
+    val bytes: Long,
+    val files: Long
+)
+
+@Immutable
 data class SchedulerUiState(
-    val automaticCleaningEnabled: Boolean = false,
+    val enabled: Boolean = true,
+    val cacheEnabled: Boolean = true,
+    val cacheMinutes: Int = 60,
+    val emptyEnabled: Boolean = true,
+    val emptyMinutes: Int = 60,
+    val rulesEnabled: Boolean = true,
+    val rulesMinutes: Int = 360,
+    val fragmentEnabled: Boolean = true,
+    val fragmentMinutes: Int = 720,
+    val deepEnabled: Boolean = false,
+    val deepMinutes: Int = 10_080,
+    val organizeEnabled: Boolean = false,
+    val organizeMinutes: Int = 1_440,
+    val organizeScreenOffOnly: Boolean = true,
+    val organizeChargingOnly: Boolean = false,
+    val organizeIdleOnly: Boolean = false,
+    val organizeRunImmediately: Boolean = false,
+    val organizerConflictPolicy: Int = 1,
+    val organizerUndoRetention: Int = 10,
     val dailyEnabled: Boolean = false,
-    val dailyTimeText: String = "03:00",
-    val dailyGraceText: String = "",
-    val scheduleSummary: String = "自动清理未开启"
-)
+    val dailyHour: Int = 3,
+    val dailyMinute: Int = 30,
+    val dailyGraceMinutes: Int = 240,
+    val screenOffOnly: Boolean = true,
+    val chargingOnly: Boolean = false,
+    val idleOnly: Boolean = false,
+    val minBattery: Int = 25,
+    val notifyOnComplete: Boolean = true,
+    val notifyZero: Boolean = false,
+    val maxFileMb: Int = 256,
+    val apkPackagesEnabled: Boolean = true,
+    val apkPackageDays: Int = 30,
+    val scanRootWorkers: Int = 0,
+    val runtimeState: String = "waiting",
+    val runtimeReason: String = "等待调度器首次轮询",
+    val queueCount: Int = 0,
+    val queueGroups: String = "",
+    val nextTask: String = "",
+    val blockedGroups: String = "",
+    val nextCheckEpoch: Long = 0L,
+    val runtimeGroup: String = "",
+    val cacheNextEpoch: Long = 0L,
+    val emptyNextEpoch: Long = 0L,
+    val rulesNextEpoch: Long = 0L,
+    val fragmentNextEpoch: Long = 0L,
+    val deepNextEpoch: Long = 0L,
+    val organizeNextEpoch: Long = 0L,
+    val supervisorStatus: String = "unknown",
+    val supervisorHeartbeatAge: Long = -1L,
+    val runtimeStale: Boolean = false,
+    val saving: Boolean = false
+) {
+    fun toJson(): JSONObject = JSONObject()
+        .put("enabled", enabled.flag())
+        .put("schedule_cache_enabled", cacheEnabled.flag())
+        .put("schedule_cache_minutes", cacheMinutes.coerceIn(5, 43_200))
+        .put("schedule_cache_hours", ((cacheMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_empty_enabled", emptyEnabled.flag())
+        .put("schedule_empty_minutes", emptyMinutes.coerceIn(5, 43_200))
+        .put("schedule_empty_hours", ((emptyMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_rules_enabled", rulesEnabled.flag())
+        .put("schedule_rules_minutes", rulesMinutes.coerceIn(5, 43_200))
+        .put("schedule_rules_hours", ((rulesMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_fragment_enabled", fragmentEnabled.flag())
+        .put("schedule_fragment_minutes", fragmentMinutes.coerceIn(5, 43_200))
+        .put("schedule_fragment_hours", ((fragmentMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_deep_enabled", deepEnabled.flag())
+        .put("schedule_deep_minutes", deepMinutes.coerceIn(5, 43_200))
+        .put("schedule_deep_hours", ((deepMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_organize_enabled", organizeEnabled.flag())
+        .put("schedule_organize_minutes", organizeMinutes.coerceIn(15, 43_200))
+        .put("schedule_organize_hours", ((organizeMinutes + 59) / 60).coerceIn(1, 720))
+        .put("organize_screen_off_only", organizeScreenOffOnly.flag())
+        .put("organize_charging_only", organizeChargingOnly.flag())
+        .put("organize_device_idle_only", organizeIdleOnly.flag())
+        .put("organize_run_immediately", organizeRunImmediately.flag())
+        .put("organizer_conflict_policy", organizerConflictPolicy.coerceIn(0, 2))
+        .put("organizer_undo_retention", organizerUndoRetention.coerceIn(1, 20))
+        .put("daily_schedule_enabled", dailyEnabled.flag())
+        .put("daily_schedule_hour", dailyHour.coerceIn(0, 23))
+        .put("daily_schedule_minute", dailyMinute.coerceIn(0, 59))
+        .put("daily_grace_minutes", dailyGraceMinutes.coerceIn(15, 720))
+        .put("screen_off_only", screenOffOnly.flag())
+        .put("charging_only", chargingOnly.flag())
+        .put("device_idle_only", idleOnly.flag())
+        .put("min_battery", minBattery.coerceIn(0, 100))
+        .put("notify_on_complete", notifyOnComplete.flag())
+        .put("notify_zero_result", notifyZero.flag())
+        .put("max_file_mb", maxFileMb.coerceIn(16, 2048))
+        .put("clean_apk_packages", apkPackagesEnabled.flag())
+        .put("apk_package_days", apkPackageDays.coerceIn(0, 365))
+        .put("scan_root_workers", 0)
+
+    companion object {
+        fun fromJson(json: JSONObject): SchedulerUiState {
+            val runtime = json.optJSONObject("runtime") ?: JSONObject()
+            val nextRuns = runtime.optJSONObject("nextRuns") ?: JSONObject()
+            return SchedulerUiState(
+                enabled = json.optInt("enabled", 1) == 1,
+                cacheEnabled = json.optInt("schedule_cache_enabled", 1) == 1,
+                cacheMinutes = json.optInt("schedule_cache_minutes", json.optInt("schedule_cache_hours", 1) * 60).coerceIn(5, 43_200),
+                emptyEnabled = json.optInt("schedule_empty_enabled", 1) == 1,
+                emptyMinutes = json.optInt("schedule_empty_minutes", json.optInt("schedule_empty_hours", 1) * 60).coerceIn(5, 43_200),
+                rulesEnabled = json.optInt("schedule_rules_enabled", 1) == 1,
+                rulesMinutes = json.optInt("schedule_rules_minutes", json.optInt("schedule_rules_hours", 6) * 60).coerceIn(5, 43_200),
+                fragmentEnabled = json.optInt("schedule_fragment_enabled", 1) == 1,
+                fragmentMinutes = json.optInt("schedule_fragment_minutes", json.optInt("schedule_fragment_hours", 12) * 60).coerceIn(5, 43_200),
+                deepEnabled = json.optInt("schedule_deep_enabled", 0) == 1,
+                deepMinutes = json.optInt("schedule_deep_minutes", json.optInt("schedule_deep_hours", 168) * 60).coerceIn(5, 43_200),
+                organizeEnabled = json.optInt("schedule_organize_enabled", 0) == 1,
+                organizeMinutes = json.optInt("schedule_organize_minutes", json.optInt("schedule_organize_hours", 24) * 60).coerceIn(15, 43_200),
+                organizeScreenOffOnly = json.optInt("organize_screen_off_only", 1) == 1,
+                organizeChargingOnly = json.optInt("organize_charging_only", 0) == 1,
+                organizeIdleOnly = json.optInt("organize_device_idle_only", 0) == 1,
+                organizeRunImmediately = json.optInt("organize_run_immediately", 0) == 1,
+                organizerConflictPolicy = json.optInt("organizer_conflict_policy", 1).coerceIn(0, 2),
+                organizerUndoRetention = json.optInt("organizer_undo_retention", 10).coerceIn(1, 20),
+                dailyEnabled = json.optInt("daily_schedule_enabled", 0) == 1,
+                dailyHour = json.optInt("daily_schedule_hour", 3).coerceIn(0, 23),
+                dailyMinute = json.optInt("daily_schedule_minute", 30).coerceIn(0, 59),
+                dailyGraceMinutes = json.optInt("daily_grace_minutes", 240).coerceIn(15, 720),
+                screenOffOnly = json.optInt("screen_off_only", 1) == 1,
+                chargingOnly = json.optInt("charging_only", 0) == 1,
+                idleOnly = json.optInt("device_idle_only", 0) == 1,
+                minBattery = json.optInt("min_battery", 25).coerceIn(0, 100),
+                notifyOnComplete = json.optInt("notify_on_complete", 1) == 1,
+                notifyZero = json.optInt("notify_zero_result", 0) == 1,
+                maxFileMb = json.optInt("max_file_mb", 256).coerceIn(16, 2048),
+                apkPackagesEnabled = json.optInt("clean_apk_packages", 1) == 1,
+                apkPackageDays = json.optInt("apk_package_days", 30).coerceIn(0, 365),
+                runtimeState = runtime.optString("state", "waiting"),
+                runtimeReason = runtime.optString("reason", "等待调度器首次轮询"),
+                queueCount = runtime.optInt("queueCount", 0).coerceAtLeast(0),
+                queueGroups = runtime.optString("queueGroups"),
+                nextTask = runtime.optString("nextTask"),
+                blockedGroups = runtime.optString("blockedGroups"),
+                nextCheckEpoch = runtime.optLong("nextCheckEpoch", 0L).coerceAtLeast(0L),
+                runtimeGroup = runtime.optString("group"),
+                cacheNextEpoch = nextRuns.optLong("cache", 0L).coerceAtLeast(0L),
+                emptyNextEpoch = nextRuns.optLong("empty", 0L).coerceAtLeast(0L),
+                rulesNextEpoch = nextRuns.optLong("rules", 0L).coerceAtLeast(0L),
+                fragmentNextEpoch = nextRuns.optLong("fragment", 0L).coerceAtLeast(0L),
+                deepNextEpoch = nextRuns.optLong("deep", 0L).coerceAtLeast(0L),
+                organizeNextEpoch = nextRuns.optLong("organize", 0L).coerceAtLeast(0L),
+                supervisorStatus = runtime.optString("supervisorStatus", "unknown"),
+                supervisorHeartbeatAge = runtime.optLong("supervisorHeartbeatAge", -1L),
+                runtimeStale = runtime.optBoolean("stale", false),
+                scanRootWorkers = 0
+            )
+        }
+    }
+}
+
+private fun Boolean.flag() = if (this) 1 else 0
 
 data class DashboardActions(
-    val refresh: () -> Unit = {},
-    val clean: () -> Unit = {},
-    val cleanScan: () -> Unit = {},
-    val dismissScan: () -> Unit = {},
-    val stop: () -> Unit = {},
-    val apkScan: () -> Unit = {}
+    val refresh: () -> Unit,
+    val clean: () -> Unit,
+    val scan: () -> Unit,
+    val apkScan: () -> Unit,
+    val cleanScan: () -> Unit,
+    val dismissScan: () -> Unit,
+    val stop: () -> Unit,
+    val deep: () -> Unit,
+    val corpses: () -> Unit,
+    val audit: () -> Unit,
+    val updateScheduler: (SchedulerUiState) -> Unit,
+    val saveScheduler: (SchedulerUiState) -> Unit,
+    val schedulerCommand: (String) -> Unit,
+    val clearHistory: () -> Unit,
+    val clearRawLog: () -> Unit,
+    val reviewProtected: () -> Unit,
+    val whitelist: () -> Unit,
+    val theme: () -> Unit,
+    val reconnect: () -> Unit,
+    val resetScanPerformance: () -> Unit,
+    val crash: () -> Unit
 )
-
-object DashboardParser {
-    fun parseDashboard(json: String?): DashboardUiState {
-        if (json.isNullOrBlank()) return DashboardUiState()
-        return runCatching {
-            val root = JSONObject(json)
-            DashboardUiState(
-                connected = root.optBoolean("connected"),
-                ready = root.optBoolean("ready"),
-                running = root.optBoolean("running"),
-                device = root.optString("device"),
-                android = root.optString("android"),
-                serviceText = root.optString("serviceText"),
-                taskPhase = root.optString("taskPhase"),
-                storagePercent = root.optDouble("storagePercent").toFloat(),
-                storageFree = root.optLong("storageFree"),
-                storageUsed = root.optLong("storageUsed"),
-                storageTotal = root.optLong("storageTotal"),
-                lastReleased = root.optLong("lastReleased"),
-                scanCompleted = root.optBoolean("scanCompleted"),
-                scanBytes = root.optLong("scanBytes"),
-                scanFiles = root.optInt("scanFiles"),
-                scanEmptyFiles = root.optInt("scanEmptyFiles"),
-                scanEmptyDirs = root.optInt("scanEmptyDirs"),
-                scanFragments = root.optInt("scanFragments"),
-                scanErrors = root.optInt("scanErrors"),
-                scanElapsed = root.optLong("scanElapsed"),
-                lifetimeRuns = root.optLong("lifetimeRuns"),
-                lifetimeReleased = root.optLong("lifetimeReleased"),
-                lifetimeFiles = root.optLong("lifetimeFiles"),
-                lifetimeEmptyFiles = root.optLong("lifetimeEmptyFiles"),
-                lifetimeEmptyDirs = root.optLong("lifetimeEmptyDirs"),
-                lifetimeFragments = root.optLong("lifetimeFragments"),
-                lifetimeElapsed = root.optLong("lifetimeElapsed"),
-                whitelistCount = root.optInt("whitelistCount"),
-                scanPerformance = root.optString("scanPerformance"),
-                rawLogName = root.optString("rawLogName"),
-                rawLog = root.optString("rawLog")
-            )
-        }.getOrElse { DashboardUiState() }
-    }
-
-    fun parseHistory(json: String?): List<BaiZeHistoryEntry> {
-        if (json.isNullOrBlank()) return emptyList()
-        return runCatching {
-            val array = org.json.JSONArray(json)
-            buildList {
-                for (index in 0 until array.length()) {
-                    val item = array.getJSONObject(index)
-                    add(
-                        BaiZeHistoryEntry(
-                            title = item.optString("title"),
-                            summary = item.optString("summary"),
-                            size = item.optString("size"),
-                            category = item.optString("category"),
-                            positive = item.optBoolean("positive", true)
-                        )
-                    )
-                }
-            }
-        }.getOrElse { emptyList() }
-    }
-
-    fun parseRecentApps(json: String?): List<BaiZeAppEntry> {
-        if (json.isNullOrBlank()) return emptyList()
-        return runCatching {
-            val array = org.json.JSONArray(json)
-            buildList {
-                for (index in 0 until array.length()) {
-                    val item = array.getJSONObject(index)
-                    add(
-                        BaiZeAppEntry(
-                            name = item.optString("name"),
-                            packageName = item.optString("packageName"),
-                            size = item.optString("size")
-                        )
-                    )
-                }
-            }
-        }.getOrElse { emptyList() }
-    }
-
-    fun parseRecentJunk(json: String?): List<BaiZeJunkItem> {
-        if (json.isNullOrBlank()) return emptyList()
-        return runCatching {
-            val array = org.json.JSONArray(json)
-            buildList {
-                for (index in 0 until array.length()) {
-                    val item = array.getJSONObject(index)
-                    add(
-                        BaiZeJunkItem(
-                            category = item.optString("category"),
-                            path = item.optString("path"),
-                            size = item.optString("size")
-                        )
-                    )
-                }
-            }
-        }.getOrElse { emptyList() }
-    }
-
-    fun parseScheduler(json: String?): SchedulerUiState {
-        if (json.isNullOrBlank()) return SchedulerUiState()
-        return runCatching {
-            val root = JSONObject(json)
-            SchedulerUiState(
-                automaticCleaningEnabled = root.optBoolean("automaticCleaningEnabled"),
-                dailyEnabled = root.optBoolean("dailyEnabled"),
-                dailyTimeText = "%02d:%02d".format(root.optInt("dailyHour"), root.optInt("dailyMinute")),
-                dailyGraceText = "补做窗口 ${root.optInt("dailyGraceMinutes")} 分钟",
-                scheduleSummary = root.optString("scheduleSummary")
-            )
-        }.getOrElse { SchedulerUiState() }
-    }
-}
-
-@Composable
-fun HomeRoute(
-    style: UiStyle,
-    state: DashboardUiState,
-    actions: DashboardActions,
-    onOpenClean: () -> Unit
-) {
-    when (style) {
-        UiStyle.MATERIAL -> HomeScreenMaterial(state, actions, onOpenClean)
-        UiStyle.MIUIX -> HomeScreenMiuix(state, actions, onOpenClean)
-    }
-}
 
 private enum class BaiZePage(val title: String, val icon: ImageVector) {
     Home("首页", Icons.Rounded.Home),
@@ -518,7 +656,7 @@ private fun PageHeader(eyebrow: String, title: String, subtitle: String, refresh
     ) {
         Column(Modifier.weight(1f)) {
             Text(eyebrow.uppercase(), color = MaterialTheme.colorScheme.primary, fontSize = 11.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
-            Spacer(Modifier.height(4.dp))
+            Spacer(Modifier.height(5.dp))
             Text(title, color = MaterialTheme.colorScheme.onSurface, style = BaiZeTokens.type.display)
             Spacer(Modifier.height(4.dp))
             Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp, fontWeight = FontWeight.Medium)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
@@ -1,23 +1,23 @@
+@file:Suppress("unused")
+
 package io.github.xgl34222220.baize
 
-import android.os.Build
 import android.text.format.Formatter
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -37,55 +37,31 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AutoAwesome
-import androidx.compose.material.icons.rounded.BugReport
-import androidx.compose.material.icons.rounded.CalendarMonth
-import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.material.icons.rounded.DeleteSweep
-import androidx.compose.material.icons.rounded.Description
-import androidx.compose.material.icons.rounded.ErrorOutline
-import androidx.compose.material.icons.rounded.FolderDelete
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.InstallMobile
-import androidx.compose.material.icons.rounded.Notifications
-import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.Rule
 import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Settings
-import androidx.compose.material.icons.rounded.Shield
 import androidx.compose.material.icons.rounded.Stop
-import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -98,72 +74,55 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.android.material.color.MaterialColors
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.clean.CleanRoute
-import io.github.xgl34222220.baize.ui.home.HomeRoute
 import io.github.xgl34222220.baize.ui.history.HistoryRoute
-import io.github.xgl34222220.baize.ui.settings.SettingsRoute
+import io.github.xgl34222220.baize.ui.home.material.HomeScreenMaterial
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidDock
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidNavItem
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidPrimaryButton
 import io.github.xgl34222220.baize.ui.miuix.MiuixOverviewHero
+import io.github.xgl34222220.baize.ui.settings.SettingsRoute
 import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import org.json.JSONObject
 import kotlin.math.roundToInt
 
-private val SuccessGreen = Color(0xFF2DBE87)
-
-@Immutable
-data class ScanPerformanceUiState(
-    val available: Boolean = false,
-    val workerPolicy: String = "auto",
-    val workerReason: String = "not_measured",
-    val actualWorkers: Int = 1,
-    val recommendedWorkers: Int = 1,
-    val parallelGainPercent: Int = 0,
-    val serialRate: Long = 0,
-    val parallelRate: Long = 0,
-    val successfulRuns: Int = 0,
-    val nextProbeRun: Int = 0,
-    val parallelBlockedUntil: Long = 0
-)
-
-@Immutable
+/** Compose 面板状态。 */
 data class DashboardUiState(
     val connected: Boolean = false,
     val ready: Boolean = false,
     val running: Boolean = false,
-    val serviceText: String = "正在等待 Root 服务…",
-    val taskPhase: String = "等待下一次清理",
-    val schedulerText: String = "等待调度器状态",
-    val device: String = Build.MODEL,
-    val android: String = "Android ${Build.VERSION.RELEASE}",
-    val storageTotal: Long = 0,
-    val storageUsed: Long = 0,
-    val storageFree: Long = 0,
+    val device: String = "",
+    val android: String = "",
+    val serviceText: String = "",
+    val taskPhase: String = "正在初始化 Root 清理服务",
     val storagePercent: Float = 0f,
+    val storageFree: Long = 0,
+    val storageUsed: Long = 0,
+    val storageTotal: Long = 0,
     val lastReleased: Long = 0,
     val scanCompleted: Boolean = false,
     val scanBytes: Long = 0,
-    val scanFiles: Long = 0,
-    val scanEmptyFiles: Long = 0,
-    val scanEmptyDirs: Long = 0,
-    val scanFragments: Long = 0,
-    val scanErrors: Long = 0,
+    val scanFiles: Int = 0,
+    val scanEmptyFiles: Int = 0,
+    val scanEmptyDirs: Int = 0,
+    val scanFragments: Int = 0,
+    val scanErrors: Int = 0,
     val scanElapsed: Long = 0,
     val lifetimeRuns: Long = 0,
     val lifetimeReleased: Long = 0,
@@ -173,266 +132,169 @@ data class DashboardUiState(
     val lifetimeFragments: Long = 0,
     val lifetimeElapsed: Long = 0,
     val whitelistCount: Int = 0,
-    val recentApps: List<AppJunkUiItem> = emptyList(),
-    val recentJunk: List<GeneralJunkUiItem> = emptyList(),
+    val scanPerformance: String = "",
     val rawLogName: String = "",
     val rawLog: String = "",
-    val lastTaskTime: String = "",
-    val protectedItems: List<ProtectedUiItem> = emptyList(),
-    val history: List<HistoryUiItem> = emptyList(),
-    val scanPerformance: ScanPerformanceUiState = ScanPerformanceUiState()
+    val history: List<BaiZeHistoryEntry> = emptyList(),
+    val recentApps: List<BaiZeAppEntry> = emptyList(),
+    val recentJunk: List<BaiZeJunkItem> = emptyList()
 )
 
-@Immutable
-data class AppJunkUiItem(
-    val packageName: String,
-    val label: String,
-    val category: String,
-    val files: Long,
-    val bytes: Long,
-    val errors: Long = 0,
-    val categories: List<AppJunkCategoryUiItem> = emptyList()
-)
-
-@Immutable
-data class AppJunkCategoryUiItem(
-    val name: String,
-    val files: Long,
-    val bytes: Long,
-    val errors: Long,
-    val samplePath: String
-)
-
-@Immutable
-data class GeneralJunkUiItem(
-    val name: String,
-    val files: Long,
-    val bytes: Long,
-    val errors: Long,
-    val samplePath: String
-)
-
-@Immutable
-data class ProtectedUiItem(
-    val id: String,
-    val category: String,
-    val path: String,
-    val reason: String,
-    val risk: String,
-    val selectable: Boolean
-)
-
-@Immutable
-data class HistoryUiItem(
+data class BaiZeHistoryEntry(
     val title: String,
-    val time: String,
-    val trigger: String,
-    val result: String,
-    val bytes: Long,
-    val files: Int,
-    val emptyDirs: Int,
-    val errors: Int,
-    val cleaned: Boolean,
-    val categories: List<HistoryCategoryUiItem> = emptyList(),
-    val apps: List<HistoryAppUiItem> = emptyList()
-)
-
-@Immutable
-data class HistoryCategoryUiItem(
-    val name: String,
-    val bytes: Long,
-    val files: Long
-)
-
-@Immutable
-data class HistoryAppUiItem(
-    val packageName: String,
-    val label: String,
+    val summary: String,
+    val size: String,
     val category: String,
-    val bytes: Long,
-    val files: Long
+    val positive: Boolean
 )
 
-@Immutable
-data class SchedulerUiState(
-    val enabled: Boolean = true,
-    val cacheEnabled: Boolean = true,
-    val cacheMinutes: Int = 60,
-    val emptyEnabled: Boolean = true,
-    val emptyMinutes: Int = 60,
-    val rulesEnabled: Boolean = true,
-    val rulesMinutes: Int = 360,
-    val fragmentEnabled: Boolean = true,
-    val fragmentMinutes: Int = 720,
-    val deepEnabled: Boolean = false,
-    val deepMinutes: Int = 10_080,
-    val organizeEnabled: Boolean = false,
-    val organizeMinutes: Int = 1_440,
-    val organizeScreenOffOnly: Boolean = true,
-    val organizeChargingOnly: Boolean = false,
-    val organizeIdleOnly: Boolean = false,
-    val organizeRunImmediately: Boolean = false,
-    val organizerConflictPolicy: Int = 1,
-    val organizerUndoRetention: Int = 10,
-    val dailyEnabled: Boolean = false,
-    val dailyHour: Int = 3,
-    val dailyMinute: Int = 30,
-    val dailyGraceMinutes: Int = 240,
-    val screenOffOnly: Boolean = true,
-    val chargingOnly: Boolean = false,
-    val idleOnly: Boolean = false,
-    val minBattery: Int = 25,
-    val notifyOnComplete: Boolean = true,
-    val notifyZero: Boolean = false,
-    val maxFileMb: Int = 256,
-    val apkPackagesEnabled: Boolean = true,
-    val apkPackageDays: Int = 30,
-    val scanRootWorkers: Int = 0,
-    val runtimeState: String = "waiting",
-    val runtimeReason: String = "等待调度器首次轮询",
-    val queueCount: Int = 0,
-    val queueGroups: String = "",
-    val nextTask: String = "",
-    val blockedGroups: String = "",
-    val nextCheckEpoch: Long = 0L,
-    val runtimeGroup: String = "",
-    val cacheNextEpoch: Long = 0L,
-    val emptyNextEpoch: Long = 0L,
-    val rulesNextEpoch: Long = 0L,
-    val fragmentNextEpoch: Long = 0L,
-    val deepNextEpoch: Long = 0L,
-    val organizeNextEpoch: Long = 0L,
-    val supervisorStatus: String = "unknown",
-    val supervisorHeartbeatAge: Long = -1L,
-    val runtimeStale: Boolean = false,
-    val saving: Boolean = false
-) {
-    fun toJson(): JSONObject = JSONObject()
-        .put("enabled", enabled.flag())
-        .put("schedule_cache_enabled", cacheEnabled.flag())
-        .put("schedule_cache_minutes", cacheMinutes.coerceIn(5, 43_200))
-        .put("schedule_cache_hours", ((cacheMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_empty_enabled", emptyEnabled.flag())
-        .put("schedule_empty_minutes", emptyMinutes.coerceIn(5, 43_200))
-        .put("schedule_empty_hours", ((emptyMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_rules_enabled", rulesEnabled.flag())
-        .put("schedule_rules_minutes", rulesMinutes.coerceIn(5, 43_200))
-        .put("schedule_rules_hours", ((rulesMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_fragment_enabled", fragmentEnabled.flag())
-        .put("schedule_fragment_minutes", fragmentMinutes.coerceIn(5, 43_200))
-        .put("schedule_fragment_hours", ((fragmentMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_deep_enabled", deepEnabled.flag())
-        .put("schedule_deep_minutes", deepMinutes.coerceIn(5, 43_200))
-        .put("schedule_deep_hours", ((deepMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_organize_enabled", organizeEnabled.flag())
-        .put("schedule_organize_minutes", organizeMinutes.coerceIn(15, 43_200))
-        .put("schedule_organize_hours", ((organizeMinutes + 59) / 60).coerceIn(1, 720))
-        .put("organize_screen_off_only", organizeScreenOffOnly.flag())
-        .put("organize_charging_only", organizeChargingOnly.flag())
-        .put("organize_device_idle_only", organizeIdleOnly.flag())
-        .put("organize_run_immediately", organizeRunImmediately.flag())
-        .put("organizer_conflict_policy", organizerConflictPolicy.coerceIn(0, 2))
-        .put("organizer_undo_retention", organizerUndoRetention.coerceIn(1, 20))
-        .put("daily_schedule_enabled", dailyEnabled.flag())
-        .put("daily_schedule_hour", dailyHour.coerceIn(0, 23))
-        .put("daily_schedule_minute", dailyMinute.coerceIn(0, 59))
-        .put("daily_grace_minutes", dailyGraceMinutes.coerceIn(15, 720))
-        .put("screen_off_only", screenOffOnly.flag())
-        .put("charging_only", chargingOnly.flag())
-        .put("device_idle_only", idleOnly.flag())
-        .put("min_battery", minBattery.coerceIn(0, 100))
-        .put("notify_on_complete", notifyOnComplete.flag())
-        .put("notify_zero_result", notifyZero.flag())
-        .put("max_file_mb", maxFileMb.coerceIn(16, 2048))
-        .put("clean_apk_packages", apkPackagesEnabled.flag())
-        .put("apk_package_days", apkPackageDays.coerceIn(0, 365))
-        .put("scan_root_workers", 0)
+data class BaiZeAppEntry(val name: String, val packageName: String, val size: String)
+data class BaiZeJunkItem(val category: String, val path: String, val size: String)
 
-    companion object {
-        fun fromJson(json: JSONObject): SchedulerUiState {
-            val runtime = json.optJSONObject("runtime") ?: JSONObject()
-            val nextRuns = runtime.optJSONObject("nextRuns") ?: JSONObject()
-            return SchedulerUiState(
-                enabled = json.optInt("enabled", 1) == 1,
-                cacheEnabled = json.optInt("schedule_cache_enabled", 1) == 1,
-                cacheMinutes = json.optInt("schedule_cache_minutes", json.optInt("schedule_cache_hours", 1) * 60).coerceIn(5, 43_200),
-                emptyEnabled = json.optInt("schedule_empty_enabled", 1) == 1,
-                emptyMinutes = json.optInt("schedule_empty_minutes", json.optInt("schedule_empty_hours", 1) * 60).coerceIn(5, 43_200),
-                rulesEnabled = json.optInt("schedule_rules_enabled", 1) == 1,
-                rulesMinutes = json.optInt("schedule_rules_minutes", json.optInt("schedule_rules_hours", 6) * 60).coerceIn(5, 43_200),
-                fragmentEnabled = json.optInt("schedule_fragment_enabled", 1) == 1,
-                fragmentMinutes = json.optInt("schedule_fragment_minutes", json.optInt("schedule_fragment_hours", 12) * 60).coerceIn(5, 43_200),
-                deepEnabled = json.optInt("schedule_deep_enabled", 0) == 1,
-                deepMinutes = json.optInt("schedule_deep_minutes", json.optInt("schedule_deep_hours", 168) * 60).coerceIn(5, 43_200),
-                organizeEnabled = json.optInt("schedule_organize_enabled", 0) == 1,
-                organizeMinutes = json.optInt("schedule_organize_minutes", json.optInt("schedule_organize_hours", 24) * 60).coerceIn(15, 43_200),
-                organizeScreenOffOnly = json.optInt("organize_screen_off_only", 1) == 1,
-                organizeChargingOnly = json.optInt("organize_charging_only", 0) == 1,
-                organizeIdleOnly = json.optInt("organize_device_idle_only", 0) == 1,
-                organizeRunImmediately = json.optInt("organize_run_immediately", 0) == 1,
-                organizerConflictPolicy = json.optInt("organizer_conflict_policy", 1).coerceIn(0, 2),
-                organizerUndoRetention = json.optInt("organizer_undo_retention", 10).coerceIn(1, 20),
-                dailyEnabled = json.optInt("daily_schedule_enabled", 0) == 1,
-                dailyHour = json.optInt("daily_schedule_hour", 3).coerceIn(0, 23),
-                dailyMinute = json.optInt("daily_schedule_minute", 30).coerceIn(0, 59),
-                dailyGraceMinutes = json.optInt("daily_grace_minutes", 240).coerceIn(15, 720),
-                screenOffOnly = json.optInt("screen_off_only", 1) == 1,
-                chargingOnly = json.optInt("charging_only", 0) == 1,
-                idleOnly = json.optInt("device_idle_only", 0) == 1,
-                minBattery = json.optInt("min_battery", 25).coerceIn(0, 100),
-                notifyOnComplete = json.optInt("notify_on_complete", 1) == 1,
-                notifyZero = json.optInt("notify_zero_result", 0) == 1,
-                maxFileMb = json.optInt("max_file_mb", 256).coerceIn(16, 2048),
-                apkPackagesEnabled = json.optInt("clean_apk_packages", 1) == 1,
-                apkPackageDays = json.optInt("apk_package_days", 30).coerceIn(0, 365),
-                runtimeState = runtime.optString("state", "waiting"),
-                runtimeReason = runtime.optString("reason", "等待调度器首次轮询"),
-                queueCount = runtime.optInt("queueCount", 0).coerceAtLeast(0),
-                queueGroups = runtime.optString("queueGroups"),
-                nextTask = runtime.optString("nextTask"),
-                blockedGroups = runtime.optString("blockedGroups"),
-                nextCheckEpoch = runtime.optLong("nextCheckEpoch", 0L).coerceAtLeast(0L),
-                runtimeGroup = runtime.optString("group"),
-                cacheNextEpoch = nextRuns.optLong("cache", 0L).coerceAtLeast(0L),
-                emptyNextEpoch = nextRuns.optLong("empty", 0L).coerceAtLeast(0L),
-                rulesNextEpoch = nextRuns.optLong("rules", 0L).coerceAtLeast(0L),
-                fragmentNextEpoch = nextRuns.optLong("fragment", 0L).coerceAtLeast(0L),
-                deepNextEpoch = nextRuns.optLong("deep", 0L).coerceAtLeast(0L),
-                organizeNextEpoch = nextRuns.optLong("organize", 0L).coerceAtLeast(0L),
-                supervisorStatus = runtime.optString("supervisorStatus", "unknown"),
-                supervisorHeartbeatAge = runtime.optLong("supervisorHeartbeatAge", -1L),
-                runtimeStale = runtime.optBoolean("stale", false),
-                scanRootWorkers = 0
+data class SchedulerUiState(
+    val automaticCleaningEnabled: Boolean = false,
+    val dailyEnabled: Boolean = false,
+    val dailyTimeText: String = "03:00",
+    val dailyGraceText: String = "",
+    val scheduleSummary: String = "自动清理未开启"
+)
+
+data class DashboardActions(
+    val refresh: () -> Unit = {},
+    val clean: () -> Unit = {},
+    val cleanScan: () -> Unit = {},
+    val dismissScan: () -> Unit = {},
+    val stop: () -> Unit = {},
+    val apkScan: () -> Unit = {}
+)
+
+object DashboardParser {
+    fun parseDashboard(json: String?): DashboardUiState {
+        if (json.isNullOrBlank()) return DashboardUiState()
+        return runCatching {
+            val root = JSONObject(json)
+            DashboardUiState(
+                connected = root.optBoolean("connected"),
+                ready = root.optBoolean("ready"),
+                running = root.optBoolean("running"),
+                device = root.optString("device"),
+                android = root.optString("android"),
+                serviceText = root.optString("serviceText"),
+                taskPhase = root.optString("taskPhase"),
+                storagePercent = root.optDouble("storagePercent").toFloat(),
+                storageFree = root.optLong("storageFree"),
+                storageUsed = root.optLong("storageUsed"),
+                storageTotal = root.optLong("storageTotal"),
+                lastReleased = root.optLong("lastReleased"),
+                scanCompleted = root.optBoolean("scanCompleted"),
+                scanBytes = root.optLong("scanBytes"),
+                scanFiles = root.optInt("scanFiles"),
+                scanEmptyFiles = root.optInt("scanEmptyFiles"),
+                scanEmptyDirs = root.optInt("scanEmptyDirs"),
+                scanFragments = root.optInt("scanFragments"),
+                scanErrors = root.optInt("scanErrors"),
+                scanElapsed = root.optLong("scanElapsed"),
+                lifetimeRuns = root.optLong("lifetimeRuns"),
+                lifetimeReleased = root.optLong("lifetimeReleased"),
+                lifetimeFiles = root.optLong("lifetimeFiles"),
+                lifetimeEmptyFiles = root.optLong("lifetimeEmptyFiles"),
+                lifetimeEmptyDirs = root.optLong("lifetimeEmptyDirs"),
+                lifetimeFragments = root.optLong("lifetimeFragments"),
+                lifetimeElapsed = root.optLong("lifetimeElapsed"),
+                whitelistCount = root.optInt("whitelistCount"),
+                scanPerformance = root.optString("scanPerformance"),
+                rawLogName = root.optString("rawLogName"),
+                rawLog = root.optString("rawLog")
             )
-        }
+        }.getOrElse { DashboardUiState() }
+    }
+
+    fun parseHistory(json: String?): List<BaiZeHistoryEntry> {
+        if (json.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = org.json.JSONArray(json)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val item = array.getJSONObject(index)
+                    add(
+                        BaiZeHistoryEntry(
+                            title = item.optString("title"),
+                            summary = item.optString("summary"),
+                            size = item.optString("size"),
+                            category = item.optString("category"),
+                            positive = item.optBoolean("positive", true)
+                        )
+                    )
+                }
+            }
+        }.getOrElse { emptyList() }
+    }
+
+    fun parseRecentApps(json: String?): List<BaiZeAppEntry> {
+        if (json.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = org.json.JSONArray(json)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val item = array.getJSONObject(index)
+                    add(
+                        BaiZeAppEntry(
+                            name = item.optString("name"),
+                            packageName = item.optString("packageName"),
+                            size = item.optString("size")
+                        )
+                    )
+                }
+            }
+        }.getOrElse { emptyList() }
+    }
+
+    fun parseRecentJunk(json: String?): List<BaiZeJunkItem> {
+        if (json.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = org.json.JSONArray(json)
+            buildList {
+                for (index in 0 until array.length()) {
+                    val item = array.getJSONObject(index)
+                    add(
+                        BaiZeJunkItem(
+                            category = item.optString("category"),
+                            path = item.optString("path"),
+                            size = item.optString("size")
+                        )
+                    )
+                }
+            }
+        }.getOrElse { emptyList() }
+    }
+
+    fun parseScheduler(json: String?): SchedulerUiState {
+        if (json.isNullOrBlank()) return SchedulerUiState()
+        return runCatching {
+            val root = JSONObject(json)
+            SchedulerUiState(
+                automaticCleaningEnabled = root.optBoolean("automaticCleaningEnabled"),
+                dailyEnabled = root.optBoolean("dailyEnabled"),
+                dailyTimeText = "%02d:%02d".format(root.optInt("dailyHour"), root.optInt("dailyMinute")),
+                dailyGraceText = "补做窗口 ${root.optInt("dailyGraceMinutes")} 分钟",
+                scheduleSummary = root.optString("scheduleSummary")
+            )
+        }.getOrElse { SchedulerUiState() }
     }
 }
 
-private fun Boolean.flag() = if (this) 1 else 0
-
-data class DashboardActions(
-    val refresh: () -> Unit,
-    val clean: () -> Unit,
-    val scan: () -> Unit,
-    val apkScan: () -> Unit,
-    val cleanScan: () -> Unit,
-    val dismissScan: () -> Unit,
-    val stop: () -> Unit,
-    val deep: () -> Unit,
-    val corpses: () -> Unit,
-    val audit: () -> Unit,
-    val updateScheduler: (SchedulerUiState) -> Unit,
-    val saveScheduler: (SchedulerUiState) -> Unit,
-    val schedulerCommand: (String) -> Unit,
-    val clearHistory: () -> Unit,
-    val clearRawLog: () -> Unit,
-    val reviewProtected: () -> Unit,
-    val whitelist: () -> Unit,
-    val theme: () -> Unit,
-    val reconnect: () -> Unit,
-    val resetScanPerformance: () -> Unit,
-    val crash: () -> Unit
-)
+@Composable
+fun HomeRoute(
+    style: UiStyle,
+    state: DashboardUiState,
+    actions: DashboardActions,
+    onOpenClean: () -> Unit
+) {
+    when (style) {
+        UiStyle.MATERIAL -> HomeScreenMaterial(state, actions, onOpenClean)
+        UiStyle.MIUIX -> HomeScreenMiuix(state, actions, onOpenClean)
+    }
+}
 
 private enum class BaiZePage(val title: String, val icon: ImageVector) {
     Home("首页", Icons.Rounded.Home),
@@ -579,36 +441,18 @@ private fun AnimatedPageHost(
 @Composable
 private fun MiuiXBackdrop(dark: Boolean, amoled: Boolean) {
     val scheme = MaterialTheme.colorScheme
-    val base = when {
-        amoled -> listOf(Color.Black, Color.Black, Color.Black)
-        dark -> listOf(Color(0xFF101117), Color(0xFF151827), Color(0xFF101117))
-        else -> listOf(Color(0xFFF8F7FF), Color(0xFFF0F5FF), Color(0xFFF8F8FC))
-    }
+    // 纯色中性底 + 一抹极淡单色氛围，不做蓝紫渐变与多层光斑。
     Box(
         Modifier
             .fillMaxSize()
-            .background(Brush.verticalGradient(base))
+            .background(BaiZeTokens.colors.surfaceBase)
             .drawBehind {
                 if (amoled) return@drawBehind
                 drawRect(
                     Brush.radialGradient(
-                        listOf(scheme.secondary.copy(alpha = if (dark) .15f else .24f), Color.Transparent),
-                        center = Offset(size.width * .9f, size.height * .06f),
-                        radius = size.width * .72f
-                    )
-                )
-                drawRect(
-                    Brush.radialGradient(
-                        listOf(scheme.primary.copy(alpha = if (dark) .12f else .18f), Color.Transparent),
-                        center = Offset(size.width * .02f, size.height * .54f),
-                        radius = size.width * .82f
-                    )
-                )
-                drawRect(
-                    Brush.radialGradient(
-                        listOf(scheme.tertiary.copy(alpha = if (dark) .06f else .12f), Color.Transparent),
-                        center = Offset(size.width, size.height),
-                        radius = size.width * .72f
+                        listOf(scheme.primary.copy(alpha = if (dark) .05f else .06f), Color.Transparent),
+                        center = Offset(size.width * .85f, 0f),
+                        radius = size.width * .9f
                     )
                 )
             }
@@ -618,7 +462,7 @@ private fun MiuiXBackdrop(dark: Boolean, amoled: Boolean) {
 @Composable
 private fun GlassSurface(
     modifier: Modifier = Modifier,
-    shape: RoundedCornerShape = RoundedCornerShape(30.dp),
+    shape: Shape = RoundedCornerShape(28.dp),
     shadow: Int = 10,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable () -> Unit
@@ -628,10 +472,7 @@ private fun GlassSurface(
     val amoled = dark && settings.amoledBlack
     val glass = settings.glassEnabled
     val fill = when {
-        amoled -> Color(0xFF080808)
-        dark && glass -> Color(0xFF1B1D25)
-        dark -> MaterialTheme.colorScheme.surface
-        glass -> Color(0xFFF9F9FD)
+        amoled || glass -> BaiZeTokens.colors.surfaceRaised
         else -> MaterialTheme.colorScheme.surface
     }
     val border = if (dark) Color.White.copy(alpha = .08f) else MaterialTheme.colorScheme.primary.copy(alpha = .08f)
@@ -648,7 +489,7 @@ private fun GlassSurface(
 @Composable
 private fun ResultSurface(
     modifier: Modifier = Modifier,
-    shape: RoundedCornerShape = RoundedCornerShape(26.dp),
+    shape: RoundedCornerShape = RoundedCornerShape(28.dp),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     content: @Composable () -> Unit
 ) {
@@ -672,18 +513,18 @@ private fun PageHeader(eyebrow: String, title: String, subtitle: String, refresh
     Row(
         Modifier
             .fillMaxWidth()
-            .padding(horizontal = 22.dp, vertical = 14.dp),
+            .padding(horizontal = BaiZeTokens.spacing.pageHorizontal, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(Modifier.weight(1f)) {
-            Text(eyebrow.uppercase(), color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
-            Spacer(Modifier.height(5.dp))
-            Text(title, color = MaterialTheme.colorScheme.onSurface, fontSize = 34.sp, lineHeight = 38.sp, fontWeight = FontWeight.Black)
+            Text(eyebrow.uppercase(), color = MaterialTheme.colorScheme.primary, fontSize = 11.sp, fontWeight = FontWeight.Bold, letterSpacing = 2.sp)
+            Spacer(Modifier.height(4.dp))
+            Text(title, color = MaterialTheme.colorScheme.onSurface, style = BaiZeTokens.type.display)
             Spacer(Modifier.height(4.dp))
             Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp, fontWeight = FontWeight.Medium)
         }
         if (refresh != null) {
-            GlassSurface(shape = RoundedCornerShape(18.dp), shadow = 6) {
+            GlassSurface(shape = BaiZeTokens.corners.medium, shadow = 6) {
                 IconButton(onClick = refresh, modifier = Modifier.size(58.dp)) {
                     Icon(Icons.Rounded.Refresh, contentDescription = "刷新", modifier = Modifier.size(27.dp))
                 }
@@ -718,7 +559,7 @@ internal fun HomeScreenMiuix(
             PageHeader(
                 "SMART CLEAN",
                 "白泽",
-                "Miuix · ${io.github.xgl34222220.baize.performance.PerformanceRuntime.statusLine()} · v${BuildConfig.VERSION_NAME}",
+                "智能清理概览 · v${BuildConfig.VERSION_NAME}",
                 actions.refresh
             )
         }
@@ -730,15 +571,15 @@ internal fun HomeScreenMiuix(
                 taskPhase = state.taskPhase,
                 releasedText = Formatter.formatFileSize(context, state.lastReleased),
                 positive = positive,
-                modifier = Modifier.padding(horizontal = 18.dp)
+                modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal)
             )
         }
         item {
             GlassSurface(
-                modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
-                shape = RoundedCornerShape(30.dp),
+                modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
+                shape = RoundedCornerShape(28.dp),
                 shadow = 6,
-                contentPadding = PaddingValues(18.dp)
+                contentPadding = PaddingValues(BaiZeTokens.spacing.xl)
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     StorageRing(state.storagePercent)
@@ -752,9 +593,9 @@ internal fun HomeScreenMiuix(
                         )
                         Text(
                             Formatter.formatFileSize(context, state.storageFree),
-                            fontSize = 31.sp,
-                            lineHeight = 35.sp,
-                            fontWeight = FontWeight.Black
+                            fontSize = 28.sp,
+                            lineHeight = 34.sp,
+                            fontWeight = FontWeight.Bold
                         )
                         Text(
                             "已用 ${Formatter.formatFileSize(context, state.storageUsed)} · 共 ${Formatter.formatFileSize(context, state.storageTotal)}",
@@ -775,7 +616,7 @@ internal fun HomeScreenMiuix(
                     state.scanCompleted -> actions.cleanScan
                     else -> actions.clean
                 },
-                modifier = Modifier.padding(horizontal = 18.dp)
+                modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal)
             )
         }
         item {
@@ -793,15 +634,15 @@ internal fun HomeScreenMiuix(
             item { ScanResultCard(state, actions) }
         }
         item {
-            Column(Modifier.padding(horizontal = 22.dp, vertical = 5.dp)) {
+            Column(Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal, vertical = 5.dp)) {
                 Text(
                     "QUICK ACTIONS",
                     color = MaterialTheme.colorScheme.primary,
-                    fontSize = 10.sp,
+                    fontSize = 11.sp,
                     fontWeight = FontWeight.Bold,
                     letterSpacing = 2.sp
                 )
-                Text("快捷操作", fontSize = 27.sp, fontWeight = FontWeight.Black)
+                Text("快捷操作", style = BaiZeTokens.type.headline)
                 Text(
                     "完整清理类别、开关与周期统一放在“清理”页",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -811,8 +652,8 @@ internal fun HomeScreenMiuix(
         }
         item {
             GlassSurface(
-                Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
-                shape = RoundedCornerShape(30.dp),
+                Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
+                shape = RoundedCornerShape(28.dp),
                 shadow = 6,
                 contentPadding = PaddingValues(10.dp)
             ) {
@@ -846,7 +687,7 @@ private fun MiuixHomeQuickAction(
 ) {
     Column(
         modifier = modifier
-            .clip(RoundedCornerShape(22.dp))
+            .clip(BaiZeTokens.corners.medium)
             .clickable(onClick = onClick)
             .padding(horizontal = 5.dp, vertical = 12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -855,7 +696,7 @@ private fun MiuixHomeQuickAction(
         Box(
             Modifier
                 .size(46.dp)
-                .clip(RoundedCornerShape(16.dp))
+                .clip(RoundedCornerShape(12.dp))
                 .background(MaterialTheme.colorScheme.primary.copy(alpha = .12f)),
             contentAlignment = Alignment.Center
         ) {
@@ -874,9 +715,10 @@ private fun MiuixHomeQuickAction(
 @Composable
 private fun StorageRing(progress: Float) {
     val primary = MaterialTheme.colorScheme.primary
+    val trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .10f)
     Box(Modifier.size(88.dp), contentAlignment = Alignment.Center) {
         Canvas(Modifier.fillMaxSize()) {
-            drawArc(Color(0xFFDDE4F1), -90f, 360f, false, style = Stroke(9.dp.toPx(), cap = StrokeCap.Round))
+            drawArc(trackColor, -90f, 360f, false, style = Stroke(9.dp.toPx(), cap = StrokeCap.Round))
             drawArc(primary, -90f, 360f * progress, false, style = Stroke(9.dp.toPx(), cap = StrokeCap.Round))
         }
         Text("${(progress * 100).roundToInt()}%", fontWeight = FontWeight.Bold, color = MaterialTheme.colorScheme.primary)
@@ -886,14 +728,14 @@ private fun StorageRing(progress: Float) {
 @Composable
 private fun StatusPill(ready: Boolean, text: String, scanReady: Boolean = false) {
     GlassSurface(
-        Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
-        shape = RoundedCornerShape(24.dp),
+        Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
+        shape = RoundedCornerShape(percent = 50),
         shadow = 5,
-        contentPadding = PaddingValues(horizontal = 18.dp, vertical = 14.dp)
+        contentPadding = PaddingValues(horizontal = BaiZeTokens.spacing.pageHorizontal, vertical = 14.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             val positive = ready || scanReady
-            Box(Modifier.size(10.dp).clip(CircleShape).background(if (positive) SuccessGreen else Color(0xFFF2A93B)))
+            Box(Modifier.size(10.dp).clip(CircleShape).background(if (positive) BaiZeTokens.colors.success else BaiZeTokens.colors.warning))
             Spacer(Modifier.width(10.dp))
             Text(text, modifier = Modifier.weight(1f), fontSize = 12.sp, fontWeight = FontWeight.SemiBold, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Text(
@@ -913,7 +755,7 @@ private fun StatusPill(ready: Boolean, text: String, scanReady: Boolean = false)
 private fun ScanResultCard(state: DashboardUiState, actions: DashboardActions) {
     val context = LocalContext.current
     GlassSurface(
-        Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
+        Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
         shape = RoundedCornerShape(28.dp),
         shadow = 8,
         contentPadding = PaddingValues(20.dp)
@@ -921,7 +763,7 @@ private fun ScanResultCard(state: DashboardUiState, actions: DashboardActions) {
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Box(
-                    Modifier.size(48.dp).clip(RoundedCornerShape(16.dp))
+                    Modifier.size(48.dp).clip(RoundedCornerShape(12.dp))
                         .background(MaterialTheme.colorScheme.primary.copy(.14f)),
                     contentAlignment = Alignment.Center
                 ) {
@@ -929,7 +771,7 @@ private fun ScanResultCard(state: DashboardUiState, actions: DashboardActions) {
                 }
                 Spacer(Modifier.width(13.dp))
                 Column(Modifier.weight(1f)) {
-                    Text("清理准备完成", fontSize = 19.sp, fontWeight = FontWeight.Black)
+                    Text("清理准备完成", style = BaiZeTokens.type.title, fontWeight = FontWeight.Bold)
                     Text(
                         when {
                             state.scanFiles <= 0 -> "没有发现可安全清理的内容"
@@ -952,7 +794,7 @@ private fun ScanResultCard(state: DashboardUiState, actions: DashboardActions) {
                 Button(
                     onClick = actions.dismissScan,
                     modifier = Modifier.weight(1f).height(52.dp),
-                    shape = RoundedCornerShape(19.dp),
+                    shape = RoundedCornerShape(20.dp),
                     colors = ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.onSurface.copy(.07f),
                         contentColor = MaterialTheme.colorScheme.onSurface
@@ -962,7 +804,7 @@ private fun ScanResultCard(state: DashboardUiState, actions: DashboardActions) {
                     onClick = actions.cleanScan,
                     enabled = state.scanFiles > 0 && !state.running,
                     modifier = Modifier.weight(1.45f).height(52.dp),
-                    shape = RoundedCornerShape(19.dp),
+                    shape = RoundedCornerShape(20.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
                 ) {
                     Icon(Icons.Rounded.AutoAwesome, null, modifier = Modifier.size(18.dp))
@@ -972,9 +814,9 @@ private fun ScanResultCard(state: DashboardUiState, actions: DashboardActions) {
             }
             Text(
                 "点击后直接消费本次快照，不会重新扫描；删除前只复核路径、白名单、挂载点和文件状态。快照 30 分钟后自动失效。",
-                modifier = Modifier.padding(top = 11.dp),
+                modifier = Modifier.padding(top = 12.dp),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp
+                fontSize = 11.sp
             )
         }
     }
@@ -1006,8 +848,8 @@ private fun MaterialFloatingDock(
         modifier = outerModifier,
         shape = shape,
         color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = .96f),
-        tonalElevation = if (floating) 10.dp else 5.dp,
-        shadowElevation = if (floating) 18.dp else 8.dp
+        tonalElevation = if (floating) 3.dp else 1.dp,
+        shadowElevation = if (floating) 8.dp else 4.dp
     ) {
         BoxWithConstraints(
             modifier = Modifier
@@ -1072,7 +914,7 @@ private fun MaterialFloatingDock(
                         Text(
                             text = item.title,
                             color = textColor,
-                            fontSize = 10.sp,
+                            fontSize = 11.sp,
                             fontWeight = if (active) FontWeight.Bold else FontWeight.Medium
                         )
                     }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/appearance/AppearanceSettings.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/appearance/AppearanceSettings.kt
@@ -55,15 +55,16 @@ data class AccentOption(
     val argb: Int
 )
 
+// 低饱和高级色为主，保留「白泽蓝」「霞光橘」两个较饱和选项给喜欢鲜艳的用户。
 val AccentOptions = listOf(
-    AccentOption("default", "白泽蓝", 0xFF3975F4.toInt()),
-    AccentOption("red", "朱红", 0xFFC70018.toInt()),
-    AccentOption("pink", "玫粉", 0xFFC50056.toInt()),
-    AccentOption("purple", "曜紫", 0xFFAF00C7.toInt()),
-    AccentOption("deep_purple", "深紫", 0xFF7900F5.toInt()),
-    AccentOption("indigo", "靛蓝", 0xFF1559F4.toInt()),
-    AccentOption("blue", "湖蓝", 0xFF0A79B8.toInt()),
-    AccentOption("light_blue", "青蓝", 0xFF0080A0.toInt())
+    AccentOption("default", "雾蓝", 0xFF7C93AB.toInt()),
+    AccentOption("sage", "鼠尾草绿", 0xFF8FA98F.toInt()),
+    AccentOption("sand", "暖沙", 0xFFC2AE8B.toInt()),
+    AccentOption("terracotta", "陶土", 0xFFBE8A72.toInt()),
+    AccentOption("mauve", "雾霾紫", 0xFFA494B8.toInt()),
+    AccentOption("slate", "岩青", 0xFF7FA3A8.toInt()),
+    AccentOption("azure", "白泽蓝", 0xFF3975F4.toInt()),
+    AccentOption("amber", "霞光橘", 0xFFD98E4A.toInt())
 )
 
 fun accentOptionFor(argb: Int): AccentOption =
@@ -74,7 +75,7 @@ data class AppearanceSettings(
     val uiStyle: UiStyle = UiStyle.MIUIX,
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val seedArgb: Int = AccentOptions.first().argb,
-    val kolorStyle: KolorStyle = KolorStyle.VIBRANT,
+    val kolorStyle: KolorStyle = KolorStyle.SOFT,
     val monetEnabled: Boolean = false,
     val amoledBlack: Boolean = false,
     val blurEnabled: Boolean = true,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/CleanScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/CleanScreenMiuix.kt
@@ -52,11 +52,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -64,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.clean.CleanCategoryId
 import io.github.xgl34222220.baize.ui.clean.CleanCategoryUiItem
@@ -228,16 +225,14 @@ private fun MiuixCleanHeader() {
         Text(
             "清理分类",
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.2.sp
         )
         Spacer(Modifier.height(4.dp))
         Text(
             "清理中心",
-            fontSize = 36.sp,
-            lineHeight = 40.sp,
-            fontWeight = FontWeight.Black
+            style = BaiZeTokens.type.display
         )
         Text(
             "选择类别、周期和手动清理工具",
@@ -257,7 +252,7 @@ private fun MiuixCleanOverview(
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.background.luminance() < .5f
     val amoled = dark && settings.amoledBlack
-    val shape = RoundedCornerShape(34.dp)
+    val shape = RoundedCornerShape(36.dp)
     val status = when {
         state.running -> "清理任务执行中"
         state.scanSnapshotReady -> "扫描快照已就绪"
@@ -268,37 +263,16 @@ private fun MiuixCleanOverview(
     Box(
         modifier
             .fillMaxWidth()
-            .shadow(10.dp, shape, clip = false)
             .clip(shape)
             .background(
                 when {
-                    amoled -> Color(0xFF090909)
+                    amoled -> BaiZeTokens.colors.surfaceRaised
                     dark -> scheme.surfaceContainerHigh
                     else -> scheme.surface
                 }
             )
             .border(1.dp, scheme.onSurface.copy(alpha = .06f), shape)
-            .drawBehind {
-                if (!amoled) {
-                    drawCircle(
-                        brush = Brush.radialGradient(
-                            listOf(scheme.primary.copy(alpha = if (dark) .20f else .15f), Color.Transparent),
-                            center = Offset(size.width, 0f),
-                            radius = size.width * .72f
-                        ),
-                        radius = size.width * .72f,
-                        center = Offset(size.width, 0f)
-                    )
-                }
-                drawRoundRect(
-                    brush = Brush.verticalGradient(
-                        listOf(Color.White.copy(alpha = if (dark) .05f else .30f), Color.Transparent)
-                    ),
-                    cornerRadius = CornerRadius(34.dp.toPx()),
-                    size = size.copy(height = size.height * .42f)
-                )
-            }
-            .padding(22.dp)
+            .padding(BaiZeTokens.spacing.xxl)
     ) {
         Column {
             Text(
@@ -310,9 +284,7 @@ private fun MiuixCleanOverview(
             Row(verticalAlignment = Alignment.Bottom) {
                 Text(
                     state.enabledCategoryCount.toString(),
-                    fontSize = 46.sp,
-                    lineHeight = 48.sp,
-                    fontWeight = FontWeight.Black
+                    style = BaiZeTokens.type.hero
                 )
                 Text(
                     " / ${state.categories.size} 类",
@@ -326,9 +298,9 @@ private fun MiuixCleanOverview(
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(21.dp))
+                    .clip(RoundedCornerShape(20.dp))
                     .background(scheme.onSurface.copy(alpha = if (dark) .055f else .04f))
-                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Box(
@@ -336,8 +308,8 @@ private fun MiuixCleanOverview(
                         .size(10.dp)
                         .clip(CircleShape)
                         .background(
-                            if (state.engineReady || state.scanSnapshotReady) Color(0xFF2DBE87)
-                            else Color(0xFFF2A93B)
+                            if (state.engineReady || state.scanSnapshotReady) BaiZeTokens.colors.success
+                            else BaiZeTokens.colors.warning
                         )
                 )
                 Spacer(Modifier.width(10.dp))
@@ -346,7 +318,7 @@ private fun MiuixCleanOverview(
                     Text(
                         state.serviceText,
                         color = scheme.onSurfaceVariant,
-                        fontSize = 10.sp,
+                        fontSize = 11.sp,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -365,15 +337,15 @@ private fun MiuixGroupCard(
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.background.luminance() < .5f
     val amoled = dark && settings.amoledBlack
-    val shape = RoundedCornerShape(30.dp)
+    val shape = RoundedCornerShape(28.dp)
     Column(
         modifier
             .fillMaxWidth()
-            .shadow(6.dp, shape, clip = false)
+            .shadow(2.dp, shape, clip = false)
             .clip(shape)
             .background(
                 when {
-                    amoled -> Color(0xFF090909)
+                    amoled -> BaiZeTokens.colors.surfaceRaised
                     dark -> scheme.surfaceContainer
                     else -> scheme.surface
                 }
@@ -406,7 +378,7 @@ private fun MiuixMasterSwitchRow(
             Text(
                 subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -432,7 +404,7 @@ private fun MiuixDailyScheduleRow(
                     if (state.dailyEnabled) "每天 ${state.dailyTimeText}，替代各类别小时周期"
                     else "关闭时按每个类别的独立小时周期执行",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp,
+                    fontSize = 11.sp,
                     lineHeight = 14.sp
                 )
             }
@@ -492,7 +464,7 @@ private fun MiuixCategoryRow(
                 Text(
                     item.description,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp,
+                    fontSize = 11.sp,
                     lineHeight = 14.sp,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
@@ -510,7 +482,7 @@ private fun MiuixCategoryRow(
                 Modifier
                     .padding(start = 58.dp)
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(15.dp))
+                    .clip(RoundedCornerShape(12.dp))
                     .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .045f))
                     .clickable(onClick = onToggleExpanded)
                     .padding(horizontal = 13.dp, vertical = 10.dp),
@@ -528,13 +500,13 @@ private fun MiuixCategoryRow(
                         if (dailyMode) "关闭每日模式后恢复当前独立周期"
                         else if (expanded) "点击收起周期设置" else "点击展开周期设置",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 9.sp
+                        fontSize = 11.sp
                     )
                 }
                 Text(
                     if (expanded) "收起设置" else "展开设置",
                     color = MaterialTheme.colorScheme.primary,
-                    fontSize = 10.sp,
+                    fontSize = 11.sp,
                     fontWeight = FontWeight.Bold
                 )
                 Spacer(Modifier.width(4.dp))
@@ -555,7 +527,7 @@ private fun MiuixCategoryRow(
                         val active = item.intervalMinutes == minutes
                         Box(
                             Modifier
-                                .clip(RoundedCornerShape(13.dp))
+                                .clip(RoundedCornerShape(12.dp))
                                 .background(
                                     if (active) MaterialTheme.colorScheme.primary.copy(alpha = .16f)
                                     else MaterialTheme.colorScheme.onSurface.copy(alpha = .05f)
@@ -567,7 +539,7 @@ private fun MiuixCategoryRow(
                                 formatMinutes(minutes),
                                 color = if (active) MaterialTheme.colorScheme.primary
                                 else MaterialTheme.colorScheme.onSurfaceVariant,
-                                fontSize = 10.sp,
+                                fontSize = 11.sp,
                                 fontWeight = FontWeight.Bold
                             )
                         }
@@ -578,7 +550,7 @@ private fun MiuixCategoryRow(
                     Modifier
                         .padding(start = 58.dp)
                         .fillMaxWidth()
-                        .clip(RoundedCornerShape(15.dp))
+                        .clip(RoundedCornerShape(12.dp))
                         .background(MaterialTheme.colorScheme.primary.copy(alpha = .09f))
                         .clickable(onClick = { showIntervalDialog = true })
                         .padding(horizontal = 13.dp, vertical = 10.dp),
@@ -602,10 +574,10 @@ private fun MiuixCategoryRow(
                             if (dailyMode) "每日模式开启时暂不使用，关闭后恢复"
                             else "每 ${formatMinutes(item.intervalMinutes)}执行一次",
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            fontSize = 9.sp
+                            fontSize = 11.sp
                         )
                     }
-                    Text("修改", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                    Text("修改", color = MaterialTheme.colorScheme.primary, fontSize = 11.sp, fontWeight = FontWeight.Bold)
                 }
             }
         }
@@ -621,13 +593,13 @@ private fun MiuixScheduleValueButton(
 ) {
     Column(
         modifier
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.primary.copy(alpha = .10f))
             .clickable(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 10.dp)
     ) {
-        Text(title, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp)
-        Text(value, color = MaterialTheme.colorScheme.primary, fontSize = 13.sp, fontWeight = FontWeight.Black)
+        Text(title, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+        Text(value, color = MaterialTheme.colorScheme.primary, fontSize = 13.sp, fontWeight = FontWeight.Bold)
     }
 }
 
@@ -647,7 +619,7 @@ private fun MiuixQuickActionRow(action: MiuixQuickAction) {
             Text(
                 action.subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -666,7 +638,7 @@ private fun MiuixIconTile(icon: ImageVector) {
     Box(
         Modifier
             .size(45.dp)
-            .clip(RoundedCornerShape(15.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(MaterialTheme.colorScheme.primary.copy(alpha = .11f)),
         contentAlignment = Alignment.Center
     ) {
@@ -718,35 +690,20 @@ private fun MiuixSaveButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val shape = RoundedCornerShape(24.dp)
     Box(
         modifier
             .fillMaxWidth()
-            .height(62.dp)
-            .shadow(10.dp, shape, clip = false)
-            .clip(shape)
-            .background(
-                Brush.horizontalGradient(
-                    listOf(MaterialTheme.colorScheme.primary, MaterialTheme.colorScheme.tertiary)
-                )
-            )
-            .drawBehind {
-                drawRoundRect(
-                    brush = Brush.verticalGradient(
-                        listOf(Color.White.copy(alpha = .28f), Color.Transparent)
-                    ),
-                    cornerRadius = CornerRadius(24.dp.toPx()),
-                    size = size.copy(height = size.height * .54f)
-                )
-            }
+            .height(60.dp)
+            .clip(BaiZeTokens.corners.full)
+            .background(MaterialTheme.colorScheme.primary)
             .clickable(enabled = !saving, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Text(
             if (saving) "正在保存…" else "保存自动清理设置",
-            color = Color.White,
+            color = MaterialTheme.colorScheme.onPrimary,
             fontSize = 17.sp,
-            fontWeight = FontWeight.Black
+            fontWeight = FontWeight.Bold
         )
     }
 }
@@ -757,19 +714,19 @@ private fun MiuixSectionHeader(
     title: String,
     subtitle: String
 ) {
-    Column(Modifier.padding(horizontal = 21.dp, vertical = 5.dp)) {
+    Column(Modifier.padding(horizontal = 20.dp, vertical = 4.dp)) {
         Text(
             eyebrow,
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.sp
         )
-        Text(title, fontSize = 27.sp, lineHeight = 31.sp, fontWeight = FontWeight.Black)
+        Text(title, color = MaterialTheme.colorScheme.onSurface, style = BaiZeTokens.type.headline)
         Text(
             subtitle,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontSize = 10.sp
+            fontSize = 11.sp
         )
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/common/AppPackageIcon.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/common/AppPackageIcon.kt
@@ -55,7 +55,7 @@ fun AppPackageIcon(
         if (current != null) {
             Image(current.asImageBitmap(), null, Modifier.fillMaxSize(), contentScale = ContentScale.Fit)
         } else {
-            Text(label.trim().firstOrNull()?.uppercase() ?: "?", fontWeight = FontWeight.Black)
+            Text(label.trim().firstOrNull()?.uppercase() ?: "?", fontWeight = FontWeight.Bold)
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/HistoryScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/HistoryScreenMiuix.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import io.github.xgl34222220.baize.AppJunkUiItem
 import io.github.xgl34222220.baize.GeneralJunkUiItem
 import io.github.xgl34222220.baize.HistoryUiItem
@@ -140,7 +141,7 @@ fun HistoryScreenMiuix(
             item(key = "protected-action", contentType = "action") {
                 Button(
                     onClick = actions.onReviewProtected,
-                    modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth()
+                    modifier = Modifier.padding(horizontal = 20.dp).fillMaxWidth()
                 ) {
                     Icon(Icons.Rounded.Shield, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
@@ -178,7 +179,7 @@ private fun HistoryHeader(canClear: Boolean, actions: HistoryUiActions) {
             Text(
                 "CLEAN HISTORY",
                 color = MaterialTheme.colorScheme.primary,
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
                 letterSpacing = 2.2.sp
             )
@@ -188,10 +189,10 @@ private fun HistoryHeader(canClear: Boolean, actions: HistoryUiActions) {
                 color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 34.sp,
                 lineHeight = 38.sp,
-                fontWeight = FontWeight.Black
+                fontWeight = FontWeight.Bold
             )
             Text(
-                "轻量列表 · 无逐卡片阴影",
+                "每次清理的结果与累计统计",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 11.sp,
                 fontWeight = FontWeight.Medium
@@ -207,7 +208,7 @@ private fun HistoryHeader(canClear: Boolean, actions: HistoryUiActions) {
 private fun HeaderButton(icon: ImageVector, description: String, enabled: Boolean, onClick: () -> Unit) {
     Surface(
         modifier = Modifier.size(50.dp),
-        shape = RoundedCornerShape(18.dp),
+        shape = RoundedCornerShape(20.dp),
         color = MaterialTheme.colorScheme.surface,
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = .06f))
     ) {
@@ -227,7 +228,7 @@ private fun HistoryOverview(state: HistoryUiState) {
                     Modifier
                         .size(9.dp)
                         .clip(CircleShape)
-                        .background(if (state.lifetimeRuns > 0) Color(0xFF2DBE87) else Color(0xFFF2A93B))
+                        .background(if (state.lifetimeRuns > 0) BaiZeTokens.colors.success else BaiZeTokens.colors.warning)
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(
@@ -243,13 +244,13 @@ private fun HistoryOverview(state: HistoryUiState) {
                 Formatter.formatFileSize(context, state.lifetimeReleased),
                 fontSize = 39.sp,
                 lineHeight = 43.sp,
-                fontWeight = FontWeight.Black
+                fontWeight = FontWeight.Bold
             )
             Spacer(Modifier.height(17.dp))
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(21.dp))
+                    .clip(RoundedCornerShape(20.dp))
                     .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .04f))
                     .padding(horizontal = 13.dp, vertical = 12.dp),
                 horizontalArrangement = Arrangement.SpaceBetween
@@ -265,8 +266,8 @@ private fun HistoryOverview(state: HistoryUiState) {
 @Composable
 private fun Metric(value: String, label: String) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(value, fontSize = 14.sp, fontWeight = FontWeight.Black)
-        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp)
+        Text(value, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
     }
 }
 
@@ -281,21 +282,21 @@ private fun CurrentSummary(state: HistoryUiState) {
             IconTile(Icons.Rounded.CheckCircle, false)
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
-                Text("本次结果", fontSize = 17.sp, fontWeight = FontWeight.Black)
+                Text("本次结果", fontSize = 17.sp, fontWeight = FontWeight.Bold)
                 if (state.lastTaskTime.isNotBlank()) {
-                    Text("执行时间 ${state.lastTaskTime}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                    Text("执行时间 ${state.lastTaskTime}", color = MaterialTheme.colorScheme.primary, fontSize = 11.sp, fontWeight = FontWeight.Bold)
                 }
                 Text(
                     "${state.currentItemCount} 项 · ${state.recentApps.size} 个应用 · ${state.recentJunk.size} 类其他垃圾",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp
+                    fontSize = 11.sp
                 )
             }
             Text(
                 Formatter.formatFileSize(context, state.currentBytes),
                 color = MaterialTheme.colorScheme.primary,
                 fontSize = 17.sp,
-                fontWeight = FontWeight.Black
+                fontWeight = FontWeight.Bold
             )
         }
     }
@@ -378,14 +379,14 @@ private fun ResultHeader(
             Text(
                 subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 9.sp,
+                fontSize = 11.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
         }
         Column(horizontalAlignment = Alignment.End) {
-            Text(bytes, color = MaterialTheme.colorScheme.primary, fontSize = 14.sp, fontWeight = FontWeight.Black)
-            Text(meta, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp)
+            Text(bytes, color = MaterialTheme.colorScheme.primary, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+            Text(meta, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
         }
         if (expandable) {
             Spacer(Modifier.width(4.dp))
@@ -405,7 +406,7 @@ private fun ProtectedResultCard(item: ProtectedUiItem) {
     GroupSurface {
         Row(Modifier.padding(horizontal = 16.dp, vertical = 14.dp), verticalAlignment = Alignment.Top) {
             Box(
-                Modifier.size(46.dp).clip(RoundedCornerShape(16.dp)).background(tint.copy(alpha = .12f)),
+                Modifier.size(46.dp).clip(RoundedCornerShape(12.dp)).background(tint.copy(alpha = .12f)),
                 contentAlignment = Alignment.Center
             ) {
                 Icon(if (item.selectable) Icons.Rounded.Shield else Icons.Rounded.Lock, null, tint = tint)
@@ -413,16 +414,16 @@ private fun ProtectedResultCard(item: ProtectedUiItem) {
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
                 Text(item.category.ifBlank { "受保护项目" }, fontSize = 15.sp, fontWeight = FontWeight.Bold)
-                Text(item.reason.ifBlank { "未提供保护原因" }, color = tint, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                Text(item.reason.ifBlank { "未提供保护原因" }, color = tint, fontSize = 11.sp, fontWeight = FontWeight.Bold)
                 Text(
                     item.path,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
-                    fontSize = 9.sp,
+                    fontSize = 11.sp,
                     lineHeight = 14.sp
                 )
             }
-            Text(if (item.selectable) "可复查" else "硬保护", color = tint, fontSize = 9.sp, fontWeight = FontWeight.Black)
+            Text(if (item.selectable) "可复查" else "硬保护", color = tint, fontSize = 11.sp, fontWeight = FontWeight.Bold)
         }
     }
 }
@@ -455,14 +456,14 @@ private fun RecordCard(item: HistoryUiItem) {
                     Text(
                         "${item.time} · ${item.trigger}",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 9.sp,
+                        fontSize = 11.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         summary,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 10.sp,
+                        fontSize = 11.sp,
                         maxLines = if (expanded) 4 else 2,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -472,9 +473,9 @@ private fun RecordCard(item: HistoryUiItem) {
                         Formatter.formatFileSize(context, item.bytes),
                         color = MaterialTheme.colorScheme.primary,
                         fontSize = 14.sp,
-                        fontWeight = FontWeight.Black
+                        fontWeight = FontWeight.Bold
                     )
-                    Text(historyStatus(item), color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp)
+                    Text(historyStatus(item), color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
                 }
                 if (hasDetails) {
                     Spacer(Modifier.width(4.dp))
@@ -515,16 +516,16 @@ private fun DetailRow(title: String, subtitle: String, value: String) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(Modifier.weight(1f)) {
-            Text(title, fontSize = 10.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(title, fontSize = 11.sp, fontWeight = FontWeight.Bold, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(
                 subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 8.sp,
+                fontSize = 11.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
         }
-        Text(value, color = MaterialTheme.colorScheme.primary, fontSize = 9.sp)
+        Text(value, color = MaterialTheme.colorScheme.primary, fontSize = 11.sp)
     }
 }
 
@@ -542,7 +543,7 @@ private fun EmptyHistoryCard() {
                 tint = MaterialTheme.colorScheme.primary
             )
             Spacer(Modifier.height(10.dp))
-            Text("还没有清理记录", fontSize = 18.sp, fontWeight = FontWeight.Black)
+            Text("还没有清理记录", fontSize = 18.sp, fontWeight = FontWeight.Bold)
             Text(
                 "完成一次扫描或清理后，这里会显示垃圾分类、涉及应用和释放空间。",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -558,7 +559,7 @@ private fun IconTile(icon: ImageVector, error: Boolean) {
     Box(
         Modifier
             .size(46.dp)
-            .clip(RoundedCornerShape(16.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(if (error) scheme.errorContainer else scheme.primary.copy(alpha = .11f)),
         contentAlignment = Alignment.Center
     ) {
@@ -580,13 +581,13 @@ private fun GroupSurface(
     val dark = scheme.background.luminance() < .5f
     val amoled = dark && settings.amoledBlack
     val background = when {
-        amoled -> Color(0xFF080808)
+        amoled -> BaiZeTokens.colors.surfaceRaised
         dark -> scheme.surfaceContainerHigh
         else -> scheme.surface
     }
     Surface(
-        modifier = modifier.padding(horizontal = 18.dp).fillMaxWidth(),
-        shape = RoundedCornerShape(27.dp),
+        modifier = modifier.padding(horizontal = 20.dp).fillMaxWidth(),
+        shape = RoundedCornerShape(28.dp),
         color = background,
         tonalElevation = 0.dp,
         shadowElevation = 0.dp,
@@ -596,16 +597,16 @@ private fun GroupSurface(
 
 @Composable
 private fun SectionTitle(eyebrow: String, title: String, subtitle: String) {
-    Column(Modifier.padding(horizontal = 22.dp, vertical = 3.dp)) {
+    Column(Modifier.padding(horizontal = 20.dp, vertical = 3.dp)) {
         Text(
             eyebrow,
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.sp
         )
-        Text(title, fontSize = 26.sp, lineHeight = 30.sp, fontWeight = FontWeight.Black)
-        Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+        Text(title, fontSize = 26.sp, lineHeight = 30.sp, fontWeight = FontWeight.Bold)
+        Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
     }
 }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/material/HomeScreenMaterial.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/material/HomeScreenMaterial.kt
@@ -2,7 +2,6 @@ package io.github.xgl34222220.baize.ui.home.material
 
 import android.text.format.Formatter
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -45,7 +44,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -59,6 +57,7 @@ import io.github.xgl34222220.baize.BuildConfig
 import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 private data class MaterialCleanCategory(
     val icon: ImageVector,
@@ -85,21 +84,12 @@ fun HomeScreenMaterial(
                 if (!settings.glassEnabled) return@drawBehind
                 drawCircle(
                     brush = Brush.radialGradient(
-                        colors = listOf(scheme.primary.copy(alpha = .15f), Color.Transparent),
+                        colors = listOf(scheme.primary.copy(alpha = .06f), Color.Transparent),
                         center = Offset(size.width, 0f),
                         radius = size.width * .82f
                     ),
                     radius = size.width * .82f,
                     center = Offset(size.width, 0f)
-                )
-                drawCircle(
-                    brush = Brush.radialGradient(
-                        colors = listOf(scheme.tertiary.copy(alpha = .11f), Color.Transparent),
-                        center = Offset(0f, size.height * .58f),
-                        radius = size.width
-                    ),
-                    radius = size.width,
-                    center = Offset(0f, size.height * .58f)
                 )
             }
     ) {
@@ -133,14 +123,14 @@ private fun MaterialPageHeader(onRefresh: () -> Unit) {
             Text(
                 "SMART CLEAN",
                 color = MaterialTheme.colorScheme.primary,
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
                 letterSpacing = 2.4.sp
             )
-            Spacer(Modifier.height(5.dp))
+            Spacer(Modifier.height(4.dp))
             Text("白泽", style = MaterialTheme.typography.headlineLarge)
             Text(
-                "Material 3 清理概览 · v${BuildConfig.VERSION_NAME}",
+                "智能清理概览 · v${BuildConfig.VERSION_NAME}",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 style = MaterialTheme.typography.bodyMedium
             )
@@ -163,23 +153,15 @@ private fun MaterialHeroCard(state: DashboardUiState) {
         else -> "正在连接清理引擎"
     }
 
+    val container = scheme.primaryContainer
+    val onContainer = scheme.onPrimaryContainer
     Box(
         Modifier
-            .padding(horizontal = 18.dp)
+            .padding(horizontal = BaiZeTokens.spacing.pageHorizontal)
             .fillMaxWidth()
-            .shadow(16.dp, MaterialTheme.shapes.extraLarge)
-            .clip(MaterialTheme.shapes.extraLarge)
-            .background(Brush.linearGradient(listOf(scheme.primary, scheme.tertiary)))
-            .border(1.dp, Color.White.copy(alpha = .22f), MaterialTheme.shapes.extraLarge)
-            .drawBehind {
-                drawRect(
-                    brush = Brush.verticalGradient(
-                        listOf(Color.White.copy(alpha = .23f), Color.Transparent)
-                    ),
-                    size = size.copy(height = size.height * .43f)
-                )
-            }
-            .padding(24.dp)
+            .clip(BaiZeTokens.corners.large)
+            .background(container)
+            .padding(BaiZeTokens.spacing.xxl)
     ) {
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -187,28 +169,28 @@ private fun MaterialHeroCard(state: DashboardUiState) {
                     Modifier
                         .size(10.dp)
                         .clip(CircleShape)
-                        .background(if (state.ready || state.scanCompleted) Color(0xFF78EEB8) else Color(0xFFFFD36F))
+                        .background(if (state.ready || state.scanCompleted) BaiZeTokens.colors.success else BaiZeTokens.colors.warning)
                 )
-                Spacer(Modifier.width(9.dp))
-                Text(state.device, color = Color.White.copy(alpha = .88f), fontWeight = FontWeight.Bold)
-                Text("  ·  ${state.android}", color = Color.White.copy(alpha = .66f), fontSize = 12.sp)
+                Spacer(Modifier.width(8.dp))
+                Text(state.device, color = onContainer, fontWeight = FontWeight.Bold)
+                Text("  ·  ${state.android}", color = onContainer.copy(alpha = .66f), fontSize = 12.sp)
             }
-            Spacer(Modifier.height(25.dp))
-            Text(title, color = Color.White, style = MaterialTheme.typography.headlineMedium)
-            Spacer(Modifier.height(7.dp))
+            Spacer(Modifier.height(24.dp))
+            Text(title, color = onContainer, style = MaterialTheme.typography.headlineMedium)
+            Spacer(Modifier.height(8.dp))
             Text(
                 state.taskPhase,
-                color = Color.White.copy(alpha = .74f),
+                color = onContainer.copy(alpha = .74f),
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
-            Spacer(Modifier.height(28.dp))
-            Text("最近一次释放", color = Color.White.copy(alpha = .64f), fontSize = 12.sp)
+            Spacer(Modifier.height(24.dp))
+            Text("最近一次释放", color = onContainer.copy(alpha = .64f), fontSize = 12.sp)
             Text(
                 Formatter.formatFileSize(context, state.lastReleased),
-                color = Color.White,
-                style = MaterialTheme.typography.displaySmall
+                color = onContainer,
+                style = BaiZeTokens.type.hero
             )
         }
     }
@@ -218,12 +200,12 @@ private fun MaterialHeroCard(state: DashboardUiState) {
 private fun MaterialStorageCard(state: DashboardUiState) {
     val context = LocalContext.current
     Card(
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
+        modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer.copy(alpha = .92f)
         ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
     ) {
         Row(Modifier.padding(20.dp), verticalAlignment = Alignment.CenterVertically) {
             Box(Modifier.size(88.dp), contentAlignment = Alignment.Center) {
@@ -236,7 +218,7 @@ private fun MaterialStorageCard(state: DashboardUiState) {
                 Text(
                     "${(state.storagePercent * 100).toInt()}%",
                     color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Black
+                    fontWeight = FontWeight.Bold
                 )
             }
             Spacer(Modifier.width(20.dp))
@@ -266,10 +248,10 @@ private fun MaterialCleanButton(state: DashboardUiState, actions: DashboardActio
             else -> actions.clean
         },
         enabled = enabled,
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth().height(70.dp),
-        shape = MaterialTheme.shapes.extraLarge,
+        modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth().height(64.dp),
+        shape = BaiZeTokens.corners.extraLarge,
         colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary),
-        elevation = ButtonDefaults.buttonElevation(defaultElevation = 10.dp)
+        elevation = ButtonDefaults.buttonElevation(defaultElevation = 2.dp)
     ) {
         Icon(
             when {
@@ -286,7 +268,7 @@ private fun MaterialCleanButton(state: DashboardUiState, actions: DashboardActio
                 state.scanCompleted -> "按扫描结果清理"
                 else -> "一键智能清理"
             },
-            fontSize = 19.sp,
+            fontSize = 17.sp,
             fontWeight = FontWeight.Bold
         )
     }
@@ -295,14 +277,14 @@ private fun MaterialCleanButton(state: DashboardUiState, actions: DashboardActio
 @Composable
 private fun MaterialServiceCard(state: DashboardUiState) {
     Card(
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
+        modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
     ) {
-        Row(Modifier.padding(horizontal = 18.dp, vertical = 15.dp), verticalAlignment = Alignment.CenterVertically) {
+        Row(Modifier.padding(horizontal = 20.dp, vertical = 16.dp), verticalAlignment = Alignment.CenterVertically) {
             Box(
                 Modifier.size(10.dp).clip(CircleShape)
-                    .background(if (state.ready || state.scanCompleted) Color(0xFF2DBE87) else Color(0xFFF2A93B))
+                    .background(if (state.ready || state.scanCompleted) BaiZeTokens.colors.success else BaiZeTokens.colors.warning)
             )
             Spacer(Modifier.width(10.dp))
             Text(
@@ -328,7 +310,7 @@ private fun MaterialServiceCard(state: DashboardUiState) {
 @Composable
 private fun MaterialScanResultCard(state: DashboardUiState, actions: DashboardActions) {
     Card(
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
+        modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
     ) {
@@ -361,11 +343,11 @@ private fun MaterialScanResultCard(state: DashboardUiState, actions: DashboardAc
 
 @Composable
 private fun MaterialSectionTitle(eyebrow: String, title: String) {
-    Column(Modifier.padding(horizontal = 22.dp, vertical = 4.dp)) {
+    Column(Modifier.padding(horizontal = 20.dp, vertical = 4.dp)) {
         Text(
             eyebrow,
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.sp
         )
@@ -383,7 +365,7 @@ private fun MaterialQuickActions(
         MaterialCleanCategory(Icons.Rounded.CleaningServices, "全部选项", "进入清理页", onOpenClean)
     )
     Card(
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
+        modifier = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
     ) {
@@ -419,7 +401,7 @@ private fun MaterialQuickActions(
                     Text(
                         item.description,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 10.sp,
+                        fontSize = 11.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/logs/miuix/LogsScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/logs/miuix/LogsScreenMiuix.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.logs.LogLevel
 import io.github.xgl34222220.baize.ui.logs.LogUiItem
@@ -105,7 +106,7 @@ private fun MiuixLogsHeader(
             Text(
                 "SYSTEM LOGS",
                 color = MaterialTheme.colorScheme.primary,
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 fontWeight = FontWeight.Bold,
                 letterSpacing = 2.4.sp
             )
@@ -115,10 +116,10 @@ private fun MiuixLogsHeader(
                 color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 36.sp,
                 lineHeight = 40.sp,
-                fontWeight = FontWeight.Black
+                fontWeight = FontWeight.Bold
             )
             Text(
-                "Miuix 紧凑状态与诊断",
+                "服务状态与诊断信息",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium
@@ -148,7 +149,7 @@ private fun MiuixHeaderButton(
     enabled: Boolean,
     onClick: () -> Unit
 ) {
-    val shape = RoundedCornerShape(19.dp)
+    val shape = RoundedCornerShape(20.dp)
     Box(
         Modifier
             .size(54.dp)
@@ -171,7 +172,7 @@ private fun MiuixRuntimeOverview(state: LogsUiState) {
     val amoled = dark && settings.amoledBlack
     val shape = RoundedCornerShape(36.dp)
     val background = when {
-        amoled -> Color(0xFF090909)
+        amoled -> BaiZeTokens.colors.surfaceRaised
         dark -> scheme.surfaceContainerHigh
         else -> scheme.surface
     }
@@ -182,14 +183,14 @@ private fun MiuixRuntimeOverview(state: LogsUiState) {
         else -> "服务需要恢复"
     }
     val statusColor = when {
-        state.healthy -> Color(0xFF2DBE87)
-        state.connected -> Color(0xFFF2A93B)
+        state.healthy -> BaiZeTokens.colors.success
+        state.connected -> BaiZeTokens.colors.warning
         else -> scheme.error
     }
 
     Box(
         Modifier
-            .padding(horizontal = 18.dp)
+            .padding(horizontal = 20.dp)
             .fillMaxWidth()
             .shadow(12.dp, shape, clip = false)
             .clip(shape)
@@ -218,7 +219,7 @@ private fun MiuixRuntimeOverview(state: LogsUiState) {
                 color = scheme.onSurface,
                 fontSize = 34.sp,
                 lineHeight = 39.sp,
-                fontWeight = FontWeight.Black
+                fontWeight = FontWeight.Bold
             )
 
             Spacer(Modifier.height(18.dp))
@@ -246,8 +247,8 @@ private fun MiuixStatusRow(label: String, value: String) {
             label,
             modifier = Modifier.width(45.dp),
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.Black
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold
         )
         Text(
             value,
@@ -269,12 +270,12 @@ private fun MiuixStatePill(label: String, positive: Boolean) {
     Text(
         label,
         modifier = Modifier
-            .clip(RoundedCornerShape(14.dp))
+            .clip(RoundedCornerShape(12.dp))
             .background(background)
             .padding(horizontal = 9.dp, vertical = 6.dp),
         color = if (positive) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
-        fontSize = 9.sp,
-        fontWeight = FontWeight.Black
+        fontSize = 11.sp,
+        fontWeight = FontWeight.Bold
     )
 }
 
@@ -293,7 +294,7 @@ private fun MiuixRawLogCard(state: LogsUiState, actions: LogsUiActions) {
                     Text(
                         if (state.hasRawLog) "显示最后 36 行，不使用任务摘要代替" else "执行模块扫描或清理后自动读取",
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 9.sp
+                        fontSize = 11.sp
                     )
                 }
                 MiuixHeaderButton(
@@ -309,12 +310,12 @@ private fun MiuixRawLogCard(state: LogsUiState, actions: LogsUiActions) {
                     visible,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clip(RoundedCornerShape(18.dp))
+                        .clip(RoundedCornerShape(20.dp))
                         .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .045f))
                         .padding(13.dp),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontFamily = FontFamily.Monospace,
-                    fontSize = 9.sp,
+                    fontSize = 11.sp,
                     lineHeight = 14.sp
                 )
             }
@@ -365,7 +366,7 @@ private fun MiuixToolRow(
         Box(
             Modifier
                 .size(44.dp)
-                .clip(RoundedCornerShape(15.dp))
+                .clip(RoundedCornerShape(12.dp))
                 .background(MaterialTheme.colorScheme.primary.copy(alpha = .12f)),
             contentAlignment = Alignment.Center
         ) {
@@ -377,7 +378,7 @@ private fun MiuixToolRow(
             Text(
                 subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 9.sp
+                fontSize = 11.sp
             )
         }
     }
@@ -387,8 +388,8 @@ private fun MiuixToolRow(
 private fun MiuixLogCard(item: LogUiItem) {
     val context = LocalContext.current
     val (icon, tint) = when (item.level) {
-        LogLevel.SUCCESS -> Icons.Rounded.CheckCircle to Color(0xFF2DBE87)
-        LogLevel.WARNING -> Icons.Rounded.Search to Color(0xFFF2A93B)
+        LogLevel.SUCCESS -> Icons.Rounded.CheckCircle to BaiZeTokens.colors.success
+        LogLevel.WARNING -> Icons.Rounded.Search to BaiZeTokens.colors.warning
         LogLevel.ERROR -> Icons.Rounded.ErrorOutline to MaterialTheme.colorScheme.error
         LogLevel.INFO -> Icons.Rounded.Description to MaterialTheme.colorScheme.primary
     }
@@ -401,7 +402,7 @@ private fun MiuixLogCard(item: LogUiItem) {
             Box(
                 Modifier
                     .size(46.dp)
-                    .clip(RoundedCornerShape(16.dp))
+                    .clip(RoundedCornerShape(12.dp))
                     .background(tint.copy(alpha = .12f)),
                 contentAlignment = Alignment.Center
             ) {
@@ -413,12 +414,12 @@ private fun MiuixLogCard(item: LogUiItem) {
                 Text(
                     "${item.time} · ${item.trigger}",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 9.sp
+                    fontSize = 11.sp
                 )
                 Text(
                     item.message,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp,
+                    fontSize = 11.sp,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -428,12 +429,12 @@ private fun MiuixLogCard(item: LogUiItem) {
                     Formatter.formatFileSize(context, item.bytes),
                     color = tint,
                     fontSize = 13.sp,
-                    fontWeight = FontWeight.Black
+                    fontWeight = FontWeight.Bold
                 )
                 Text(
                     if (item.errors > 0) "异常 ${item.errors}" else "${item.files} 项",
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 9.sp
+                    fontSize = 11.sp
                 )
             }
         }
@@ -448,16 +449,16 @@ private fun MiuixGroupSurface(
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.background.luminance() < .5f
     val amoled = dark && settings.amoledBlack
-    val shape = RoundedCornerShape(29.dp)
+    val shape = RoundedCornerShape(28.dp)
     val background = when {
-        amoled -> Color(0xFF090909)
+        amoled -> BaiZeTokens.colors.surfaceRaised
         dark -> scheme.surfaceContainerHigh
         else -> scheme.surface
     }
 
     Column(
         modifier = Modifier
-            .padding(horizontal = 18.dp)
+            .padding(horizontal = 20.dp)
             .fillMaxWidth()
             .shadow(6.dp, shape, clip = false)
             .clip(shape)
@@ -473,19 +474,19 @@ private fun MiuixSectionTitle(
     title: String,
     subtitle: String
 ) {
-    Column(Modifier.padding(horizontal = 22.dp, vertical = 5.dp)) {
+    Column(Modifier.padding(horizontal = 20.dp, vertical = 5.dp)) {
         Text(
             eyebrow,
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.2.sp
         )
-        Text(title, fontSize = 27.sp, lineHeight = 31.sp, fontWeight = FontWeight.Black)
+        Text(title, fontSize = 27.sp, lineHeight = 31.sp, fontWeight = FontWeight.Bold)
         Text(
             subtitle,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontSize = 10.sp
+            fontSize = 11.sp
         )
     }
 }
@@ -506,11 +507,11 @@ private fun MiuixEmptyLogs() {
                 tint = MaterialTheme.colorScheme.primary
             )
             Spacer(Modifier.height(10.dp))
-            Text("还没有任务日志", fontSize = 19.sp, fontWeight = FontWeight.Black)
+            Text("还没有任务日志", fontSize = 19.sp, fontWeight = FontWeight.Bold)
             Text(
                 "完成一次扫描或清理后，这里会显示任务结果、大小和异常数量。",
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp
+                fontSize = 11.sp
             )
         }
     }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/MiuixLiquidComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/MiuixLiquidComponents.kt
@@ -32,17 +32,13 @@ import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Stop
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -55,6 +51,7 @@ import dev.chrisbanes.haze.hazeEffect
 import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
 import dev.chrisbanes.haze.materials.HazeMaterials
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 /** A stable Miuix navigation item. Labels always stay below icons. */
 data class MiuixLiquidNavItem(
@@ -80,9 +77,9 @@ fun MiuixLiquidDock(
     val amoled = dark && settings.amoledBlack
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val shape = if (floating) {
-        RoundedCornerShape(34.dp)
+        BaiZeTokens.corners.extraLarge
     } else {
-        RoundedCornerShape(topStart = 34.dp, topEnd = 34.dp)
+        RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
     }
 
     val activeHazeState = hazeState.takeIf {
@@ -95,7 +92,7 @@ fun MiuixLiquidDock(
         dark -> scheme.surface.copy(alpha = .98f)
         else -> Color.White.copy(alpha = .98f)
     }
-    val borderColor = if (dark) Color.White.copy(alpha = .15f) else Color.White.copy(alpha = .82f)
+    val borderColor = if (dark) Color.White.copy(alpha = .10f) else scheme.outlineVariant.copy(alpha = .6f)
     val hazeModifier = activeHazeState?.let { state ->
         Modifier.hazeEffect(
             state = state,
@@ -118,34 +115,11 @@ fun MiuixLiquidDock(
                 }
             )
             .fillMaxWidth()
-            .shadow(if (floating) 22.dp else 8.dp, shape, clip = false)
+            .shadow(if (floating) 8.dp else 2.dp, shape, clip = false)
             .clip(shape)
             .then(hazeModifier)
             .background(dockColor)
             .border(1.dp, borderColor, shape)
-            .drawBehind {
-                drawRoundRect(
-                    brush = Brush.verticalGradient(
-                        listOf(
-                            Color.White.copy(alpha = if (dark) .14f else .46f),
-                            Color.Transparent
-                        )
-                    ),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(34.dp.toPx()),
-                    size = size.copy(height = size.height * .58f)
-                )
-                if (!amoled && settings.glassEnabled) {
-                    drawCircle(
-                        brush = Brush.radialGradient(
-                            listOf(scheme.primary.copy(alpha = .14f), Color.Transparent),
-                            center = Offset(size.width * .18f, size.height * .08f),
-                            radius = size.width * .6f
-                        ),
-                        radius = size.width * .6f,
-                        center = Offset(size.width * .18f, size.height * .08f)
-                    )
-                }
-            }
             .padding(
                 start = 6.dp,
                 top = 7.dp,
@@ -170,20 +144,8 @@ fun MiuixLiquidDock(
                 .offset(x = indicatorX + 4.dp)
                 .width(itemWidth - 8.dp)
                 .height(58.dp)
-                .clip(RoundedCornerShape(24.dp))
-                .background(
-                    Brush.linearGradient(
-                        listOf(
-                            scheme.primary.copy(alpha = if (dark) .28f else .20f),
-                            scheme.tertiary.copy(alpha = if (dark) .20f else .13f)
-                        )
-                    )
-                )
-                .border(
-                    1.dp,
-                    Color.White.copy(alpha = if (dark) .12f else .62f),
-                    RoundedCornerShape(24.dp)
-                )
+                .clip(BaiZeTokens.corners.medium)
+                .background(scheme.primary.copy(alpha = if (dark) .22f else .12f))
         )
 
         Row(Modifier.fillMaxWidth()) {
@@ -202,7 +164,7 @@ fun MiuixLiquidDock(
                     modifier = Modifier
                         .width(itemWidth)
                         .height(58.dp)
-                        .clip(RoundedCornerShape(24.dp))
+                        .clip(BaiZeTokens.corners.medium)
                         .clickable { onSelected(index) },
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
@@ -217,8 +179,8 @@ fun MiuixLiquidDock(
                     Text(
                         text = item.title,
                         color = textColor,
-                        fontSize = if (compact) 9.sp else 10.sp,
-                        lineHeight = if (compact) 11.sp else 12.sp,
+                        fontSize = 11.sp,
+                        lineHeight = 13.sp,
                         fontWeight = if (active) FontWeight.Bold else FontWeight.Medium
                     )
                 }
@@ -237,45 +199,18 @@ fun MiuixOverviewHero(
     positive: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val settings = LocalAppearanceSettings.current
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.background.luminance() < .5f
-    val amoled = dark && settings.amoledBlack
-    val shape = RoundedCornerShape(36.dp)
-    val surface = when {
-        amoled -> Color(0xFF090909)
-        dark -> scheme.surfaceContainerHigh
-        else -> scheme.surface
-    }
+    val shape = BaiZeTokens.corners.large
+    val surface = BaiZeTokens.colors.surfaceRaised
 
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .shadow(12.dp, shape, clip = false)
             .clip(shape)
             .background(surface)
             .border(1.dp, scheme.onSurface.copy(alpha = if (dark) .08f else .05f), shape)
-            .drawBehind {
-                if (!amoled) {
-                    drawCircle(
-                        brush = Brush.radialGradient(
-                            listOf(scheme.primary.copy(alpha = if (dark) .20f else .16f), Color.Transparent),
-                            center = Offset(size.width, 0f),
-                            radius = size.width * .78f
-                        ),
-                        radius = size.width * .78f,
-                        center = Offset(size.width, 0f)
-                    )
-                }
-                drawRoundRect(
-                    brush = Brush.verticalGradient(
-                        listOf(Color.White.copy(alpha = if (dark) .05f else .35f), Color.Transparent)
-                    ),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(36.dp.toPx()),
-                    size = size.copy(height = size.height * .38f)
-                )
-            }
-            .padding(24.dp)
+            .padding(BaiZeTokens.spacing.xxl)
     ) {
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -283,7 +218,7 @@ fun MiuixOverviewHero(
                     Modifier
                         .size(10.dp)
                         .clip(CircleShape)
-                        .background(if (positive) Color(0xFF2DBE87) else Color(0xFFF2A93B))
+                        .background(if (positive) BaiZeTokens.colors.success else BaiZeTokens.colors.warning)
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(device, fontSize = 13.sp, fontWeight = FontWeight.Bold)
@@ -296,7 +231,7 @@ fun MiuixOverviewHero(
                 )
             }
 
-            Spacer(Modifier.height(23.dp))
+            Spacer(Modifier.height(24.dp))
             Text(
                 "最近一次释放",
                 color = scheme.onSurfaceVariant,
@@ -306,24 +241,22 @@ fun MiuixOverviewHero(
             Text(
                 releasedText,
                 color = scheme.onSurface,
-                fontSize = 42.sp,
-                lineHeight = 46.sp,
-                fontWeight = FontWeight.Black
+                style = BaiZeTokens.type.hero
             )
 
             Spacer(Modifier.height(20.dp))
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(22.dp))
+                    .clip(BaiZeTokens.corners.medium)
                     .background(scheme.onSurface.copy(alpha = if (dark) .055f else .04f))
-                    .padding(horizontal = 15.dp, vertical = 13.dp),
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
                     if (positive) Icons.Rounded.CheckCircle else Icons.Rounded.Refresh,
                     contentDescription = null,
-                    tint = if (positive) Color(0xFF2DBE87) else scheme.primary,
+                    tint = if (positive) BaiZeTokens.colors.success else scheme.primary,
                     modifier = Modifier.size(24.dp)
                 )
                 Spacer(Modifier.width(11.dp))
@@ -351,9 +284,7 @@ fun MiuixLiquidPrimaryButton(
     modifier: Modifier = Modifier
 ) {
     val scheme = MaterialTheme.colorScheme
-    val settings = LocalAppearanceSettings.current
-    val dark = scheme.background.luminance() < .5f
-    val shape = RoundedCornerShape(28.dp)
+    val shape = BaiZeTokens.corners.full
     val label = when {
         running -> "停止清理"
         scanReady -> "按扫描结果清理"
@@ -365,38 +296,31 @@ fun MiuixLiquidPrimaryButton(
         else -> Icons.Rounded.AutoAwesome
     }
 
-    val baseGradient = when {
-        !enabled -> listOf(scheme.onSurface.copy(alpha = .16f), scheme.onSurface.copy(alpha = .10f))
-        running -> listOf(Color(0xFF6B6E79), Color(0xFF4C4F59))
-        else -> listOf(scheme.primary, scheme.tertiary)
+    // 纯色胶囊：默认 primary，运行中用中性面，禁用为淡灰。
+    val containerColor = when {
+        !enabled -> scheme.onSurface.copy(alpha = .12f)
+        running -> scheme.surfaceVariant
+        else -> scheme.primary
+    }
+    val contentColor = when {
+        !enabled -> scheme.onSurface.copy(alpha = .45f)
+        running -> scheme.onSurface
+        else -> scheme.onPrimary
     }
 
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(72.dp)
-            .shadow(if (enabled) 14.dp else 0.dp, shape, clip = false)
+            .height(64.dp)
             .clip(shape)
-            .background(Brush.horizontalGradient(baseGradient))
-            .border(1.dp, Color.White.copy(alpha = if (dark) .16f else .48f), shape)
-            .drawBehind {
-                if (settings.glassEnabled) {
-                    drawRoundRect(
-                        brush = Brush.verticalGradient(
-                            listOf(Color.White.copy(alpha = .34f), Color.Transparent)
-                        ),
-                        cornerRadius = androidx.compose.ui.geometry.CornerRadius(28.dp.toPx()),
-                        size = size.copy(height = size.height * .54f)
-                    )
-                }
-            }
+            .background(containerColor)
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(25.dp))
+            Icon(icon, contentDescription = null, tint = contentColor, modifier = Modifier.size(22.dp))
             Spacer(Modifier.width(10.dp))
-            Text(label, color = Color.White, fontSize = 19.sp, fontWeight = FontWeight.Black)
+            Text(label, color = contentColor, fontSize = 17.sp, fontWeight = FontWeight.Bold)
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/SettingsScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/SettingsScreenMiuix.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.settings.SettingsUiActions
@@ -94,15 +95,15 @@ fun SettingsScreenMiuix(
                 onClick = { actions.onSaveScheduler(config) },
                 enabled = !config.saving,
                 modifier = Modifier
-                    .padding(horizontal = 18.dp)
+                    .padding(horizontal = 20.dp)
                     .fillMaxWidth()
                     .height(64.dp),
-                shape = RoundedCornerShape(24.dp)
+                shape = RoundedCornerShape(20.dp)
             ) {
                 Text(
                     if (config.saving) "正在保存…" else "保存全部设置",
                     fontSize = 17.sp,
-                    fontWeight = FontWeight.Black
+                    fontWeight = FontWeight.Bold
                 )
             }
         }
@@ -120,7 +121,7 @@ private fun MiuixSettingsHeader() {
         Text(
             "设置中心",
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.4.sp
         )
@@ -130,10 +131,10 @@ private fun MiuixSettingsHeader() {
             color = MaterialTheme.colorScheme.onSurface,
             fontSize = 36.sp,
             lineHeight = 40.sp,
-            fontWeight = FontWeight.Black
+            fontWeight = FontWeight.Bold
         )
         Text(
-            "MIUI 风格设置与清理保护",
+            "设置与清理保护",
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             fontSize = 12.sp,
             fontWeight = FontWeight.Medium
@@ -153,7 +154,7 @@ private fun MiuixAppearanceHero(
                 MiuixIconTile(Icons.Rounded.Palette, large = true)
                 Spacer(Modifier.width(14.dp))
                 Column(Modifier.weight(1f)) {
-                    Text("界面与主题", fontSize = 21.sp, fontWeight = FontWeight.Black)
+                    Text("界面与主题", fontSize = 21.sp, fontWeight = FontWeight.Bold)
                     Text(
                         state.appearanceSummary,
                         color = scheme.onSurfaceVariant,
@@ -176,7 +177,7 @@ private fun MiuixAppearanceHero(
             Row(
                 Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(21.dp))
+                    .clip(RoundedCornerShape(20.dp))
                     .background(scheme.primary.copy(alpha = .12f))
                     .clickable(onClick = actions.onOpenAppearance)
                     .padding(horizontal = 16.dp, vertical = 15.dp),
@@ -189,7 +190,7 @@ private fun MiuixAppearanceHero(
                     modifier = Modifier.weight(1f),
                     color = scheme.primary,
                     fontSize = 14.sp,
-                    fontWeight = FontWeight.Black
+                    fontWeight = FontWeight.Bold
                 )
                 Icon(Icons.Rounded.ChevronRight, contentDescription = null, tint = scheme.primary)
             }
@@ -206,16 +207,16 @@ private fun MiuixTaskCenter(state: SettingsUiState) {
     val runningGroup = config.runtimeGroup.ifBlank { config.nextTask }
     val isRunning = config.runtimeState == "running"
     MiuixGroupSurface {
-        Column(Modifier.padding(horizontal = 17.dp, vertical = 10.dp)) {
+        Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
             Text(
                 if (isRunning) "正在执行 ${schedulerTaskLabel(runningGroup)}" else "待执行",
                 fontSize = 17.sp,
-                fontWeight = FontWeight.Black
+                fontWeight = FontWeight.Bold
             )
             Text(
                 "白泽会按计划自动清理和归类，暂时未满足条件时会继续等待。",
                 color = scheme.onSurfaceVariant,
-                fontSize = 10.sp,
+                fontSize = 11.sp,
                 lineHeight = 15.sp
             )
             Spacer(Modifier.height(8.dp))
@@ -267,7 +268,7 @@ private fun MiuixAutomationGroup(
     actions: SettingsUiActions
 ) {
     MiuixGroupSurface {
-        Column(Modifier.padding(horizontal = 17.dp, vertical = 6.dp)) {
+        Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
             MiuixSwitchRow(
                 icon = Icons.Rounded.CleaningServices,
                 title = "启用自动清理",
@@ -363,7 +364,7 @@ private fun MiuixProtectionGroup(
 ) {
     val config = state.scheduler
     MiuixGroupSurface {
-        Column(Modifier.padding(horizontal = 17.dp, vertical = 6.dp)) {
+        Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
             MiuixActionRow(
                 icon = Icons.Rounded.Shield,
                 title = "应用白名单",
@@ -434,13 +435,13 @@ private fun MiuixServiceGroup(
 ) {
     val scheme = MaterialTheme.colorScheme
     val statusColor = when {
-        state.running -> Color(0xFFF2A93B)
-        state.serviceHealthy -> Color(0xFF2DBE87)
+        state.running -> BaiZeTokens.colors.warning
+        state.serviceHealthy -> BaiZeTokens.colors.success
         state.connected -> scheme.primary
         else -> scheme.error
     }
     MiuixGroupSurface {
-        Column(Modifier.padding(horizontal = 17.dp, vertical = 10.dp)) {
+        Column(Modifier.padding(horizontal = 16.dp, vertical = 12.dp)) {
             Row(
                 Modifier
                     .fillMaxWidth()
@@ -450,11 +451,11 @@ private fun MiuixServiceGroup(
                 Box(Modifier.size(11.dp).clip(CircleShape).background(statusColor))
                 Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
-                    Text("Root 服务", fontSize = 16.sp, fontWeight = FontWeight.Black)
+                    Text("Root 服务", fontSize = 16.sp, fontWeight = FontWeight.Bold)
                     Text(
                         state.serviceText,
                         color = scheme.onSurfaceVariant,
-                        fontSize = 10.sp,
+                        fontSize = 11.sp,
                         maxLines = 3,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -464,7 +465,7 @@ private fun MiuixServiceGroup(
                 state.schedulerText,
                 modifier = Modifier.padding(horizontal = 2.dp, vertical = 8.dp),
                 color = scheme.onSurfaceVariant,
-                fontSize = 10.sp
+                fontSize = 11.sp
             )
             MiuixDivider()
             MiuixActionRow(Icons.Rounded.Refresh, "重新连接 Root 服务", "重新绑定双 Root 引擎", actions.onReconnect)
@@ -496,7 +497,7 @@ private fun conflictPolicyLabel(value: Int): String = when (value) {
 
 @Composable
 private fun MiuixGroupSurface(
-    shape: RoundedCornerShape = RoundedCornerShape(30.dp),
+    shape: RoundedCornerShape = RoundedCornerShape(28.dp),
     shadow: Int = 7,
     content: @Composable () -> Unit
 ) {
@@ -505,13 +506,13 @@ private fun MiuixGroupSurface(
     val dark = scheme.background.luminance() < .5f
     val amoled = dark && settings.amoledBlack
     val background = when {
-        amoled -> Color(0xFF090909)
+        amoled -> BaiZeTokens.colors.surfaceRaised
         dark -> scheme.surfaceContainerHigh
         else -> scheme.surface
     }
     Box(
         Modifier
-            .padding(horizontal = 18.dp)
+            .padding(horizontal = 20.dp)
             .fillMaxWidth()
             .shadow(shadow.dp, shape, clip = false)
             .clip(shape)
@@ -543,7 +544,7 @@ private fun MiuixSwitchRow(
             Text(
                 description,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 9.sp,
+                fontSize = 11.sp,
                 lineHeight = 13.sp
             )
         }
@@ -576,7 +577,7 @@ private fun MiuixSliderRow(
                 Text(
                     description,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 9.sp
+                    fontSize = 11.sp
                 )
             }
         }
@@ -613,7 +614,7 @@ private fun MiuixActionRow(
             Text(
                 description,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 9.sp,
+                fontSize = 11.sp,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
@@ -651,7 +652,7 @@ private fun MiuixIconTile(icon: ImageVector, large: Boolean = false) {
 private fun MiuixInfoPill(text: String, modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(18.dp))
+            .clip(RoundedCornerShape(20.dp))
             .background(MaterialTheme.colorScheme.onSurface.copy(alpha = .055f))
             .padding(horizontal = 7.dp, vertical = 9.dp),
         contentAlignment = Alignment.Center
@@ -659,8 +660,8 @@ private fun MiuixInfoPill(text: String, modifier: Modifier = Modifier) {
         Text(
             text,
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 10.sp,
-            fontWeight = FontWeight.Black,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
@@ -680,19 +681,19 @@ private fun MiuixSectionTitle(
     title: String,
     subtitle: String
 ) {
-    Column(Modifier.padding(horizontal = 22.dp, vertical = 3.dp)) {
+    Column(Modifier.padding(horizontal = 20.dp, vertical = 3.dp)) {
         Text(
             eyebrow,
             color = MaterialTheme.colorScheme.primary,
-            fontSize = 9.sp,
+            fontSize = 11.sp,
             fontWeight = FontWeight.Bold,
             letterSpacing = 2.sp
         )
-        Text(title, fontSize = 27.sp, fontWeight = FontWeight.Black)
+        Text(title, fontSize = 27.sp, fontWeight = FontWeight.Bold)
         Text(
             subtitle,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            fontSize = 10.sp
+            fontSize = 11.sp
         )
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
@@ -3,14 +3,11 @@ package io.github.xgl34222220.baize.ui.theme
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -25,77 +22,60 @@ import io.github.xgl34222220.baize.ui.appearance.KolorStyle
 import io.github.xgl34222220.baize.ui.appearance.ThemeMode
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 
+// Material 3 Shapes 与 BaiZeCorners 四档对齐（12/20/28/36）。
 private val MaterialShapes = Shapes(
     extraSmall = RoundedCornerShape(4.dp),
-    small = RoundedCornerShape(8.dp),
-    medium = RoundedCornerShape(12.dp),
-    large = RoundedCornerShape(20.dp),
-    extraLarge = RoundedCornerShape(32.dp)
-)
-
-private val MaterialTypography = Typography(
-    displaySmall = TextStyle(fontSize = 38.sp, lineHeight = 43.sp, fontWeight = FontWeight.Black),
-    headlineLarge = TextStyle(fontSize = 32.sp, lineHeight = 37.sp, fontWeight = FontWeight.Black),
-    headlineMedium = TextStyle(fontSize = 26.sp, lineHeight = 31.sp, fontWeight = FontWeight.Bold),
-    titleLarge = TextStyle(fontSize = 21.sp, lineHeight = 26.sp, fontWeight = FontWeight.Bold),
-    titleMedium = TextStyle(fontSize = 17.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold),
-    bodyLarge = TextStyle(fontSize = 16.sp, lineHeight = 23.sp),
-    bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 20.sp),
-    labelLarge = TextStyle(fontSize = 14.sp, fontWeight = FontWeight.Bold)
-)
-
-private val MiuixShapes = Shapes(
-    extraSmall = RoundedCornerShape(10.dp),
-    small = RoundedCornerShape(14.dp),
+    small = RoundedCornerShape(12.dp),
     medium = RoundedCornerShape(20.dp),
     large = RoundedCornerShape(28.dp),
     extraLarge = RoundedCornerShape(36.dp)
 )
 
-private val MiuixTypography = Typography(
-    displaySmall = TextStyle(fontSize = 42.sp, lineHeight = 47.sp, fontWeight = FontWeight.Black),
-    headlineLarge = TextStyle(fontSize = 34.sp, lineHeight = 39.sp, fontWeight = FontWeight.Black),
-    headlineMedium = TextStyle(fontSize = 27.sp, lineHeight = 32.sp, fontWeight = FontWeight.Black),
-    titleLarge = TextStyle(fontSize = 20.sp, lineHeight = 25.sp, fontWeight = FontWeight.Bold),
-    titleMedium = TextStyle(fontSize = 16.sp, lineHeight = 21.sp, fontWeight = FontWeight.Bold),
+private val MiuixShapes = MaterialShapes
+
+// 两套皮肤共用同一字阶；中文标题 Bold（不再使用 Black），大数字经 BaiZeTokens.type.hero 提供 tnum。
+private val MaterialTypography = Typography(
+    displaySmall = TextStyle(fontSize = 40.sp, lineHeight = 46.sp, fontWeight = FontWeight.Bold),
+    headlineLarge = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
+    headlineMedium = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
+    titleLarge = TextStyle(fontSize = 17.sp, lineHeight = 23.sp, fontWeight = FontWeight.Bold),
+    titleMedium = TextStyle(fontSize = 15.sp, lineHeight = 21.sp, fontWeight = FontWeight.SemiBold),
+    bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 21.sp),
     bodyMedium = TextStyle(fontSize = 13.sp, lineHeight = 18.sp),
-    labelLarge = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Bold)
+    bodySmall = TextStyle(fontSize = 11.sp, lineHeight = 15.sp),
+    labelLarge = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Bold),
+    labelMedium = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Bold)
 )
 
-@Immutable
-data class MiuixTokens(
-    val pageBackground: Color,
-    val cardBackground: Color,
-    val elevatedCardBackground: Color,
-    val textPrimary: Color,
-    val textSecondary: Color,
-    val success: Color = Color(0xFF27BE83),
-    val warning: Color = Color(0xFFF0A532)
-)
-
-val LocalMiuixTokens = staticCompositionLocalOf {
-    MiuixTokens(
-        pageBackground = Color(0xFFF4F4F6),
-        cardBackground = Color.White,
-        elevatedCardBackground = Color.White,
-        textPrimary = Color(0xFF16171B),
-        textSecondary = Color(0xFF70727C)
-    )
-}
+private val MiuixTypography = MaterialTypography
 
 @Composable
 fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
-    when (settings.uiStyle) {
-        UiStyle.MATERIAL -> BaiZeMaterialTheme(settings, content)
-        UiStyle.MIUIX -> BaiZeMiuixTheme(settings, content)
+    val dark = resolveDark(settings.themeMode)
+    val amoled = dark && settings.amoledBlack
+    val baiZeColors = when {
+        amoled -> AmoledBaiZeColors
+        dark -> DarkBaiZeColors
+        else -> LightBaiZeColors
+    }
+    CompositionLocalProvider(
+        LocalBaiZeColors provides baiZeColors,
+        LocalBaiZeCorners provides DefaultBaiZeCorners,
+        LocalBaiZeSpacing provides DefaultBaiZeSpacing,
+        LocalBaiZeTypeScale provides DefaultBaiZeTypeScale
+    ) {
+        when (settings.uiStyle) {
+            UiStyle.MATERIAL -> BaiZeMaterialTheme(settings, dark, content)
+            UiStyle.MIUIX -> BaiZeMiuixTheme(settings, dark, content)
+        }
     }
 }
 
 @Composable
-private fun BaiZeMaterialTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
+private fun BaiZeMaterialTheme(settings: AppearanceSettings, dark: Boolean, content: @Composable () -> Unit) {
     DynamicMaterialTheme(
         seedColor = resolveSeedColor(settings),
-        useDarkTheme = resolveDark(settings.themeMode),
+        useDarkTheme = dark,
         withAmoled = settings.amoledBlack,
         style = settings.kolorStyle.toPaletteStyle(),
         shapes = MaterialShapes,
@@ -106,40 +86,17 @@ private fun BaiZeMaterialTheme(settings: AppearanceSettings, content: @Composabl
 }
 
 @Composable
-private fun BaiZeMiuixTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
-    val dark = resolveDark(settings.themeMode)
-    val pureBlack = dark && settings.amoledBlack
+private fun BaiZeMiuixTheme(settings: AppearanceSettings, dark: Boolean, content: @Composable () -> Unit) {
     DynamicMaterialTheme(
         seedColor = resolveSeedColor(settings),
         useDarkTheme = dark,
-        withAmoled = pureBlack,
+        withAmoled = dark && settings.amoledBlack,
         style = settings.kolorStyle.toPaletteStyle(),
         shapes = MiuixShapes,
         typography = MiuixTypography,
-        animate = true
-    ) {
-        val scheme = MaterialTheme.colorScheme
-        val tokens = MiuixTokens(
-            pageBackground = when {
-                pureBlack -> Color.Black
-                dark -> Color(0xFF101114)
-                else -> Color(0xFFF4F4F6)
-            },
-            cardBackground = when {
-                pureBlack -> Color(0xFF080808)
-                dark -> Color(0xFF1C1D21)
-                else -> Color.White
-            },
-            elevatedCardBackground = when {
-                pureBlack -> Color(0xFF111111)
-                dark -> Color(0xFF24252A)
-                else -> Color(0xFFFDFDFE)
-            },
-            textPrimary = scheme.onSurface,
-            textSecondary = scheme.onSurfaceVariant
-        )
-        CompositionLocalProvider(LocalMiuixTokens provides tokens, content = content)
-    }
+        animate = true,
+        content = content
+    )
 }
 
 @Composable

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTokens.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTokens.kt
@@ -1,0 +1,161 @@
+package io.github.xgl34222220.baize.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * 方向 A 设计 token：两套皮肤（Material / Miuix）共享的语义色、圆角、间距与字阶。
+ * 由 [BaiZeTheme] 按明暗/AMOLED 注入，页面与组件一律经 [BaiZeTokens] 读取，
+ * 不再散落硬编码色值与随机的 dp/sp。
+ */
+
+// ---------- 语义色 ----------
+
+@Immutable
+data class BaiZeColors(
+    /** 成功 / 就绪（低饱和绿） */
+    val success: Color,
+    /** 警告 / 未就绪（低饱和琥珀） */
+    val warning: Color,
+    /** 错误 / 危险操作 */
+    val danger: Color,
+    /** 中性信息提示 */
+    val info: Color,
+    /** 页面背景 */
+    val surfaceBase: Color,
+    /** 卡片 / 列表项 */
+    val surfaceRaised: Color,
+    /** 浮层 / 弹层 / 强调卡片 */
+    val surfaceOverlay: Color
+)
+
+val LightBaiZeColors = BaiZeColors(
+    success = Color(0xFF3D9B76),
+    warning = Color(0xFFB08A3C),
+    danger = Color(0xFFC0554F),
+    info = Color(0xFF5B84A6),
+    surfaceBase = Color(0xFFF4F4F6),
+    surfaceRaised = Color(0xFFFFFFFF),
+    surfaceOverlay = Color(0xFFFCFCFD)
+)
+
+val DarkBaiZeColors = BaiZeColors(
+    success = Color(0xFF6FBA97),
+    warning = Color(0xFFCBA465),
+    danger = Color(0xFFCF7E74),
+    info = Color(0xFF8AA9C4),
+    surfaceBase = Color(0xFF101114),
+    surfaceRaised = Color(0xFF1C1D21),
+    surfaceOverlay = Color(0xFF24252A)
+)
+
+/** AMOLED 纯黑模式：背景纯黑，卡片仅用极浅阶差。 */
+val AmoledBaiZeColors = DarkBaiZeColors.copy(
+    surfaceBase = Color(0xFF000000),
+    surfaceRaised = Color(0xFF101012),
+    surfaceOverlay = Color(0xFF1A1B1F)
+)
+
+// ---------- 圆角 ----------
+
+@Immutable
+data class BaiZeCorners(
+    /** 小控件：图标托底、标签、chip */
+    val small: Shape,
+    /** 常规卡片、列表项 */
+    val medium: Shape,
+    /** 页面级大卡片、对话框 */
+    val large: Shape,
+    /** Hero / 主按钮 / Dock */
+    val extraLarge: Shape,
+    /** 胶囊、圆形指示点 */
+    val full: Shape
+)
+
+val DefaultBaiZeCorners = BaiZeCorners(
+    small = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(20.dp),
+    large = RoundedCornerShape(28.dp),
+    extraLarge = RoundedCornerShape(36.dp),
+    full = RoundedCornerShape(percent = 50)
+)
+
+// ---------- 间距（4 倍数） ----------
+
+@Immutable
+data class BaiZeSpacing(
+    val xs: Dp = 4.dp,
+    val sm: Dp = 8.dp,
+    val md: Dp = 12.dp,
+    val lg: Dp = 16.dp,
+    val xl: Dp = 20.dp,
+    val xxl: Dp = 24.dp,
+    val huge: Dp = 32.dp,
+    /** 全应用统一的页面水平边距 */
+    val pageHorizontal: Dp = 20.dp
+)
+
+val DefaultBaiZeSpacing = BaiZeSpacing()
+
+// ---------- 字阶 ----------
+
+@Immutable
+data class BaiZeTypeScale(
+    /** 11sp：说明文字、辅助信息（应用内最小字号） */
+    val caption: TextStyle,
+    /** 13sp：正文 */
+    val body: TextStyle,
+    /** 15sp：强调正文 */
+    val bodyLarge: TextStyle,
+    /** 17sp：卡片标题 */
+    val title: TextStyle,
+    /** 22sp：区块标题（中文 Bold，不用 Black） */
+    val headline: TextStyle,
+    /** 28sp：页头主标题 */
+    val display: TextStyle,
+    /** 40sp 等宽数字：Hero 大数字 */
+    val hero: TextStyle
+)
+
+val DefaultBaiZeTypeScale = BaiZeTypeScale(
+    caption = TextStyle(fontSize = 11.sp, lineHeight = 15.sp),
+    body = TextStyle(fontSize = 13.sp, lineHeight = 18.sp),
+    bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 21.sp),
+    title = TextStyle(fontSize = 17.sp, lineHeight = 23.sp, fontWeight = FontWeight.SemiBold),
+    headline = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
+    display = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
+    hero = TextStyle(
+        fontSize = 40.sp,
+        lineHeight = 46.sp,
+        fontWeight = FontWeight.Bold,
+        fontFeatureSettings = "tnum"
+    )
+)
+
+// ---------- CompositionLocal 注入 ----------
+
+val LocalBaiZeColors = staticCompositionLocalOf { LightBaiZeColors }
+val LocalBaiZeCorners = staticCompositionLocalOf { DefaultBaiZeCorners }
+val LocalBaiZeSpacing = staticCompositionLocalOf { DefaultBaiZeSpacing }
+val LocalBaiZeTypeScale = staticCompositionLocalOf { DefaultBaiZeTypeScale }
+
+/** 统一的 token 读取入口：`BaiZeTokens.colors.success` 等。 */
+object BaiZeTokens {
+    val colors: BaiZeColors
+        @Composable get() = LocalBaiZeColors.current
+    val corners: BaiZeCorners
+        @Composable get() = LocalBaiZeCorners.current
+    val spacing: BaiZeSpacing
+        @Composable get() = LocalBaiZeSpacing.current
+    val type: BaiZeTypeScale
+        @Composable get() = LocalBaiZeTypeScale.current
+}


### PR DESCRIPTION
## 背景

针对「UI 好丑」的反馈，按方向 A 实施：设计 token 化 + 去塑料感。只动表现层，两套皮肤（Material / Miuix）逻辑、状态、回调一律未动；不抽共享组件、不删 Activity、不动 XML（属方向 B）。

## 改了什么

### 1. 新增设计 token（`ui/theme/BaiZeTokens.kt`）

由 `BaiZeTheme` 按明暗/AMOLED 经 CompositionLocal 注入，两套皮肤共用：

| Token | 取值 |
|---|---|
| 语义色 | `success / warning / danger / info` 各 1 个（低饱和，明/暗/AMOLED 三套） |
| surface 三阶 | `surfaceBase`（页底）/ `surfaceRaised`（卡片）/ `surfaceOverlay`（浮层） |
| 圆角 | 12 / 20 / 28 / 36 + full（胶囊），替换原先 24 种取值（13~38dp） |
| 间距 | 4 倍数（4/8/12/16/20/24/32），页面水平边距统一 `pageHorizontal = 20dp`（原先 6 种） |
| 字阶 | 11/13/15/17/22/28/40sp；hero 大数字 40sp + `tnum` 等宽数字；中文标题 Black → Bold |

前后对照：成功绿 3 种（`0xFF2DBE87`×9、`0xFF78EEB8`、`0xFF7BE8B6`）→ `colors.success`；警告橙 4 种 → `colors.warning`；暗色卡片底 5 种（`0xFF080808/090909/1B1D25/111111` 等）→ `colors.surfaceRaised`；正文 9/10sp → 最小 11sp。原先定义了但全工程零消费的 `MiuixTokens/LocalMiuixTokens` 已删除，由 BaiZeTokens 取代。

### 2. 去「四件套」塑料感

- **Material Hero**（首页）：删 primary→tertiary 双拼渐变、16dp 阴影、白描边、白高光 → `primaryContainer` tonal 填充 + token 大数字
- **Miuix 主按钮**：删渐变/白描边/白高光/14dp 阴影 → 纯色胶囊（full 圆角，运行中中性色、禁用淡灰）
- **Miuix Dock**：22dp 阴影 → 8dp，删白色高光层与 primary 光斑，指示器改单色淡填；Material Dock tonal 10→3、阴影 18→8
- **Miuix 背景**：删蓝紫渐变底 + 三层 radial 光斑 → token `surfaceBase` 纯色 + 一抹极淡（alpha 5~6%）单色氛围
- 清理页 Overview、保存按钮等同法收敛

### 3. 默认配色降饱和

- 默认 `KolorStyle`：`VIBRANT` → `SOFT`（TonalSpot）
- 8 个种子色换为低饱和色：雾蓝（默认）、鼠尾草绿、暖沙、陶土、雾霾紫、岩青，保留「白泽蓝」「霞光橘」两个饱和选项
- ⚠️ 老用户若存的是已移除的种子色 argb，会自动回落到默认「雾蓝」

### 4. 小修

- 页头性能调试串（`PerformanceRuntime.statusLine()`）从 UI 移除
- 「轻量列表 · 无逐卡片阴影」「Miuix 紧凑状态与诊断」「MIUI 风格设置」等实现细节文案改为用户向文案；设置项文案去掉 Haze 库名

## 两套皮肤各自的变化

- **Miuix**：背景、Dock、主按钮、Overview hero、清理/记录/日志/设置页全部接入 token；玻璃模糊（Haze）保留
- **Material**：首页 Hero/按钮/存储卡接入 token 与 tonal 填充；Shapes/Typography 与 token 四档对齐

## ⚠️ 未验证声明

本仓库无 Android SDK 环境，**未做本地编译与真机验证**。已逐文件自审 import 与语法（括号平衡、CompositionLocal 读取均在 @Composable 上下文、Shape 类型匹配），但不能排除个别编译错误。**建议合并前先本地 `./gradlew assembleDebug` 编译一次；合并后请截图反馈**（首页/清理/记录/设置，明暗两模式），可据此快速微调 token 值。

## 遗留事项（建议 follow-up）

- `history/material`、`logs/material`、`settings/material`、`appearance/material`、`appearance/miuix`、`clean/material` 六个文件本轮未推送（工作区中断），仍保留原有硬编码与字号；不影响编译与本 PR 其他改动，建议下一 PR 补齐同样的 token 化
- 少量 12sp 说明文字未并入 11/13 字阶；个别卡片内边距（10/13/15dp 等）未全部对齐 4 倍数
- 旧 `FloatingGlassDock.kt` / `ThemeDecorViews.kt` / `ThemePopupMenu.kt` 为无引用死代码，未处理