### PR TITLE
perf: 一键清理 P0 性能修复（去重 awk 化/批量缓存扫描/深度清理合并遍历）+ 大文件保护绕过修复

### DIFF
--- a/cleaner.sh
+++ b/cleaner.sh
@@ -797,6 +797,7 @@ collect_cache_candidates() {
     cache_chunk_count=$((cache_chunk_count + 1))
     cache_done=$((cache_done + 1))
     if [ "$cache_chunk_count" -ge 64 ]; then
+      should_stop && { rm -f "$cache_chunk"; return 9; }
       process_cache_chunk "$cache_chunk" "$days" "$target_list" "$cache_category" "$cache_done" "$cache_total" "$cache_chunk_hook"
       : >"$cache_chunk"
       cache_chunk_count=0
@@ -811,6 +812,7 @@ collect_cache_candidates() {
     fi
   done <"$dir_list"
   if [ "$cache_chunk_count" -gt 0 ]; then
+    should_stop && { rm -f "$cache_chunk"; return 9; }
     process_cache_chunk "$cache_chunk" "$days" "$target_list" "$cache_category" "$cache_done" "$cache_total" "$cache_chunk_hook"
   fi
   rm -f "$cache_chunk"

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -1438,7 +1438,7 @@ deep_target_stats() {
   start_stats=$(date +%s)
   if [ "$DEEP_FIND_XDEV" = "1" ]; then xdev_arg='-xdev'; else xdev_arg=''; fi
   if [ "$DEEP_FIND_EXEC_PLUS" = "1" ]; then
-    command_body='find "$1" $4 -type f -exec stat -c %s -- {} + 2>/dev/null | awk -v max="$3" '\''{ n++; sum += $1; if ($1 > max) big=1 } END { printf "%d %.0f %d\\n", n+0, sum+0, big+0 }'\''
+    command_body='find "$1" $4 -type f -exec stat -c %s -- {} + 2>/dev/null | awk -v max="$3" '\''{ n++; sum += $1; if ($1 > max) big=1 } END { printf "%d %.0f %d\\n", n+0, sum+0, big+0 }'\'''
   else
     command_body='find "$1" $4 -type f -print0 >"$2" 2>/dev/null
 if [ -s "$2" ]; then

--- a/cleaner.sh
+++ b/cleaner.sh
@@ -337,7 +337,8 @@ first_nul_path() {
   return 1
 }
 
-filter_processed_list() {
+# 逐条去重的原始实现：仅在路径含换行或批量解析结果对不齐时回退使用，语义与旧版完全一致。
+filter_processed_list_legacy() {
   source_list=$1
   unique_list="$source_list.unique"
   : >"$unique_list"
@@ -351,6 +352,63 @@ filter_processed_list() {
     printf '%s\0' "$candidate" >>"$unique_list"
   done <"$source_list"
   mv -f "$unique_list" "$source_list"
+}
+
+# 单趟 awk 去重：已处理列表载入关联数组，候选经一趟 xargs -0 readlink -f 批量解析符号链接后一次过滤，
+# 进程数从每候选 3 个降为常数个。readlink 解析语义与 canonical_rule_path 首选实现一致；
+# 路径含换行或批量解析行数与候选对不齐（解析失败等）时回退逐条处理，保证语义不变。
+filter_processed_list() {
+  source_list=$1
+  total=$(count_nul "$source_list")
+  case "$total" in ''|*[!0-9]*) total=0 ;; esac
+  [ "$total" -gt 0 ] || { filter_processed_list_legacy "$source_list"; return; }
+
+  source_nl="$source_list.nl"
+  canon_nl="$source_list.canon"
+  unique_nl="$source_list.uniq.nl"
+  unique_list="$source_list.unique"
+  tr '\000' '\n' <"$source_list" >"$source_nl"
+  nl_lines=$(wc -l <"$source_nl" 2>/dev/null | tr -d ' ')
+  if [ "$nl_lines" != "$total" ]; then
+    rm -f "$source_nl"
+    filter_processed_list_legacy "$source_list"
+    return
+  fi
+  : >"$canon_nl"
+  if command -v readlink >/dev/null 2>&1; then
+    xargs -0 readlink -f -- <"$source_list" 2>/dev/null >"$canon_nl"
+  fi
+  canon_lines=$(wc -l <"$canon_nl" 2>/dev/null | tr -d ' ')
+  if [ "$canon_lines" != "$total" ]; then
+    rm -f "$source_nl" "$canon_nl"
+    filter_processed_list_legacy "$source_list"
+    return
+  fi
+  : >"$unique_nl"
+  awk -v processed="$PROCESSED_PATHS" -v canon="$canon_nl" -v unique="$unique_nl" '
+    BEGIN {
+      while ((getline line < processed) > 0) seen[line] = 1
+      close(processed)
+      ci = 0
+      while ((getline line < canon) > 0) { ci++; resolved[ci] = line }
+      close(canon)
+    }
+    {
+      candidate = $0
+      if (candidate == "") next
+      key = resolved[FNR]
+      if (key == "") key = candidate
+      gsub(/\r/, " ", key)
+      gsub(/\n/, " ", key)
+      if (key in seen) next
+      seen[key] = 1
+      printf "%s\n", key >> processed
+      printf "%s\n", candidate >> unique
+    }
+  ' "$source_nl"
+  tr '\n' '\000' <"$unique_nl" >"$unique_list"
+  mv -f "$unique_list" "$source_list"
+  rm -f "$source_nl" "$canon_nl" "$unique_nl"
 }
 
 is_whitelisted() {
@@ -662,6 +720,7 @@ process_cache_chunk() {
   cache_category=$4
   cache_done=$5
   cache_total=$6
+  cache_chunk_hook=${7:-}
   set --
   while IFS= read -r cache_dir || [ -n "$cache_dir" ]; do
     [ -d "$cache_dir" ] && [ ! -L "$cache_dir" ] && set -- "$@" "$cache_dir"
@@ -673,7 +732,11 @@ process_cache_chunk() {
   run_cache_find 25 "$cache_days" "$cache_chunk_out" "$@"
   cache_code=$?
   if [ "$cache_code" -eq 0 ]; then
-    cat "$cache_chunk_out" >>"$cache_target_list"
+    if [ -n "$cache_chunk_hook" ]; then
+      "$cache_chunk_hook" "$cache_chunk_out"
+    else
+      cat "$cache_chunk_out" >>"$cache_target_list"
+    fi
   else
     case "$cache_code" in
       124|137|143) log_line "[缓存慢批次] $cache_category 第 ${cache_done}/${cache_total} 个目录附近超时，正在逐目录定位" ;;
@@ -694,7 +757,11 @@ process_cache_chunk() {
       run_cache_find 6 "$cache_days" "$cache_one_out" "$cache_dir"
       cache_one_code=$?
       if [ "$cache_one_code" -eq 0 ]; then
-        cat "$cache_one_out" >>"$cache_target_list"
+        if [ -n "$cache_chunk_hook" ]; then
+          "$cache_chunk_hook" "$cache_one_out"
+        else
+          cat "$cache_one_out" >>"$cache_target_list"
+        fi
       else
         CACHE_SLOW_DIRS=$((CACHE_SLOW_DIRS + 1))
         PROTECTED_ITEMS=$((PROTECTED_ITEMS + 1))
@@ -713,6 +780,7 @@ collect_cache_candidates() {
   days=$2
   target_list=$3
   cache_category=$4
+  cache_chunk_hook=${5:-}
   cache_total=$(wc -l <"$dir_list" 2>/dev/null | tr -d ' ')
   case "$cache_total" in ''|*[!0-9]*) cache_total=0 ;; esac
   [ "$cache_total" -gt 0 ] || return 0
@@ -729,7 +797,7 @@ collect_cache_candidates() {
     cache_chunk_count=$((cache_chunk_count + 1))
     cache_done=$((cache_done + 1))
     if [ "$cache_chunk_count" -ge 64 ]; then
-      process_cache_chunk "$cache_chunk" "$days" "$target_list" "$cache_category" "$cache_done" "$cache_total"
+      process_cache_chunk "$cache_chunk" "$days" "$target_list" "$cache_category" "$cache_done" "$cache_total" "$cache_chunk_hook"
       : >"$cache_chunk"
       cache_chunk_count=0
       should_stop && { rm -f "$cache_chunk"; return 9; }
@@ -743,61 +811,61 @@ collect_cache_candidates() {
     fi
   done <"$dir_list"
   if [ "$cache_chunk_count" -gt 0 ]; then
-    process_cache_chunk "$cache_chunk" "$days" "$target_list" "$cache_category" "$cache_done" "$cache_total"
+    process_cache_chunk "$cache_chunk" "$days" "$target_list" "$cache_category" "$cache_done" "$cache_total" "$cache_chunk_hook"
   fi
   rm -f "$cache_chunk"
   return 0
 }
 
-process_cache_candidates() {
-  list=$1
-  CATEGORY=$2
-  app_package=${3:-}
-  app_done=${4:-0}
-  app_total=${5:-0}
-  filter_whitelist_list "$list"
-  filter_processed_list "$list"
-  count=$(count_nul "$list")
-  case "$count" in ''|*[!0-9]*) count=0 ;; esac
-  [ "$count" -gt 0 ] || { rm -f "$list"; return 0; }
-  sample_path=$(first_nul_path "$list" 2>/dev/null)
+# 批次回调：对单批缓存候选做白名单/去重过滤、批量删除，并用一趟 du|awk 按包名累积统计。
+# 统计原始行格式：包名 \t 文件数(1) \t KB \t 样本路径，最终由 scan_cache_batch 聚合成每 App 输出。
+CACHE_STATS=""
+CACHE_REMSTATS=""
+CACHE_CATEGORY=""
+CACHE_PKG_FIELD=""
 
-  if [ -n "$app_package" ]; then
-    if [ "$MODE" = "clean" ]; then
-      set_phase "正在清理应用缓存" "$app_done" "$app_total" "$app_package"
-    else
-      set_phase "正在统计应用缓存" "$app_done" "$app_total" "$app_package"
-    fi
-  fi
+cache_stats_row() {
+  # $1=NUL 文件列表；按 CACHE_PKG_FIELD 提取包名，逐文件输出统计原始行
+  [ -s "$1" ] || return 0
+  xargs -0 du -k <"$1" 2>/dev/null | awk -v f="$CACHE_PKG_FIELD" '
+    {
+      kb = $1
+      path = $0
+      sub(/^[^ \t]*[ \t]+/, "", path)
+      split(path, seg, "/")
+      pkg = seg[f]
+      if (pkg == "") next
+      printf "%s\t1\t%d\t%s\n", pkg, kb, path
+    }'
+}
 
-  estimated=$(bytes_from_list "$list")
-  case "$estimated" in ''|*[!0-9]*) estimated=0 ;; esac
+cache_chunk_process() {
+  chunk_list=$1
+  filter_whitelist_list "$chunk_list"
+  filter_processed_list "$chunk_list"
+  chunk_count=$(count_nul "$chunk_list")
+  case "$chunk_count" in ''|*[!0-9]*) chunk_count=0 ;; esac
+  [ "$chunk_count" -gt 0 ] || { rm -f "$chunk_list"; return 0; }
+
+  cache_stats_row "$chunk_list" >>"$CACHE_STATS"
   if [ "$MODE" = "clean" ]; then
-    err_file="$TMP_DIR/rm-cache.err.$LIST_SEQ"
-    xargs -0 -n 200 rm -f -- <"$list" 2>"$err_file"
-    remaining="$list.remaining"
-    existing_files_to_list "$list" "$remaining"
-    batch_actuals "$list" "$remaining" "$estimated"
-    [ "$REMAINING_COUNT" -gt 0 ] && ERRORS=$((ERRORS + REMAINING_COUNT))
-    reason=$(tail -n 1 "$err_file" 2>/dev/null)
-    [ "$REMAINING_COUNT" -gt 0 ] && log_line "[部分未清理][$CATEGORY] ${reason:-系统拒绝删除部分文件}"
-    log_line "[应用清理][$app_package][$CATEGORY] $ACTUAL_COUNT 个缓存文件，$ACTUAL_BYTES bytes，未清理 $REMAINING_COUNT 个"
-    report_line cleaned low "$CATEGORY:$app_package" "$ACTUAL_COUNT" "$ACTUAL_BYTES" "$app_package"
-    [ "$REMAINING_COUNT" -gt 0 ] && report_line failed low "$CATEGORY:$app_package" "$REMAINING_COUNT" "$REMAINING_BYTES" "$app_package"
-    append_app_detail "$app_package" "$CATEGORY" "$ACTUAL_COUNT" "$ACTUAL_BYTES" "$REMAINING_COUNT" "$sample_path"
-    FILES=$((FILES + ACTUAL_COUNT))
-    add_bytes "$ACTUAL_BYTES"
+    LIST_SEQ=$((LIST_SEQ + 1))
+    err_file="$TMP_DIR/rm-cache.$LIST_SEQ.err"
+    xargs -0 -n 200 rm -f -- <"$chunk_list" 2>"$err_file"
+    remaining="$chunk_list.remaining"
+    existing_files_to_list "$chunk_list" "$remaining"
+    cache_stats_row "$remaining" >>"$CACHE_REMSTATS"
+    if [ -s "$remaining" ]; then
+      reason=$(tail -n 1 "$err_file" 2>/dev/null)
+      log_line "[部分未清理][$CACHE_CATEGORY] ${reason:-系统拒绝删除部分文件}"
+    fi
     rm -f "$remaining" "$err_file"
-  else
-    log_line "[应用扫描][$app_package][$CATEGORY] $count 个缓存文件，$estimated bytes"
-    report_line candidate low "$CATEGORY:$app_package" "$count" "$estimated" "$app_package"
-    append_app_detail "$app_package" "$CATEGORY" "$count" "$estimated" 0 "$sample_path"
-    FILES=$((FILES + count))
-    add_bytes "$estimated"
   fi
-  rm -f "$list"
+  rm -f "$chunk_list"
   return 0
 }
+
+# （原 process_cache_candidates 已由 cache_chunk_process + scan_cache_batch 取代并移除）
 
 clean_dir() {
   dir=$1
@@ -960,12 +1028,113 @@ is_allowed_custom_dir() {
   return 1
 }
 
+# 缓存阶段统一出口：批量收集（64 目录/批，collect_cache_candidates + cache_chunk_process 回调），
+# 结束后用单趟 awk 把累积统计按包名聚合，输出与逐 App 时代完全一致的
+# report_line / append_app_detail / log_line 格式，并汇总全局计数器。
+scan_cache_batch() {
+  dir_list=$1
+  days=$2
+  category=$3
+  pkg_field=$4
+
+  total_dirs=$(wc -l <"$dir_list" 2>/dev/null | tr -d ' ')
+  case "$total_dirs" in ''|*[!0-9]*) total_dirs=0 ;; esac
+  [ "$total_dirs" -gt 0 ] || { rm -f "$dir_list"; return 0; }
+
+  LIST_SEQ=$((LIST_SEQ + 1))
+  CACHE_STATS="$TMP_DIR/cache-stats.$LIST_SEQ"
+  CACHE_REMSTATS="$TMP_DIR/cache-remstats.$LIST_SEQ"
+  totals="$TMP_DIR/cache-totals.$LIST_SEQ"
+  : >"$CACHE_STATS"
+  : >"$CACHE_REMSTATS"
+  CACHE_CATEGORY=$category
+  CACHE_PKG_FIELD=$pkg_field
+
+  collect_cache_candidates "$dir_list" "$days" /dev/null "$category" cache_chunk_process
+  code=$?
+  rm -f "$dir_list"
+  if [ "$code" -eq 9 ]; then
+    rm -f "$CACHE_STATS" "$CACHE_REMSTATS"
+    return 9
+  fi
+  [ -s "$CACHE_STATS" ] || { rm -f "$CACHE_STATS" "$CACHE_REMSTATS"; return 0; }
+
+  set_phase "正在汇总${category}统计" 0 0 ""
+  awk -v stats="$CACHE_STATS" -v rem="$CACHE_REMSTATS" -v category="$category" -v mode="$MODE" \
+      -v report="$REPORT_FILE" -v details="$APP_DETAILS" -v items="$APP_ITEMS" \
+      -v logf="$LOG_FILE" -v totals="$totals" '
+    function sanitize(s) { gsub(/[\t\r\n]/, " ", s); return s }
+    BEGIN {
+      while ((getline line < rem) > 0) {
+        split(line, a, "\t")
+        remc[a[1]] += a[2] + 0
+        remb[a[1]] += a[3] * 1024
+      }
+      close(rem)
+      while ((getline line < stats) > 0) {
+        split(line, a, "\t")
+        counts[a[1]] += a[2] + 0
+        bytes[a[1]] += a[3] * 1024
+        if (!(a[1] in samples)) samples[a[1]] = a[4]
+      }
+      close(stats)
+      total_files = 0
+      total_bytes = 0
+      total_errors = 0
+      for (p in counts) {
+        rc = remc[p] + 0
+        rb = remb[p] + 0
+        if (mode == "clean") {
+          ac = counts[p] - rc; if (ac < 0) ac = 0
+          ab = bytes[p] - rb; if (ab < 0) ab = 0
+          printf "[应用清理][%s][%s] %d 个缓存文件，%.0f bytes，未清理 %d 个\n", p, category, ac, ab, rc >> logf
+          printf "cleaned\tlow\t%s\t%d\t%.0f\t%s\n", sanitize(category ":" p), ac, ab, sanitize(p) >> report
+          if (rc > 0)
+            printf "failed\tlow\t%s\t%d\t%.0f\t%s\n", sanitize(category ":" p), rc, rb, sanitize(p) >> report
+          if (ac > 0 || ab > 0 || rc > 0) {
+            printf "%s\t%s\t%d\t%.0f\n", sanitize(p), sanitize(category), ac, ab >> details
+            printf "%s\t%s\t%d\t%.0f\t%d\t%s\n", sanitize(p), sanitize(category), ac, ab, rc, sanitize(samples[p]) >> items
+          }
+          total_files += ac
+          total_bytes += ab
+          total_errors += rc
+        } else {
+          printf "[应用扫描][%s][%s] %d 个缓存文件，%.0f bytes\n", p, category, counts[p], bytes[p] >> logf
+          printf "candidate\tlow\t%s\t%d\t%.0f\t%s\n", sanitize(category ":" p), counts[p], bytes[p], sanitize(p) >> report
+          printf "%s\t%s\t%d\t%.0f\n", sanitize(p), sanitize(category), counts[p], bytes[p] >> details
+          printf "%s\t%s\t%d\t%.0f\t0\t%s\n", sanitize(p), sanitize(category), counts[p], bytes[p], sanitize(samples[p]) >> items
+          total_files += counts[p]
+          total_bytes += bytes[p]
+        }
+      }
+      printf "files=%d\nbytes=%.0f\nerrors=%d\n", total_files, total_bytes, total_errors > totals
+    }'
+  t_files=0
+  t_bytes=0
+  t_errors=0
+  while IFS='=' read -r t_key t_value; do
+    case "$t_key" in
+      files) t_files=$t_value ;;
+      bytes) t_bytes=$t_value ;;
+      errors) t_errors=$t_value ;;
+    esac
+  done <"$totals"
+  case "$t_files" in ''|*[!0-9]*) t_files=0 ;; esac
+  case "$t_bytes" in ''|*[!0-9.]*) t_bytes=0 ;; esac
+  case "$t_errors" in ''|*[!0-9]*) t_errors=0 ;; esac
+  FILES=$((FILES + t_files))
+  ERRORS=$((ERRORS + t_errors))
+  add_bytes "$t_bytes"
+  rm -f "$CACHE_STATS" "$CACHE_REMSTATS" "$totals"
+  return 0
+}
+
 scan_cache_roots() {
   roots=$1
   days=$2
   category=$3
-  packages="$TMP_DIR/cache-packages.internal"
-  : >"$packages"
+  dir_list="$TMP_DIR/cache-dirs.internal"
+  : >"$dir_list"
 
   for root in $roots; do
     [ -d "$root" ] || continue
@@ -975,100 +1144,30 @@ scan_cache_roots() {
         [ -d "$app_dir" ] || continue
         package=${app_dir##*/}
         valid_package_name "$package" || continue
-        { [ -d "$app_dir/cache" ] || [ -d "$app_dir/code_cache" ]; } || continue
-        grep -Fqx -- "$package" "$packages" 2>/dev/null || printf '%s\n' "$package" >>"$packages"
+        [ -d "$app_dir/cache" ] && printf '%s\n' "$app_dir/cache" >>"$dir_list"
+        [ -d "$app_dir/code_cache" ] && printf '%s\n' "$app_dir/code_cache" >>"$dir_list"
       done
     done
   done
 
-  total=$(wc -l <"$packages" 2>/dev/null | tr -d ' ')
-  case "$total" in ''|*[!0-9]*) total=0 ;; esac
-  done_count=0
-  stage_started=$(date +%s)
-  while IFS= read -r package || [ -n "$package" ]; do
-    valid_package_name "$package" || continue
-    done_count=$((done_count + 1))
-    set --
-    for root in $roots; do
-      for user_root in "$root"/[0-9]*; do
-        [ -d "$user_root/$package/cache" ] && [ ! -L "$user_root/$package/cache" ] && set -- "$@" "$user_root/$package/cache"
-        [ -d "$user_root/$package/code_cache" ] && [ ! -L "$user_root/$package/code_cache" ] && set -- "$@" "$user_root/$package/code_cache"
-      done
-    done
-    [ "$#" -gt 0 ] || continue
-    should_stop && { rm -f "$packages"; return 9; }
-    set_phase "正在扫描应用缓存" "$done_count" "$total" "$package"
-    LIST_SEQ=$((LIST_SEQ + 1))
-    candidates="$TMP_DIR/cache-internal.$LIST_SEQ.nul"
-    run_cache_find 10 "$days" "$candidates" "$@"
-    code=$?
-    if [ "$code" -eq 0 ]; then
-      process_cache_candidates "$candidates" "$category" "$package" "$done_count" "$total"
-    else
-      CACHE_SLOW_DIRS=$((CACHE_SLOW_DIRS + 1))
-      PROTECTED_ITEMS=$((PROTECTED_ITEMS + 1))
-      report_line protected timeout "$category:$package" 1 0 "$package"
-      rm -f "$candidates"
-    fi
-    now=$(date +%s)
-    if [ $((now - stage_started)) -ge 240 ]; then
-      CACHE_TRUNCATED=1
-      log_line "[应用缓存提前结束] 已达到 240 秒上限"
-      break
-    fi
-  done <"$packages"
-  rm -f "$packages"
-  return 0
+  scan_cache_batch "$dir_list" "$days" "$category" 5
+  return $?
 }
 
 scan_external_cache() {
   days=$1
-  packages="$TMP_DIR/cache-packages.external"
-  : >"$packages"
+  dir_list="$TMP_DIR/cache-dirs.external"
+  : >"$dir_list"
   for app_dir in /data/media/[0-9]*/Android/data/*; do
     [ -d "$app_dir" ] || continue
     package=${app_dir##*/}
     valid_package_name "$package" || continue
-    { [ -d "$app_dir/cache" ] || [ -d "$app_dir/code_cache" ]; } || continue
-    grep -Fqx -- "$package" "$packages" 2>/dev/null || printf '%s\n' "$package" >>"$packages"
+    [ -d "$app_dir/cache" ] && printf '%s\n' "$app_dir/cache" >>"$dir_list"
+    [ -d "$app_dir/code_cache" ] && printf '%s\n' "$app_dir/code_cache" >>"$dir_list"
   done
 
-  total=$(wc -l <"$packages" 2>/dev/null | tr -d ' ')
-  case "$total" in ''|*[!0-9]*) total=0 ;; esac
-  done_count=0
-  stage_started=$(date +%s)
-  while IFS= read -r package || [ -n "$package" ]; do
-    valid_package_name "$package" || continue
-    done_count=$((done_count + 1))
-    set --
-    for app_dir in /data/media/[0-9]*/Android/data/"$package"; do
-      [ -d "$app_dir/cache" ] && [ ! -L "$app_dir/cache" ] && set -- "$@" "$app_dir/cache"
-      [ -d "$app_dir/code_cache" ] && [ ! -L "$app_dir/code_cache" ] && set -- "$@" "$app_dir/code_cache"
-    done
-    [ "$#" -gt 0 ] || continue
-    should_stop && { rm -f "$packages"; return 9; }
-    set_phase "正在扫描外部应用缓存" "$done_count" "$total" "$package"
-    LIST_SEQ=$((LIST_SEQ + 1))
-    candidates="$TMP_DIR/cache-external.$LIST_SEQ.nul"
-    run_cache_find 10 "$days" "$candidates" "$@"
-    code=$?
-    if [ "$code" -eq 0 ]; then
-      process_cache_candidates "$candidates" "外部应用缓存" "$package" "$done_count" "$total"
-    else
-      CACHE_SLOW_DIRS=$((CACHE_SLOW_DIRS + 1))
-      PROTECTED_ITEMS=$((PROTECTED_ITEMS + 1))
-      report_line protected timeout "外部应用缓存:$package" 1 0 "$package"
-      rm -f "$candidates"
-    fi
-    now=$(date +%s)
-    if [ $((now - stage_started)) -ge 180 ]; then
-      CACHE_TRUNCATED=1
-      log_line "[外部缓存提前结束] 已达到 180 秒上限"
-      break
-    fi
-  done <"$packages"
-  rm -f "$packages"
-  return 0
+  scan_cache_batch "$dir_list" "$days" "外部应用缓存" 7
+  return $?
 }
 
 run_app_rules() {
@@ -1339,7 +1438,7 @@ deep_target_stats() {
   start_stats=$(date +%s)
   if [ "$DEEP_FIND_XDEV" = "1" ]; then xdev_arg='-xdev'; else xdev_arg=''; fi
   if [ "$DEEP_FIND_EXEC_PLUS" = "1" ]; then
-    command_body='find "$1" $4 -type f -exec stat -c %s -- {} + 2>/dev/null | awk -v max="$3" '\''{ n++; sum += $1; if ($1 > max) big=1 } END { printf "%d %.0f %d\\n", n+0, sum+0, big+0 }'\'''
+    command_body='find "$1" $4 -type f -exec stat -c %s -- {} + 2>/dev/null | awk -v max="$3" '\''{ n++; sum += $1; if ($1 > max) big=1 } END { printf "%d %.0f %d\\n", n+0, sum+0, big+0 }'\''
   else
     command_body='find "$1" $4 -type f -print0 >"$2" 2>/dev/null
 if [ -s "$2" ]; then
@@ -1749,7 +1848,16 @@ corpse_process_target() {
   [ "$count" -eq 0 ] && was_empty_dir=1
   report_count=$count
   [ "$report_count" -gt 0 ] || report_count=1
-  if find "$target" -type f -size "+${MAX_FILE_BYTES}c" -print -quit 2>/dev/null | grep -q .; then
+  # 大文件探测改为兼容写法：不使用 -quit（部分 ROM 的 find 不支持会静默失败并绕过保护），
+  # find 退出码非 0 时按"存在大文件"处理，宁可不删也不可误删。
+  LIST_SEQ=$((LIST_SEQ + 1))
+  big_probe="$TMP_DIR/corpse-big-probe.$LIST_SEQ"
+  big_found=1
+  if find "$target" -type f -size "+${MAX_FILE_BYTES}c" -print >"$big_probe" 2>/dev/null; then
+    [ -s "$big_probe" ] || big_found=0
+  fi
+  rm -f "$big_probe"
+  if [ "$big_found" -eq 1 ]; then
     PROTECTED_ITEMS=$((PROTECTED_ITEMS + report_count))
     PROTECTED_BYTES=$(awk -v a="$PROTECTED_BYTES" -v b="$size" 'BEGIN {printf "%.0f", a+b}')
     log_line "[残留受保护:超过单文件上限] $target（上限 ${MAX_MB} MiB）"
@@ -1970,7 +2078,8 @@ is_mount_target() {
 
 root_shell_old_enough() {
   [ "$ROOT_SHELL_DAYS" -le 0 ] && return 0
-  find "$1" -maxdepth 0 -mtime "+$ROOT_SHELL_DAYS" -print -quit 2>/dev/null | grep -q .
+  # -maxdepth 0 至多输出一行，无需 -quit（不支持的 find 会报错退出 → 无输出 → 视为不够旧，方向保守）
+  find "$1" -maxdepth 0 -mtime "+$ROOT_SHELL_DAYS" -print 2>/dev/null | grep -q .
 }
 
 root_shell_effectively_empty() {
@@ -1985,6 +2094,15 @@ root_shell_effectively_empty() {
     ! \( -type f -size 0c \( -name '.nomedia' -o -name '.keep' -o -name '.gitkeep' -o -name '.placeholder' \) \) \
     -print -quit >"$probe" 2>/dev/null
   probe_code=$?
+  if [ "$probe_code" -ne 0 ]; then
+    # 兼容不支持 -quit 的 find：去掉 -quit 重试（输出量由 6 秒超时兜底，只判断是否存在条目）。
+    # 不支持的 find 会立即报错退出，重试代价可忽略；超时目录重试后仍失败则按受保护处理。
+    run_limited_command 6 find "$dir" -mindepth 1 \
+      ! -type d \
+      ! \( -type f -size 0c \( -name '.nomedia' -o -name '.keep' -o -name '.gitkeep' -o -name '.placeholder' \) \) \
+      -print >"$probe" 2>/dev/null
+    probe_code=$?
+  fi
   if [ "$probe_code" -ne 0 ]; then
     PROTECTED_ITEMS=$((PROTECTED_ITEMS + 1))
     log_line "[根目录保护:扫描超时或异常] $dir"

--- a/v2/module/profile-snapshot-clean.sh
+++ b/v2/module/profile-snapshot-clean.sh
@@ -122,17 +122,28 @@ path_relation() {
   return 1
 }
 
+# 单趟 awk 白名单判定：不再逐行 fork sed/path_relation，双向前缀语义（路径本身、子项、父目录均受保护）与原实现完全一致。
 path_conflicts_whitelist() {
   target=${1%/}
-  while IFS= read -r raw || [ -n "$raw" ]; do
-    item=$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-    case "$item" in ''|'#'*) continue ;; /*) ;; *) continue ;; esac
-    item=${item%/}
-    [ -n "$item" ] || item=/
-    path_relation "$item" "$target" && return 0
-    path_relation "$target" "$item" && return 0
-  done <"$WHITELIST"
-  return 1
+  awk -v t="$target" '
+    function relation(parent, child,   p, c) {
+      p = parent; c = child
+      sub(/\/$/, "", p); sub(/\/$/, "", c)
+      if (p == c) return 1
+      if (substr(c, 1, length(p) + 1) == p "/") return 1
+      return 0
+    }
+    {
+      item = $0
+      sub(/^[[:space:]]*/, "", item); sub(/[[:space:]]*$/, "", item)
+      if (item == "" || item ~ /^#/) next
+      if (item !~ /^\//) next
+      sub(/\/$/, "", item)
+      if (item == "") item = "/"
+      if (relation(item, t) || relation(t, item)) { found = 1; exit }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$WHITELIST"
 }
 
 deep_path_allowed() {
@@ -164,6 +175,8 @@ corpse_target_info() {
   printf '%s\t%s\t%s\n' "$user" "$bucket" "$package"
 }
 
+# 已安装包列表按用户一次性缓存到临时文件（每用户全程仅一次 binder 调用），
+# 获取失败时返回 2，调用方按"无法复核安装状态"保守跳过。
 package_installed() {
   user=$1 package=$2
   if [ -n "${BAIZE_INSTALLED_ROOT:-}" ]; then
@@ -172,19 +185,21 @@ package_installed() {
     grep -Fqx -- "$package" "$list" 2>/dev/null
     return $?
   fi
-  if command -v cmd >/dev/null 2>&1; then
-    output=$(cmd package list packages --user "$user" "$package" 2>/dev/null)
-    [ $? -eq 0 ] || return 2
-    printf '%s\n' "$output" | sed 's/^package://' | grep -Fqx -- "$package"
-    return $?
+  cache="$TMP_DIR/installed-$user.txt"
+  if [ ! -f "$cache" ]; then
+    : >"$cache"
+    if command -v cmd >/dev/null 2>&1; then
+      cmd package list packages --user "$user" 2>/dev/null | sed 's/^package://' | sort -u >"$cache"
+    fi
+    if [ ! -s "$cache" ] && command -v pm >/dev/null 2>&1; then
+      pm list packages --user "$user" 2>/dev/null | sed 's/^package://' | sort -u >"$cache"
+    fi
+    if [ ! -s "$cache" ]; then
+      rm -f "$cache"
+      return 2
+    fi
   fi
-  if command -v pm >/dev/null 2>&1; then
-    output=$(pm list packages --user "$user" "$package" 2>/dev/null)
-    [ $? -eq 0 ] || return 2
-    printf '%s\n' "$output" | sed 's/^package://' | grep -Fqx -- "$package"
-    return $?
-  fi
-  return 2
+  grep -Fqx -- "$package" "$cache" 2>/dev/null
 }
 
 wait_with_stop() {
@@ -200,9 +215,12 @@ wait_with_stop() {
   wait "$child"
 }
 
-find_snapshot_files() {
+# 单趟遍历同时收集待删文件与候选目录（-depth 保证目录按自底向上排序）：
+# 文件须不超大小上限且不新于快照；目录只需不新于快照，删文件后统一 rmdir，非空目录自动保留。
+find_snapshot_entries() {
   target=$1 output=$2 max_bytes=$3
-  find "$target" -xdev -mindepth 1 -type f ! -size "+${max_bytes}c" ! -newer "$STATE_FILE" -print0 >"$output" 2>/dev/null &
+  find "$target" -xdev -depth -mindepth 1 ! -newer "$STATE_FILE" \
+    \( -type d -o -type f ! -size "+${max_bytes}c" \) -print0 >"$output" 2>/dev/null &
   child=$!
   wait_with_stop "$child"
 }
@@ -370,18 +388,31 @@ while IFS= read -r line || [ -n "$line" ]; do
       errors=$((errors + 1))
     fi
   elif [ -d "$target" ]; then
+    all_list="$TMP_DIR/$MODE.$current.entries0"
     list="$TMP_DIR/$MODE.$current.files0"
+    dirs_list="$TMP_DIR/$MODE.$current.dirs0"
     remaining="$TMP_DIR/$MODE.$current.remaining0"
-    : >"$list"
-    find_snapshot_files "$target" "$list" "$max_file_bytes"
+    : >"$all_list"
+    find_snapshot_entries "$target" "$all_list" "$max_file_bytes"
     find_code=$?
-    if [ "$find_code" -eq 9 ]; then code=9; break; fi
+    if [ "$find_code" -eq 9 ]; then rm -f "$all_list"; code=9; break; fi
+    : >"$list"
+    : >"$dirs_list"
+    # 单趟遍历结果按类型分流（read/[ 均为 shell 内建，无额外进程）
+    while IFS= read -r -d '' entry; do
+      if [ -d "$entry" ]; then
+        printf '%s\0' "$entry" >>"$dirs_list"
+      else
+        printf '%s\0' "$entry" >>"$list"
+      fi
+    done <"$all_list"
+    rm -f "$all_list"
     count=$(count_nul "$list"); case "$count" in ''|*[!0-9]*) count=0 ;; esac
     if [ "$count" -gt 0 ]; then
       estimated=$(bytes_from_list "$list"); case "$estimated" in ''|*[!0-9]*) estimated=0 ;; esac
       delete_file_list "$list"
       delete_code=$?
-      if [ "$delete_code" -eq 9 ]; then code=9; break; fi
+      if [ "$delete_code" -eq 9 ]; then rm -f "$list" "$dirs_list"; code=9; break; fi
       existing_files_to_list "$list" "$remaining"
       remain=$(count_nul "$remaining"); case "$remain" in ''|*[!0-9]*) remain=0 ;; esac
       remaining_bytes=$(bytes_from_list "$remaining"); case "$remaining_bytes" in ''|*[!0-9]*) remaining_bytes=0 ;; esac
@@ -389,16 +420,24 @@ while IFS= read -r line || [ -n "$line" ]; do
       target_bytes=$((estimated - remaining_bytes)); [ "$target_bytes" -lt 0 ] && target_bytes=0
       errors=$((errors + remain))
     fi
-    before_dirs=$(find "$target" -xdev -mindepth 1 -type d -empty ! -newer "$STATE_FILE" 2>/dev/null | wc -l | tr -d ' ')
-    case "$before_dirs" in ''|*[!0-9]*) before_dirs=0 ;; esac
-    find "$target" -xdev -depth -mindepth 1 -type d -empty ! -newer "$STATE_FILE" -delete 2>/dev/null
-    after_dirs=$(find "$target" -xdev -mindepth 1 -type d -empty ! -newer "$STATE_FILE" 2>/dev/null | wc -l | tr -d ' ')
-    case "$after_dirs" in ''|*[!0-9]*) after_dirs=0 ;; esac
-    target_dirs=$((before_dirs - after_dirs)); [ "$target_dirs" -lt 0 ] && target_dirs=0
+    # 目录已按 -depth 自底向上排序：文件删除后统一 rmdir，链式空目录依次消除，非空/新于快照的目录自动保留
+    dir_count=$(count_nul "$dirs_list"); case "$dir_count" in ''|*[!0-9]*) dir_count=0 ;; esac
+    if [ "$dir_count" -gt 0 ]; then
+      xargs -0 -n 100 rmdir <"$dirs_list" 2>/dev/null &
+      child=$!
+      wait_with_stop "$child"
+      rmdir_code=$?
+      if [ "$rmdir_code" -eq 9 ]; then rm -f "$list" "$dirs_list" "$remaining"; code=9; break; fi
+      remain_dirs=0
+      while IFS= read -r -d '' entry; do
+        [ -d "$entry" ] && remain_dirs=$((remain_dirs + 1))
+      done <"$dirs_list"
+      target_dirs=$((dir_count - remain_dirs)); [ "$target_dirs" -lt 0 ] && target_dirs=0
+    fi
     if [ -d "$target" ] && [ ! "$target" -nt "$STATE_FILE" ]; then
       rmdir "$target" 2>/dev/null && target_dirs=$((target_dirs + 1))
     fi
-    rm -f "$list" "$remaining"
+    rm -f "$list" "$dirs_list" "$remaining"
   else
     skipped=$((skipped + 1))
     printf 'protected\t%s\t不支持的文件类型\t1\t0\t%s\n' "$risk" "$target" >>"$REPORT_FILE"

--- a/v2/module/profile-snapshot-clean.sh
+++ b/v2/module/profile-snapshot-clean.sh
@@ -420,24 +420,31 @@ while IFS= read -r line || [ -n "$line" ]; do
       target_bytes=$((estimated - remaining_bytes)); [ "$target_bytes" -lt 0 ] && target_bytes=0
       errors=$((errors + remain))
     fi
-    # 目录已按 -depth 自底向上排序：文件删除后统一 rmdir，链式空目录依次消除，非空/新于快照的目录自动保留
-    dir_count=$(count_nul "$dirs_list"); case "$dir_count" in ''|*[!0-9]*) dir_count=0 ;; esac
+    # 目录已按 -depth 自底向上排序：文件删除后统一 rmdir，链式空目录依次消除，非空目录自动保留。
+    # 删除时点新鲜度复核：删文件会刷新父目录 mtime，凡新于快照的目录一律保留
+    # （read/-nt 均为内建，代价可忽略），与 base 版 find ! -newer -delete 的删除时点语义一致。
+    fresh_dirs="$TMP_DIR/$MODE.$current.freshdirs0"
+    : >"$fresh_dirs"
+    while IFS= read -r -d '' entry; do
+      [ ! "$entry" -nt "$STATE_FILE" ] && printf '%s\0' "$entry" >>"$fresh_dirs"
+    done <"$dirs_list"
+    dir_count=$(count_nul "$fresh_dirs"); case "$dir_count" in ''|*[!0-9]*) dir_count=0 ;; esac
     if [ "$dir_count" -gt 0 ]; then
-      xargs -0 -n 100 rmdir <"$dirs_list" 2>/dev/null &
+      xargs -0 -n 100 rmdir <"$fresh_dirs" 2>/dev/null &
       child=$!
       wait_with_stop "$child"
       rmdir_code=$?
-      if [ "$rmdir_code" -eq 9 ]; then rm -f "$list" "$dirs_list" "$remaining"; code=9; break; fi
+      if [ "$rmdir_code" -eq 9 ]; then rm -f "$list" "$dirs_list" "$remaining" "$fresh_dirs"; code=9; break; fi
       remain_dirs=0
       while IFS= read -r -d '' entry; do
         [ -d "$entry" ] && remain_dirs=$((remain_dirs + 1))
-      done <"$dirs_list"
+      done <"$fresh_dirs"
       target_dirs=$((dir_count - remain_dirs)); [ "$target_dirs" -lt 0 ] && target_dirs=0
     fi
     if [ -d "$target" ] && [ ! "$target" -nt "$STATE_FILE" ]; then
       rmdir "$target" 2>/dev/null && target_dirs=$((target_dirs + 1))
     fi
-    rm -f "$list" "$dirs_list" "$remaining"
+    rm -f "$list" "$dirs_list" "$remaining" "$fresh_dirs"
   else
     skipped=$((skipped + 1))
     printf 'protected\t%s\t不支持的文件类型\t1\t0\t%s\n' "$risk" "$target" >>"$REPORT_FILE"


### PR DESCRIPTION
## 概述

本 PR 包含审查定位的 3 项 P0 性能修复（H1/H2/H3）与 1 项安全 Bug 修复（B1），改动文件 2 个：`cleaner.sh`、`v2/module/profile-snapshot-clean.sh`。

&gt; 提交历史说明：分支上有一次中间提交因转义问题被紧随其后的修正提交覆盖（最终文件已做 sha256 字节级校验与本地一致），建议 **Squash merge**。

---

### H1：`filter_processed_list` 去重 O(N²) → 单趟 awk（cleaner.sh）

**改前**：每个候选文件 fork `readlink` + `tr` + `grep` 3 个进程，且 `grep -Fqx` 逐行扫描随运行增大的 PROCESSED_PATHS，整体 O(N²)。
**改后**：PROCESSED_PATHS 一次性载入 awk 关联数组；候选经一趟 `xargs -0 readlink -f` 批量解析符号链接（与 `canonical_rule_path` 首选实现语义一致）后单趟 awk 完成过滤+回写。进程数从 3N 降为常数个（tr/xargs/wc/awk/tr/mv）。
**语义保护**：路径含换行（`tr` 转换后行数与 NUL 计数不一致）或 readlink 批量解析结果与候选数量对不齐（个别解析失败、玩具箱不支持等）时，自动回退到原逐条实现 `filter_processed_list_legacy`（原代码原样保留），语义完全不变。
**预期收益**：以 5 万候选计，进程数从 ~15 万降为 &lt;10，去重阶段耗时从分钟级降到秒级。

### H2：缓存阶段逐 App `timeout+find` → 批量收集 + 单进程按包分组统计（cleaner.sh）

**改前**：`scan_cache_roots`/`scan_external_cache` 对 400~800 个 App 各 fork 一次 `timeout 10 find`；64 目录批量机制 `collect_cache_candidates` 是死代码。
**改后**：启用批量路径——枚举全部 cache/code_cache 目录后走 `collect_cache_candidates`（64 目录/批，批间 stop 检查、超时逐目录降级、180s 上限均保留）；每批经新增回调 `cache_chunk_process` 做白名单/去重过滤与批量删除，统计用 `xargs du -k | awk` 单进程按包名累积；全部批次结束后由 `scan_cache_batch` 用一趟 awk 聚合输出。
**格式契约**：`report_line`/`append_app_detail`（REPORT_FILE、apps-latest.tsv、app-items-latest.tsv）与 `log_line` 的每 App 输出字段与逐 App 时代完全一致（scan 模式 `candidate low &lt;类别&gt;:&lt;包名&gt; N B &lt;包名&gt;`、clean 模式 `cleaned/failed` + 未清理数），已用假数据冒烟比对确认。
**顺带移除**：被取代的原 `process_cache_candidates`（死代码，仓内无其他引用）。
**预期收益**：find 调用从 400~800 次降为 ~目录数/64 次（通常十几次），缓存阶段 fork 数下降一个数量级以上。

### H3：快照清理合并遍历 + 包列表缓存 + 白名单 awk 化（v2/module/profile-snapshot-clean.sh）

**改前**：每个目录目标最多 4 趟 find 遍历（文件收集/空目录前计数/`-delete`/后计数）+ 每目标一次 `cmd package list packages` binder 调用 + 白名单逐行 fork sed。
**改后**：
1. 单趟 `find -xdev -depth -mindepth 1 ! -newer STATE_FILE \( -type d -o -type f ! -size +MAXc \) -print0` 同时收集待删文件与候选目录，shell 内建（`read`/`[`，无 fork）按类型分流；先批量删文件，再按 `-depth` 自底向上顺序 `xargs rmdir`——非空目录与新于快照的目录自动保留，链式空目录依次消除，与原版 `-depth -empty -delete` 的删除集合一致。
2. `package_installed` 按用户一次性拉取 `cmd package list packages` 缓存到临时文件（每用户全程仅 1 次 binder 调用）；获取失败仍返回 2（保守跳过），`BAIZE_INSTALLED_ROOT` 覆盖路径不变。
3. `path_conflicts_whitelist` 改单趟 awk，双向前缀语义（路径本身/子项/父目录均保护）经 20 组用例与原实现逐一比对完全一致。
**已知差异（格式不变、数值口径变化）**：目录删除计数由&#34;删除前空目录数 − 删除后空目录数&#34;改为&#34;实际 rmdir 成功数&#34;。原口径会漏计因文件删除而新变空的父目录链，新口径更真实；TSV 列位、类型不变。

### B1（安全）：`find ... -print -quit | grep -q .` 兼容性修复（cleaner.sh，3 处）

**风险**：不支持 `-quit` 的 find（部分 ROM 的 busybox/toybox 组合）会报错退出、无输出，`grep -q .` 判定为&#34;无大文件&#34;→ 卸载残留大文件保护被静默绕过。
**修法**：
1. `corpse_process_target` 大文件探测：改为 `find ... -print &gt;probe` + 退出码检查，**find 失败按&#34;存在大文件&#34;处理（fail-safe，宁可不删）**；
2. `root_shell_old_enough`：`-maxdepth 0` 至多一行输出，直接去掉 `-quit`（find 失败→视为不够旧→不清理，方向保守）；
3. `root_shell_effectively_empty`：保留 `-quit` 快路径，失败时去掉 `-quit` 重试（6s 超时兜底），仍失败按受保护处理。已用&#34;模拟不支持 -quit 的 find&#34;冒烟验证：空/非空判定正确且无误伤。

---

## 安全红线自查（逐条）

- [x] **30 分钟快照 + sha256 绑定**：未触碰校验逻辑；H3 中 targets/whitelist/rules 的 sha256 复核原样保留
- [x] **`! -newer STATE_FILE` 新鲜度复核**：H3 合并后的单趟 find 仍带 `! -newer &#34;$STATE_FILE&#34;`（文件与目录均生效），目标根目录 rmdir 前的 `-nt` 复核保留；冒烟验证&#34;新于快照的文件及其所在目录均保留&#34;
- [x] **白名单双向前缀语义**：H3 单趟 awk 与原实现 20 组用例逐一比对一致；cleaner.sh 白名单过滤路径未改
- [x] **单文件大小上限**：H3 文件筛选仍含 `! -size &#34;+MAXc&#34;`；B1 修复后大文件保护在不支持 `-quit` 的 ROM 上不再被绕过，且 find 失败一律按受保护处理
- [x] **不跟随符号链接、不跨挂载点**：H3 find 保留 `-xdev`、无 `-L`，`-type f/-type d` 不匹配符号链接；cleaner.sh 缓存目录枚举保留 `[ ! -L ]` 检查
- [x] **cache 根目录保留（deep_keep_root）/高风险分级**：未触碰
- [x] **stop 文件批次检查**：collect_cache_candidates 批间 `should_stop` 检查保留；H3 的 find/rm/rmdir 三阶段均走 `wait_with_stop`；冒烟验证停止码 9 传递路径
- [x] **卸载残留清理前的重装复核**：`package_installed` 缓存后仍逐目标复核（缓存的是列表不是结论）；获取失败返回 2 → 保守跳过逻辑不变

## 验证

- `sh -n` / `bash -n` 两个改动脚本均通过
- 假数据冒烟（bash 环境）：H1 去重正确性（含符号链接同目标去重、二次运行全过滤、与 legacy 输出 diff 为空、含换行路径回退）；H2 按包分组统计（clean/scan 两种模式输出格式与原契约一致、删除失败计入未清理）；H3 端到端（链式空目录消除、大文件/新文件/非空目录保留）；B1 无 `-quit` find 下三处行为；`package_installed` 缓存（cmd 仅调用 1 次）
- 推送后 sha256 字节级校验：分支上两个文件与本地验证版本完全一致
- `git diff` 自审：改动集中于上述 4 项，无无关重构

## 声明

- **未做真机测试**：所有验证均在 x86 Linux + bash 假数据环境完成；toybox/busybox 的 awk、du、readlink 行为差异（如 `readlink -f --` 支持度）虽已设计回退路径，但建议真机先跑 `scan` 模式核对报告数值后再跑 `clean`。
- 缓存阶段总时限统一为 collect_cache_candidates 的 180s（原内部缓存阶段为 240s），极端慢目录场景下可能略早截断（截断方向保守，且有 CACHE_TRUNCATED 报告）。
- find 调用次数估算基于典型设备（数百 App）；实际收益以真机为准。

---

## 已知限制（独立复核确认，3 项均可接受，无需改代码）

1. **运行期包列表缓存盲区**（H3 `package_installed`）：已安装包列表按用户每次运行缓存一次。若某应用在运行期间被重新安装，缓存不会感知，其残留目录仍会按快照被清理。base 版逐目标实时查询同样存在&#34;扫描→清理&#34;竞态，本 PR 只是把复核窗口从每目标一次 binder 调用换为每用户一次缓存，风险方向一致且发生概率极低。
2. **protected 报告行结构变化**（B1）：`corpse_process_target` 大文件保护行的 path 列说明文案与 base 略有差异（TSV 六列契约 action/risk/category/items/bytes/path 不变），下游若按固定文本解析审计报告需注意。
3. **大文件探测全量遍历**（B1）：兼容写法不再用 `-quit` 提前退出，大文件探测会完整遍历目标目录树。极端大目录下耗时略增（该目标本来就要 du/find 统计，增量有限），换来的是不支持 `-quit` 的 ROM 上大文件保护不再被静默绕过。

## 复核第二轮修复（WARNING 项，已修复并推送）

- `profile-snapshot-clean.sh`：目录 rmdir 前补删除时点新鲜度复核（`[ ! &#34;$entry&#34; -nt &#34;$STATE_FILE&#34; ]` 逐条过滤，read/-nt 均为 shell 内建，代价可忽略）——删文件会刷新父目录 mtime，凡新于快照的目录一律保留，与 base 版 `find ! -newer -delete` 的删除时点语义一致。冒烟验证：删文件后 mtime 变新的目录保留、旧空目录与链式空目录正常消除、收集时点即新于快照的目录保留。
- `cleaner.sh`：`collect_cache_candidates` 在两处 `process_cache_chunk` 调用前各补一次 `should_stop` 检查，stop 响应不再延迟一个 64 目录批次。冒烟验证：stop 预设时零批次处理并返回 9、无 stop 时 65 目录分 2 批正常处理、首批处理期间收到 stop 时后续批次（含尾部批次）全部拦截。
- 两个文件推送后均已做 sha256 字节级校验，与本地验证版本完全一致。