### PR TITLE
fix(ui): rebuild MIUIx history records

### DIFF
--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -1,0 +1,43 @@
+name: BaiZe Android UI CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'v2/app/**'
+      - 'v2/macrobenchmark/**'
+      - '.github/workflows/android-ui-ci.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: baize-android-ui-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  android-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Compile and lint UI
+        working-directory: v2
+        run: gradle --no-daemon :app:compileDebugKotlin :app:lintDebug :macrobenchmark:assemble

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/HistoryScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/HistoryScreenMiuix.kt
@@ -20,16 +20,18 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Apps
+import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -66,28 +68,50 @@ fun HistoryScreenMiuix(state: HistoryUiState, actions: HistoryUiActions) {
         state.records.forEach { record -> addAll(record.apps.map { it.packageName }) }
     }
     AppPackageIconPreloader(iconPackages)
+
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val recordGroups = state.records
+        .take(50)
+        .groupBy { record -> record.time.trim().take(10).ifBlank { "更早记录" } }
+
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = bottomInset + 100.dp),
-        verticalArrangement = Arrangement.spacedBy(18.dp)
+        contentPadding = PaddingValues(bottom = bottomInset + 136.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        item { MiuixHistoryHeader(actions) }
-        item { MiuixLifetimePanel(state) }
-        item { MiuixSectionTitle("最近结果", "最近一次自动任务") }
-        item { MiuixCurrentResultGroup(state) }
+        item(key = "history-header") { MiuixHistoryHeader(actions) }
+        item(key = "history-lifetime") { MiuixLifetimePanel(state) }
+        item(key = "history-current-title") { MiuixSectionTitle("最近结果", "最近一次自动任务") }
+        item(key = "history-current") { MiuixCurrentResultGroup(state) }
+
         if (state.recentApps.isNotEmpty()) {
-            item { MiuixSectionTitle("应用垃圾", "点击应用查看清理分类与路径") }
-            item { MiuixAppResultGroup(state.recentApps) }
+            item(key = "history-app-title") { MiuixSectionTitle("应用垃圾", "点击应用查看清理分类与路径") }
+            item(key = "history-apps") { MiuixAppResultGroup(state.recentApps) }
         }
+
         if (state.recentJunk.isNotEmpty()) {
-            item { MiuixSectionTitle("其他垃圾", "本次任务处理的非应用垃圾") }
-            item { MiuixJunkResultGroup(state.recentJunk) }
+            item(key = "history-junk-title") { MiuixSectionTitle("其他垃圾", "本次任务处理的非应用垃圾") }
+            item(key = "history-junk") { MiuixJunkResultGroup(state.recentJunk) }
         }
-        item { MiuixSectionTitle("任务记录", "点击有明细的任务可展开查看") }
-        item { MiuixRecordGroup(state.records) }
+
+        item(key = "history-record-title") { MiuixSectionTitle("任务记录", "按日期排列，扫描与清理状态分开显示") }
+
+        if (recordGroups.isEmpty()) {
+            item(key = "history-empty") { MiuixEmptyRecordsCard() }
+        } else {
+            recordGroups.forEach { (date, records) ->
+                item(key = "history-date-$date") { MiuixDateLabel(date) }
+                itemsIndexed(
+                    items = records,
+                    key = { index, record -> "${record.time}|${record.title}|${record.trigger}|$index" }
+                ) { _, record ->
+                    MiuixRecordCard(record)
+                }
+            }
+        }
+
         if (state.protectedItems.isNotEmpty()) {
-            item {
+            item(key = "history-protected") {
                 Surface(
                     modifier = Modifier
                         .padding(horizontal = 18.dp)
@@ -101,10 +125,23 @@ fun HistoryScreenMiuix(state: HistoryUiState, actions: HistoryUiActions) {
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 14.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(Icons.Rounded.Security, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                        Icon(
+                            Icons.Rounded.Security,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary
+                        )
                         Spacer(Modifier.width(12.dp))
-                        Text("受保护内容", modifier = Modifier.weight(1f), fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
-                        Text("${state.protectedItems.size} 项", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 13.sp)
+                        Text(
+                            "受保护内容",
+                            modifier = Modifier.weight(1f),
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            "${state.protectedItems.size} 项",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 13.sp
+                        )
                     }
                 }
             }
@@ -124,7 +161,11 @@ private fun MiuixHistoryHeader(actions: HistoryUiActions) {
         Column(Modifier.weight(1f)) {
             Text("清理记录", fontSize = 32.sp, lineHeight = 38.sp, fontWeight = FontWeight.Bold)
             Spacer(Modifier.height(5.dp))
-            Text("自动任务结果与累计统计", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 14.sp)
+            Text(
+                "自动任务结果与累计统计",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 14.sp
+            )
         }
         MiuixHeaderButton(Icons.Rounded.Refresh, "刷新", actions.onRefresh)
         Spacer(Modifier.width(8.dp))
@@ -133,7 +174,11 @@ private fun MiuixHistoryHeader(actions: HistoryUiActions) {
 }
 
 @Composable
-private fun MiuixHeaderButton(icon: androidx.compose.ui.graphics.vector.ImageVector, description: String, onClick: () -> Unit) {
+private fun MiuixHeaderButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    description: String,
+    onClick: () -> Unit
+) {
     Surface(
         modifier = Modifier.size(44.dp),
         shape = RoundedCornerShape(15.dp),
@@ -198,7 +243,7 @@ private fun MiuixMetric(label: String, value: String, modifier: Modifier = Modif
 
 @Composable
 private fun MiuixSectionTitle(title: String, subtitle: String) {
-    Column(Modifier.padding(horizontal = 22.dp)) {
+    Column(Modifier.padding(horizontal = 22.dp, vertical = 2.dp)) {
         Text(title, fontSize = 20.sp, lineHeight = 26.sp, fontWeight = FontWeight.Bold)
         Spacer(Modifier.height(2.dp))
         Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
@@ -212,7 +257,7 @@ private fun MiuixCurrentResultGroup(state: HistoryUiState) {
         modifier = Modifier
             .padding(horizontal = 18.dp)
             .fillMaxWidth(),
-        shape = RoundedCornerShape(22.dp),
+        shape = RoundedCornerShape(20.dp),
         color = BaiZeTokens.colors.surfaceRaised
     ) {
         Column {
@@ -229,9 +274,13 @@ private fun MiuixCurrentResultGroup(state: HistoryUiState) {
                 Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
                     Text(
-                        state.latestResult.ifBlank { if (state.hasCurrentResult) "任务已完成" else "暂无最近结果" },
+                        sanitizeText(state.latestResult).ifBlank {
+                            if (state.hasCurrentResult) "任务已完成" else "暂无最近结果"
+                        },
                         fontSize = 15.sp,
-                        fontWeight = FontWeight.SemiBold
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         if (state.hasCurrentResult) "处理 ${state.currentItemCount} 项" else "自动任务执行后显示结果",
@@ -241,31 +290,36 @@ private fun MiuixCurrentResultGroup(state: HistoryUiState) {
                 }
                 Text(
                     Formatter.formatFileSize(context, state.currentBytes),
-                    color = MaterialTheme.colorScheme.primary,
-                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 15.sp,
                     fontWeight = FontWeight.Bold
                 )
             }
             if (state.lastTaskTime.isNotBlank()) {
-                MiuixDivider()
+                MiuixDivider(start = 36.dp)
                 Row(
-                    modifier = Modifier.padding(start = 68.dp, end = 17.dp, top = 13.dp, bottom = 13.dp),
+                    modifier = Modifier.padding(horizontal = 17.dp, vertical = 12.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text("执行时间", modifier = Modifier.weight(1f), fontSize = 13.sp)
-                    Text(state.lastTaskTime, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                    Text(
+                        sanitizeText(state.lastTaskTime),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp
+                    )
                 }
             }
         }
     }
 }
 
-
 @Composable
 private fun MiuixAppResultGroup(apps: List<AppJunkUiItem>) {
     Surface(
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
-        shape = RoundedCornerShape(22.dp),
+        modifier = Modifier
+            .padding(horizontal = 18.dp)
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
         color = BaiZeTokens.colors.surfaceRaised
     ) {
         Column {
@@ -289,31 +343,77 @@ private fun MiuixAppResultRow(item: AppJunkUiItem) {
             .padding(horizontal = 16.dp, vertical = 13.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            AppPackageIcon(item.packageName, item.label.ifBlank { item.packageName }, size = 40.dp, corner = 13.dp)
+            AppPackageIcon(
+                item.packageName,
+                item.label.ifBlank { item.packageName },
+                size = 40.dp,
+                corner = 13.dp
+            )
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
-                Text(item.label.ifBlank { item.packageName }, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text(item.category.ifBlank { item.packageName }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    sanitizeText(item.label.ifBlank { item.packageName }),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    sanitizeText(item.category.ifBlank { item.packageName }),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
             Column(horizontalAlignment = Alignment.End) {
-                Text(Formatter.formatFileSize(context, item.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                Text(
+                    Formatter.formatFileSize(context, item.bytes),
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold
+                )
                 Text("${item.files} 项", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
             }
             if (hasDetails) {
                 Spacer(Modifier.width(5.dp))
-                Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, contentDescription = if (expanded) "收起应用明细" else "展开应用明细", tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(
+                    if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                    contentDescription = if (expanded) "收起应用明细" else "展开应用明细",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp)
+                )
             }
         }
         if (expanded && hasDetails) {
             Spacer(Modifier.height(10.dp))
             HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .50f))
             item.categories.forEach { detail ->
-                Row(Modifier.fillMaxWidth().padding(start = 52.dp, top = 10.dp), verticalAlignment = Alignment.CenterVertically) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(start = 52.dp, top = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     Column(Modifier.weight(1f)) {
-                        Text(detail.name, fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
-                        Text(detail.samplePath.ifBlank { "未记录示例路径" }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            sanitizeText(detail.name),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        Text(
+                            sanitizeText(detail.samplePath).ifBlank { "未记录示例路径" },
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 10.sp,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
-                    Text("${detail.files} 项 · ${Formatter.formatFileSize(context, detail.bytes)}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp)
+                    Text(
+                        "${detail.files} 项 · ${Formatter.formatFileSize(context, detail.bytes)}",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 10.sp
+                    )
                 }
             }
         }
@@ -324,23 +424,53 @@ private fun MiuixAppResultRow(item: AppJunkUiItem) {
 private fun MiuixJunkResultGroup(items: List<GeneralJunkUiItem>) {
     val context = LocalContext.current
     Surface(
-        modifier = Modifier.padding(horizontal = 18.dp).fillMaxWidth(),
-        shape = RoundedCornerShape(22.dp),
+        modifier = Modifier
+            .padding(horizontal = 18.dp)
+            .fillMaxWidth(),
+        shape = RoundedCornerShape(20.dp),
         color = BaiZeTokens.colors.surfaceRaised
     ) {
         Column {
             items.forEachIndexed { index, item ->
-                Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 13.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Box(Modifier.size(40.dp).clip(RoundedCornerShape(13.dp)).background(MaterialTheme.colorScheme.primary.copy(alpha = .10f)), contentAlignment = Alignment.Center) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 13.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(
+                        Modifier
+                            .size(40.dp)
+                            .clip(RoundedCornerShape(13.dp))
+                            .background(MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
+                        contentAlignment = Alignment.Center
+                    ) {
                         Icon(Icons.Rounded.Folder, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
                     }
                     Spacer(Modifier.width(12.dp))
                     Column(Modifier.weight(1f)) {
-                        Text(item.name, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
-                        Text(item.samplePath.ifBlank { "未记录示例路径" }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        Text(
+                            sanitizeText(item.name),
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            sanitizeText(item.samplePath).ifBlank { "未记录示例路径" },
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 11.sp,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                     Column(horizontalAlignment = Alignment.End) {
-                        Text(Formatter.formatFileSize(context, item.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                        Text(
+                            Formatter.formatFileSize(context, item.bytes),
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Bold
+                        )
                         Text("${item.files} 项", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
                     }
                 }
@@ -351,83 +481,217 @@ private fun MiuixJunkResultGroup(items: List<GeneralJunkUiItem>) {
 }
 
 @Composable
-private fun MiuixRecordGroup(records: List<HistoryUiItem>) {
+private fun MiuixDateLabel(date: String) {
+    Text(
+        text = date,
+        modifier = Modifier.padding(start = 22.dp, top = 4.dp, bottom = 1.dp),
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold
+    )
+}
+
+@Composable
+private fun MiuixEmptyRecordsCard() {
     Surface(
         modifier = Modifier
             .padding(horizontal = 18.dp)
             .fillMaxWidth(),
-        shape = RoundedCornerShape(22.dp),
+        shape = RoundedCornerShape(18.dp),
         color = BaiZeTokens.colors.surfaceRaised
     ) {
-        if (records.isEmpty()) {
-            Text("暂无任务记录", modifier = Modifier.padding(18.dp), color = MaterialTheme.colorScheme.onSurfaceVariant)
-        } else {
-            Column {
-                val visibleRecords = records.take(50)
-                visibleRecords.forEachIndexed { index, record ->
-                    MiuixRecordRow(record)
-                    if (index != visibleRecords.lastIndex) MiuixDivider()
-                }
-            }
-        }
+        Text(
+            "暂无任务记录",
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 18.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 14.sp
+        )
     }
 }
 
 @Composable
-private fun MiuixRecordRow(record: HistoryUiItem) {
+private fun MiuixRecordCard(record: HistoryUiItem) {
     val context = LocalContext.current
     var expanded by rememberSaveable(record.time, record.title, record.trigger) { mutableStateOf(false) }
     val hasDetails = record.categories.isNotEmpty() || record.apps.isNotEmpty()
-    val summary = when {
-        record.apps.isNotEmpty() -> "涉及 ${record.apps.size} 个应用 · ${record.files} 项"
-        record.categories.isNotEmpty() -> record.categories.take(2).joinToString(" · ") { it.name }
-        record.bytes == 0L && record.files == 0 -> "未发现可清理内容"
-        else -> record.result
-    }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(enabled = hasDetails) { expanded = !expanded }
-            .padding(horizontal = 16.dp, vertical = 13.dp)
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(
-                modifier = Modifier.size(40.dp).clip(RoundedCornerShape(13.dp)).background(MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Box(Modifier.size(8.dp).clip(CircleShape).background(if (record.cleaned) BaiZeTokens.colors.success else MaterialTheme.colorScheme.outline))
-            }
-            Spacer(Modifier.width(12.dp))
-            Column(Modifier.weight(1f)) {
-                Text(record.title, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text(listOf(record.time, record.trigger).filter(String::isNotBlank).joinToString(" · "), color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                Text(summary, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-            }
-            Column(horizontalAlignment = Alignment.End) {
-                Text(Formatter.formatFileSize(context, record.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 13.sp, fontWeight = FontWeight.Bold)
-                Text(if (record.cleaned) "已完成" else record.result.ifBlank { "已记录" }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
-            }
-            if (hasDetails) {
-                Spacer(Modifier.width(5.dp))
-                Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, contentDescription = if (expanded) "收起任务明细" else "展开任务明细", tint = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
+    val title = sanitizeText(record.title).ifBlank { "历史任务" }
+    val meta = listOf(sanitizeText(record.time), sanitizeText(record.trigger))
+        .filter(String::isNotBlank)
+        .joinToString(" · ")
+    val summary = sanitizeText(
+        when {
+            record.apps.isNotEmpty() -> "涉及 ${record.apps.size} 个应用 · ${record.files} 项"
+            record.categories.isNotEmpty() -> record.categories.take(2).joinToString(" · ") { it.name }
+            record.bytes == 0L && record.files == 0 -> "未发现可清理内容"
+            else -> record.result
         }
-        if (expanded && hasDetails) {
-            Spacer(Modifier.height(10.dp))
-            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .50f))
-            record.apps.forEach { app ->
-                Row(Modifier.fillMaxWidth().padding(start = 52.dp, top = 10.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Column(Modifier.weight(1f)) {
-                        Text(app.label.ifBlank { app.packageName }, fontSize = 12.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        Text(app.category.ifBlank { app.packageName }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    ).ifBlank { if (record.cleaned) "清理任务已完成" else "扫描任务已完成" }
+    val statusText = if (record.cleaned) "已清理" else "扫描完成"
+    val statusColor = if (record.cleaned) BaiZeTokens.colors.success else MaterialTheme.colorScheme.onSurfaceVariant
+    val statusBackground = if (record.cleaned) {
+        BaiZeTokens.colors.success.copy(alpha = .12f)
+    } else {
+        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .10f)
+    }
+
+    Surface(
+        modifier = Modifier
+            .padding(horizontal = 18.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(18.dp))
+            .clickable(enabled = hasDetails) { expanded = !expanded },
+        shape = RoundedCornerShape(18.dp),
+        color = BaiZeTokens.colors.surfaceRaised
+    ) {
+        Column(Modifier.padding(horizontal = 15.dp, vertical = 14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(RoundedCornerShape(13.dp))
+                        .background(statusBackground),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = if (record.cleaned) Icons.Rounded.CheckCircle else Icons.Rounded.Search,
+                        contentDescription = null,
+                        tint = statusColor,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        title,
+                        fontSize = 15.sp,
+                        lineHeight = 20.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (meta.isNotBlank()) {
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            meta,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 11.sp,
+                            lineHeight = 15.sp,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
-                    Text("${app.files} 项 · ${Formatter.formatFileSize(context, app.bytes)}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp)
+                }
+                Surface(
+                    shape = RoundedCornerShape(50),
+                    color = statusBackground
+                ) {
+                    Text(
+                        statusText,
+                        modifier = Modifier.padding(horizontal = 9.dp, vertical = 5.dp),
+                        color = statusColor,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                if (hasDetails) {
+                    Spacer(Modifier.width(6.dp))
+                    Icon(
+                        if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        contentDescription = if (expanded) "收起任务明细" else "展开任务明细",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp)
+                    )
                 }
             }
-            record.categories.forEach { detail ->
-                Row(Modifier.fillMaxWidth().padding(start = 52.dp, top = 10.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Text(detail.name, modifier = Modifier.weight(1f), fontSize = 12.sp, fontWeight = FontWeight.SemiBold)
-                    Text("${detail.files} 项 · ${Formatter.formatFileSize(context, detail.bytes)}", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp)
+
+            Spacer(Modifier.height(10.dp))
+            Row(
+                modifier = Modifier.padding(start = 52.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                Text(
+                    summary,
+                    modifier = Modifier.weight(1f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                    lineHeight = 17.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.width(10.dp))
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        if (record.cleaned) "释放" else "发现",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 10.sp
+                    )
+                    Text(
+                        Formatter.formatFileSize(context, record.bytes),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 15.sp,
+                        lineHeight = 19.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            if (expanded && hasDetails) {
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(
+                    modifier = Modifier.padding(start = 52.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .45f)
+                )
+                record.apps.forEach { app ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 52.dp, top = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(Modifier.weight(1f)) {
+                            Text(
+                                sanitizeText(app.label.ifBlank { app.packageName }),
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                sanitizeText(app.category.ifBlank { app.packageName }),
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontSize = 10.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                        Text(
+                            "${app.files} 项 · ${Formatter.formatFileSize(context, app.bytes)}",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 10.sp
+                        )
+                    }
+                }
+                record.categories.forEach { detail ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 52.dp, top = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            sanitizeText(detail.name),
+                            modifier = Modifier.weight(1f),
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            "${detail.files} 项 · ${Formatter.formatFileSize(context, detail.bytes)}",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 10.sp
+                        )
+                    }
                 }
             }
         }
@@ -435,12 +699,15 @@ private fun MiuixRecordRow(record: HistoryUiItem) {
 }
 
 @Composable
-private fun MiuixDivider() {
+private fun MiuixDivider(start: androidx.compose.ui.unit.Dp = 68.dp) {
     HorizontalDivider(
-        modifier = Modifier.padding(start = 68.dp),
+        modifier = Modifier.padding(start = start),
         color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .50f)
     )
 }
+
+private fun sanitizeText(value: String): String =
+    value.replace(Regex("[\\p{Cc}\\p{Cf}\\s]+"), " ").trim()
 
 private fun formatElapsed(seconds: Long): String = when {
     seconds >= 3_600 -> "${seconds / 3_600} 小时"


### PR DESCRIPTION
## 修复内容

- 不再把最多 50 条历史记录塞进一个超高 `Column`/`Surface`，每条记录改为真正的 `LazyColumn` 独立项目，避免长列表渲染、长截图和重组时出现标题裁切与内容错位。
- 记录按日期分组，每条使用独立紧凑圆角卡片。
- 顶部只显示任务名、时间、触发方式和状态标签；摘要与空间数值放到第二行，不再让大号蓝色数值挤压左侧标题。
- 扫描记录显示“发现 / 扫描完成”，清理记录显示“释放 / 已清理”，不再混淆扫描量与实际释放量。
- 清理历史中的控制字符、换行和异常空白统一清洗，避免出现截图中的残缺标点和空标题。
- 增加底部安全留白，最后一条记录不会被 MIUIx 浮动底栏遮挡。
- 展开明细继续保留，但图标、字号、间距和状态色改为更克制的 MIUIx/HyperOS 样式。
- 新增通用 Android UI PR 流水线，后续 App 界面修改自动执行 Kotlin 编译、Lint 和 Macrobenchmark 装配。

## 验证

- Android Debug Kotlin 编译通过。
- Android Lint Debug 通过。
- Macrobenchmark 装配通过。