### PR TITLE
feat: add immutable deep-clean manifests and resume cursor

### DIFF
--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -7,12 +7,13 @@ on:
       - 'service.sh'
       - 'config/**'
       - 'v2/module/**'
+      - 'v2/native/**'
       - 'v2/scripts/**'
       - 'v2/tests/**'
       - '.github/workflows/v2.5-concurrent-scheduler-ci.yml'
       - '.github/workflows/v2.5.1-release.yml'
   push:
-    branches: [feat/v2.5.2-stability]
+    branches: [feat/v2.5.2-stability, feat/v2.5.2-deep-manifest]
 
 permissions:
   contents: read
@@ -36,6 +37,10 @@ jobs:
             sh -n "$script"
             busybox ash -n "$script"
           done
+      - name: Compile native engines with warnings as errors
+        run: |
+          gcc -std=c11 -O2 -Wall -Wextra -Werror v2/native/baize_engine_42_4.c -o /tmp/baize_engine
+          gcc -std=c11 -O2 -Wall -Wextra -Werror v2/native/baize_deep_snapshot.c -o /tmp/baize_deep_snapshot
       - name: Existing scheduler regression
         run: bash v2/tests/test-scheduler-fairness.sh
       - name: Daily scheduler field regression
@@ -48,13 +53,21 @@ jobs:
           code=$?
           tail -n 80 /tmp/concurrent-scheduler.log
           exit "$code"
-      - name: Deep clean continuous batch regression
+      - name: Legacy profile cleaner regression
         shell: bash
         run: |
           set +e
           bash -x v2/tests/test-deep-clean-budget.sh > /tmp/deep-clean-stream.log 2>&1
           code=$?
           tail -n 120 /tmp/deep-clean-stream.log
+          exit "$code"
+      - name: Immutable deep manifest regression
+        shell: bash
+        run: |
+          set +e
+          bash -x v2/tests/test-deep-manifest.sh > /tmp/deep-manifest.log 2>&1
+          code=$?
+          tail -n 160 /tmp/deep-manifest.log
           exit "$code"
       - name: Upload Root diagnostics
         if: failure()
@@ -64,9 +77,11 @@ jobs:
           path: |
             /tmp/concurrent-scheduler.log
             /tmp/deep-clean-stream.log
+            /tmp/deep-manifest.log
             /tmp/baize-v250-concurrent-scheduler-test
             /tmp/baize-deep-clean-stream-test
             /tmp/baize-scheduler-daily-fields-test
+            /tmp/baize-deep-manifest-state-*
           if-no-files-found: warn
       - name: Incremental index regression
         run: bash v2/tests/test-incremental-index.sh

--- a/v2/module/cleaner42_6.sh
+++ b/v2/module/cleaner42_6.sh
@@ -26,10 +26,11 @@ case "$MODE" in
     run_script "$MODDIR/apk-cleaner.sh" "$MODE" "$TRIGGER"
     ;;
   deep-scan)
-    run_script "$MODDIR/deep-scan-manifest.sh" "$MODE" "$TRIGGER"
+    # Keep a recognized task marker in /proc/<pid>/cmdline so the scheduler cannot clear a live lock.
+    run_script "$MODDIR/deep-scan-manifest.sh" "$MODE" "$TRIGGER" "profile-cleaner.sh"
     ;;
   deep-clean)
-    run_script "$MODDIR/deep-manifest-clean.sh" "$MODE" "$TRIGGER"
+    run_script "$MODDIR/deep-manifest-clean.sh" "$MODE" "$TRIGGER" "profile-cleaner.sh"
     ;;
   corpse-clean)
     run_script "$MODDIR/profile-cleaner.sh" "$MODE" "$TRIGGER"

--- a/v2/module/cleaner42_6.sh
+++ b/v2/module/cleaner42_6.sh
@@ -25,10 +25,16 @@ case "$MODE" in
   apk-clean)
     run_script "$MODDIR/apk-cleaner.sh" "$MODE" "$TRIGGER"
     ;;
-  deep-clean|corpse-clean)
+  deep-scan)
+    run_script "$MODDIR/deep-scan-manifest.sh" "$MODE" "$TRIGGER"
+    ;;
+  deep-clean)
+    run_script "$MODDIR/deep-manifest-clean.sh" "$MODE" "$TRIGGER"
+    ;;
+  corpse-clean)
     run_script "$MODDIR/profile-cleaner.sh" "$MODE" "$TRIGGER"
     ;;
-  cache-scan|deep-scan|corpse-scan)
+  cache-scan|corpse-scan)
     run_script "$MODDIR/native-cleaner.sh" "$MODE" "$TRIGGER"
     ;;
   *)

--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -8,6 +8,7 @@ OLD_STATE="/data/adb/safesweep"
 APK="$MODPATH/app/baize.apk"
 HASH_FILE="$MODPATH/app/baize.apk.sha256"
 NATIVE_ENGINE="$MODPATH/bin/arm64-v8a/baize_engine"
+DEEP_SNAPSHOT_ENGINE="$MODPATH/bin/arm64-v8a/baize_deep_snapshot"
 
 for base in "$MODPATH" "/data/adb/modules/baize_v2" "/data/adb/modules_update/baize_v2"; do
   rm -rf "$base/webroot" "$base/webui" "$base/www" "$base/ksu-webui" 2>/dev/null || true
@@ -29,9 +30,12 @@ chmod 0700 "$STATE_DIR"
 [ -f "$MODPATH/cache-transaction.sh" ] || abort "! 模块包中缺少自动缓存事务执行器"
 [ -f "$MODPATH/apk-scanner.sh" ] || abort "! 模块包中缺少安装包快照扫描器"
 [ -f "$MODPATH/apk-cleaner.sh" ] || abort "! 模块包中缺少安装包快照清理器"
-[ -f "$MODPATH/profile-cleaner.sh" ] || abort "! 模块包中缺少深度/残留快照执行器"
+[ -f "$MODPATH/profile-cleaner.sh" ] || abort "! 模块包中缺少卸载残留快照执行器"
+[ -f "$MODPATH/deep-scan-manifest.sh" ] || abort "! 模块包中缺少深度不可变快照扫描器"
+[ -f "$MODPATH/deep-manifest-clean.sh" ] || abort "! 模块包中缺少深度不可变快照清理器"
 [ -f "$MODPATH/cleaner.sh.compat" ] || abort "! 模块包中缺少兼容清理引擎"
 [ -f "$NATIVE_ENGINE" ] || abort "! 模块包中缺少 arm64 原生扫描器"
+[ -f "$DEEP_SNAPSHOT_ENGINE" ] || abort "! 模块包中缺少 arm64 深度快照引擎"
 [ -f "$MODPATH/scheduler.sh" ] || abort "! 模块包中缺少自动调度器"
 [ -f "$MODPATH/supervisor.sh" ] || abort "! 模块包中缺少调度器守护进程"
 [ -f "$MODPATH/task-worker.sh" ] || abort "! 模块包中缺少统一 Root Worker"
@@ -39,6 +43,7 @@ chmod 0700 "$STATE_DIR"
 [ -f "$MODPATH/organizer-worker.sh" ] || abort "! 模块包中缺少文件归类 Worker"
 [ -f "$MODPATH/config/deep.rules" ] || abort "! 模块包中缺少完整深度规则库"
 
+# Stop both the legacy and immutable-manifest pipelines before replacing module files.
 touch "$STATE_DIR/stop" 2>/dev/null
 pkill -f '/data/adb/modules/baize_v2/cleaner.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/native-cleaner.sh' >/dev/null 2>&1 || true
@@ -48,7 +53,10 @@ pkill -f '/data/adb/modules/baize_v2/cache-lane-worker.sh' >/dev/null 2>&1 || tr
 pkill -f '/data/adb/modules/baize_v2/apk-scanner.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/apk-cleaner.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/profile-cleaner.sh' >/dev/null 2>&1 || true
+pkill -f '/data/adb/modules/baize_v2/deep-scan-manifest.sh' >/dev/null 2>&1 || true
+pkill -f '/data/adb/modules/baize_v2/deep-manifest-clean.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/bin/arm64-v8a/baize_engine' >/dev/null 2>&1 || true
+pkill -f '/data/adb/modules/baize_v2/bin/arm64-v8a/baize_deep_snapshot' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/organizer-worker.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/worker-runner.sh' >/dev/null 2>&1 || true
 pkill -f '/data/adb/modules/baize_v2/task-worker.sh' >/dev/null 2>&1 || true
@@ -59,7 +67,8 @@ rm -f "$STATE_DIR/running.env" "$STATE_DIR/stop"
 rm -f "$STATE_DIR/cache_scan.env" "$STATE_DIR/cache_scan.targets" "$STATE_DIR/cache_scan.items.tsv" "$STATE_DIR/cache_scan.manifest0"
 rm -f "$STATE_DIR/cache_auto.env" "$STATE_DIR/cache_auto.targets" "$STATE_DIR/cache_auto.items.tsv" "$STATE_DIR/cache_auto.manifest0"
 rm -f "$STATE_DIR/apk_scan.env" "$STATE_DIR/apk_scan.targets"
-rm -f "$STATE_DIR/deep_scan.env" "$STATE_DIR/deep_scan.targets"
+rm -f "$STATE_DIR/deep_scan.env" "$STATE_DIR/deep_scan.targets" "$STATE_DIR/deep_scan.manifest0" \
+  "$STATE_DIR/deep_scan.cursor" "$STATE_DIR/deep_scan.manifest.env" "$STATE_DIR/deep_clean.accum.env"
 rm -f "$STATE_DIR/corpse_scan.env" "$STATE_DIR/corpse_scan.targets"
 rm -f "$STATE_DIR/worker.env" "$STATE_DIR/scheduler.env" "$STATE_DIR/supervisor.env" \
   "$STATE_DIR/scheduler-queue.tsv" "$STATE_DIR/scheduler-candidates.tmp" \
@@ -68,7 +77,7 @@ rm -f "$STATE_DIR"/scheduler-retry-*.count "$STATE_DIR"/scheduler-retry-*.until 
   "$STATE_DIR"/scheduler-fail-*.count "$STATE_DIR"/scheduler-pause-*.until 2>/dev/null || true
 rm -rf "$STATE_DIR/scheduler-requests" "$STATE_DIR/scheduler-skips"
 mkdir -p "$STATE_DIR/scheduler-requests" "$STATE_DIR/scheduler-skips"
-echo 'concurrent-lanes-v1' >"$STATE_DIR/runtime-schema"
+echo 'deep-manifest-v1' >"$STATE_DIR/runtime-schema"
 
 if [ -f "$OLD_MOD/module.prop" ] || [ -d "$OLD_UPDATE" ] || [ -d "$OLD_STATE" ]; then
   migrated=0
@@ -93,8 +102,8 @@ fi
 
 chmod 0600 "$STATE_DIR/config.conf" "$STATE_DIR/whitelist.conf" "$STATE_DIR/custom.rules" 2>/dev/null
 chmod 0644 "$APK" "$HASH_FILE" 2>/dev/null
-chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/native-cleaner.sh" "$MODPATH/cache-snapshot-clean.sh" "$MODPATH/cache-transaction.sh" "$MODPATH/cache-lane-worker.sh" "$MODPATH/one-pass-scan.sh" "$MODPATH/apk-scanner.sh" "$MODPATH/apk-cleaner.sh" "$MODPATH/profile-cleaner.sh" 2>/dev/null
-chmod 0755 "$MODPATH/cleaner.sh.compat" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" "$NATIVE_ENGINE" 2>/dev/null
+chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/native-cleaner.sh" "$MODPATH/cache-snapshot-clean.sh" "$MODPATH/cache-transaction.sh" "$MODPATH/cache-lane-worker.sh" "$MODPATH/one-pass-scan.sh" "$MODPATH/apk-scanner.sh" "$MODPATH/apk-cleaner.sh" "$MODPATH/profile-cleaner.sh" "$MODPATH/deep-scan-manifest.sh" "$MODPATH/deep-manifest-clean.sh" 2>/dev/null
+chmod 0755 "$MODPATH/cleaner.sh.compat" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" "$NATIVE_ENGINE" "$DEEP_SNAPSHOT_ENGINE" 2>/dev/null
 chmod 0755 "$MODPATH/task-worker.sh" "$MODPATH/organizer-worker.sh" "$MODPATH/worker-runner.sh" "$MODPATH/supervisor.sh" "$MODPATH/app-installer.sh" "$MODPATH/diagnostics-export.sh" "$MODPATH/storage-analyzer.sh" "$MODPATH/duplicate-scanner.sh" "$MODPATH/large-file-scanner.sh" "$MODPATH/quarantine-manager.sh" "$MODPATH/rules-validator.sh" 2>/dev/null
 
 install_app() {

--- a/v2/module/deep-manifest-clean.sh
+++ b/v2/module/deep-manifest-clean.sh
@@ -24,7 +24,7 @@ mkdir -p "$STATE_DIR" "$REPORT_DIR" "$LOG_DIR"
 [ -f "$WHITELIST" ] || : >"$WHITELIST"
 
 state_value() { sed -n "s/^$1=//p" "$STATE_FILE" 2>/dev/null | tail -n 1; }
-summary_value() { sed -n "s/^$1=//p" "$1" 2>/dev/null | tail -n 1; }
+summary_value() { summary_file=$1; summary_key=$2; sed -n "s/^$summary_key=//p" "$summary_file" 2>/dev/null | tail -n 1; }
 uint_value() { value=$1; fallback=${2:-0}; case "$value" in ''|*[!0-9]*) value=$fallback ;; esac; echo "$value"; }
 file_sha() { [ -f "$1" ] && sha256sum "$1" 2>/dev/null | awk 'NR==1{print $1}' || echo missing; }
 human_bytes() { awk -v b="$1" 'BEGIN { if (b>=1073741824) printf "%.2f GB",b/1073741824; else if(b>=1048576) printf "%.2f MB",b/1048576; else if(b>=1024) printf "%.2f KB",b/1024; else printf "%.0f B",b }'; }

--- a/v2/module/deep-manifest-clean.sh
+++ b/v2/module/deep-manifest-clean.sh
@@ -1,0 +1,194 @@
+#!/system/bin/sh
+set -u
+
+MODDIR=${0%/*}
+TRIGGER=${2:-manual}
+STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
+CONFIG="$STATE_DIR/config.conf"
+WHITELIST="$STATE_DIR/whitelist.conf"
+DEEP_RULES=${BAIZE_DEEP_RULES:-$MODDIR/config/deep.rules}
+LOCK_DIR="$STATE_DIR/run.lock"
+RUNNING_FILE="$STATE_DIR/running.env"
+STOP_FILE="$STATE_DIR/stop"
+STATE_FILE="$STATE_DIR/deep_scan.env"
+TARGETS_FILE="$STATE_DIR/deep_scan.targets"
+MANIFEST_FILE="$STATE_DIR/deep_scan.manifest0"
+CURSOR_FILE="$STATE_DIR/deep_scan.cursor"
+ACCUM_FILE="$STATE_DIR/deep_clean.accum.env"
+HISTORY_FILE="$STATE_DIR/history.tsv"
+REPORT_DIR="$STATE_DIR/reports"
+LOG_DIR="$STATE_DIR/logs"
+SNAPSHOT_ENGINE="$MODDIR/bin/arm64-v8a/baize_deep_snapshot"
+
+mkdir -p "$STATE_DIR" "$REPORT_DIR" "$LOG_DIR"
+[ -f "$WHITELIST" ] || : >"$WHITELIST"
+
+state_value() { sed -n "s/^$1=//p" "$STATE_FILE" 2>/dev/null | tail -n 1; }
+summary_value() { sed -n "s/^$1=//p" "$1" 2>/dev/null | tail -n 1; }
+uint_value() { value=$1; fallback=${2:-0}; case "$value" in ''|*[!0-9]*) value=$fallback ;; esac; echo "$value"; }
+file_sha() { [ -f "$1" ] && sha256sum "$1" 2>/dev/null | awk 'NR==1{print $1}' || echo missing; }
+human_bytes() { awk -v b="$1" 'BEGIN { if (b>=1073741824) printf "%.2f GB",b/1073741824; else if(b>=1048576) printf "%.2f MB",b/1048576; else if(b>=1024) printf "%.2f KB",b/1024; else printf "%.0f B",b }'; }
+proc_start_ticks() { [ -r "/proc/$1/stat" ] && awk '{print $22}' "/proc/$1/stat" 2>/dev/null || echo 0; }
+pid_is_task() {
+  pid=$1
+  [ "$pid" -gt 1 ] 2>/dev/null || return 1
+  [ -r "/proc/$pid/cmdline" ] || return 1
+  cmdline=$(tr '\000' ' ' <"/proc/$pid/cmdline" 2>/dev/null)
+  case "$cmdline" in *deep-manifest-clean.sh*|*cleaner.sh*|*task-worker.sh*|*worker-runner.sh*|*baize_deep_snapshot*) return 0 ;; esac
+  return 1
+}
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  old_pid=$(sed -n '1p' "$LOCK_DIR/pid" 2>/dev/null)
+  case "$old_pid" in ''|*[!0-9]*) old_pid=0 ;; esac
+  if [ "$old_pid" -gt 1 ] && kill -0 "$old_pid" 2>/dev/null && pid_is_task "$old_pid"; then
+    echo "已有扫描或清理任务正在运行"
+    exit 3
+  fi
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+  rm -f "$RUNNING_FILE" 2>/dev/null
+  mkdir "$LOCK_DIR" 2>/dev/null || { echo "无法恢复任务锁，请重试"; exit 4; }
+fi
+printf '%s\n' "$$" >"$LOCK_DIR/pid"
+printf '%s\n' "$(proc_start_ticks $$)" >"$LOCK_DIR/start_ticks"
+cleanup_lock() { rm -f "$RUNNING_FILE" 2>/dev/null; rm -rf -- "$LOCK_DIR" 2>/dev/null; }
+trap cleanup_lock EXIT
+rm -f "$STOP_FILE"
+
+[ -x "$SNAPSHOT_ENGINE" ] || { echo "深度不可变快照引擎缺失，请重新刷入完整模块" >&2; exit 8; }
+[ -s "$STATE_FILE" ] && [ -s "$MANIFEST_FILE" ] && [ -f "$CURSOR_FILE" ] || {
+  echo "没有可用的深度逐文件快照，请先完成深度扫描"
+  exit 6
+}
+
+snapshot_id=$(state_value snapshot_id)
+epoch=$(uint_value "$(state_value epoch)" 0)
+manifest_sha=$(state_value manifest_sha)
+expected_targets_sha=$(state_value targets_sha)
+expected_whitelist_sha=$(state_value whitelist_sha)
+expected_rules_sha=$(state_value rules_sha)
+max_file_bytes=$(uint_value "$(state_value max_file_bytes)" 268435456)
+now=$(date +%s)
+age=$((now - epoch))
+if [ "$epoch" -le 0 ] || [ "$age" -lt 0 ] || [ "$age" -gt 1800 ] || [ -z "$snapshot_id" ]; then
+  echo "深度扫描快照已过期，请重新扫描"
+  exit 6
+fi
+[ "$(file_sha "$MANIFEST_FILE")" = "$manifest_sha" ] || { echo "深度逐文件快照校验失败"; exit 7; }
+[ "$(file_sha "$TARGETS_FILE")" = "$expected_targets_sha" ] || { echo "深度目标快照校验失败"; exit 7; }
+[ "$(file_sha "$WHITELIST")" = "$expected_whitelist_sha" ] || { echo "白名单已变化，请重新扫描"; exit 7; }
+[ -f "$DEEP_RULES" ] && [ "$(file_sha "$DEEP_RULES")" = "$expected_rules_sha" ] || { echo "深度规则库已变化，请重新扫描"; exit 7; }
+
+if [ -f "$ACCUM_FILE" ] && [ "$(sed -n 's/^snapshot_id=//p' "$ACCUM_FILE" | tail -n 1)" != "$snapshot_id" ]; then
+  rm -f "$ACCUM_FILE"
+fi
+acc_files=$(uint_value "$(sed -n 's/^files=//p' "$ACCUM_FILE" 2>/dev/null | tail -n 1)" 0)
+acc_dirs=$(uint_value "$(sed -n 's/^dirs=//p' "$ACCUM_FILE" 2>/dev/null | tail -n 1)" 0)
+acc_bytes=$(uint_value "$(sed -n 's/^bytes=//p' "$ACCUM_FILE" 2>/dev/null | tail -n 1)" 0)
+acc_skipped=$(uint_value "$(sed -n 's/^skipped=//p' "$ACCUM_FILE" 2>/dev/null | tail -n 1)" 0)
+acc_errors=$(uint_value "$(sed -n 's/^errors=//p' "$ACCUM_FILE" 2>/dev/null | tail -n 1)" 0)
+
+STAMP=$(date '+%Y-%m-%d_%H-%M-%S')
+REPORT_FILE="$REPORT_DIR/$STAMP-deep-clean.tsv"
+SUMMARY_FILE="$LOCK_DIR/deep-clean-summary.env"
+LOG_FILE="$LOG_DIR/$STAMP-deep-clean.log"
+START_EPOCH=$(date +%s)
+
+"$SNAPSHOT_ENGINE" clean \
+  --manifest "$MANIFEST_FILE" \
+  --cursor "$CURSOR_FILE" \
+  --report "$REPORT_FILE" \
+  --summary "$SUMMARY_FILE" \
+  --whitelist "$WHITELIST" \
+  --progress "$RUNNING_FILE" \
+  --stop "$STOP_FILE" \
+  --max-file-bytes "$max_file_bytes"
+code=$?
+
+run_files=$(uint_value "$(summary_value "$SUMMARY_FILE" files)" 0)
+run_dirs=$(uint_value "$(summary_value "$SUMMARY_FILE" dirs)" 0)
+run_bytes=$(uint_value "$(summary_value "$SUMMARY_FILE" bytes)" 0)
+run_skipped=$(uint_value "$(summary_value "$SUMMARY_FILE" skipped)" 0)
+run_errors=$(uint_value "$(summary_value "$SUMMARY_FILE" errors)" 0)
+remaining=$(uint_value "$(summary_value "$SUMMARY_FILE" remaining)" 0)
+cursor=$(uint_value "$(summary_value "$SUMMARY_FILE" cursor)" 0)
+records=$(uint_value "$(summary_value "$SUMMARY_FILE" records)" 0)
+
+total_files=$((acc_files + run_files))
+total_dirs=$((acc_dirs + run_dirs))
+total_bytes=$((acc_bytes + run_bytes))
+total_skipped=$((acc_skipped + run_skipped))
+total_errors=$((acc_errors + run_errors))
+
+if [ "$code" -eq 9 ]; then
+  stopped=1
+  result="深度不可变快照清理已停止，已保存到第 ${cursor}/${records} 条，累计释放 $(human_bytes "$total_bytes")"
+  accum_tmp="$ACCUM_FILE.tmp.$$"
+  {
+    echo "snapshot_id=$snapshot_id"
+    echo "files=$total_files"
+    echo "dirs=$total_dirs"
+    echo "bytes=$total_bytes"
+    echo "skipped=$total_skipped"
+    echo "errors=$total_errors"
+  } >"$accum_tmp" && mv -f "$accum_tmp" "$ACCUM_FILE"
+elif [ "$code" -eq 0 ]; then
+  stopped=0
+  remaining=0
+  result="深度不可变快照清理完成，累计释放 $(human_bytes "$total_bytes")"
+  rm -f "$STATE_FILE" "$TARGETS_FILE" "$MANIFEST_FILE" "$CURSOR_FILE" "$STATE_DIR/deep_scan.manifest.env" "$ACCUM_FILE"
+else
+  stopped=0
+  result="深度不可变快照清理失败，代码 $code，进度保留在 ${cursor}/${records}"
+  accum_tmp="$ACCUM_FILE.tmp.$$"
+  {
+    echo "snapshot_id=$snapshot_id"
+    echo "files=$total_files"
+    echo "dirs=$total_dirs"
+    echo "bytes=$total_bytes"
+    echo "skipped=$total_skipped"
+    echo "errors=$total_errors"
+  } >"$accum_tmp" && mv -f "$accum_tmp" "$ACCUM_FILE"
+fi
+
+END_EPOCH=$(date +%s)
+elapsed=$((END_EPOCH - START_EPOCH))
+latest_tmp="$STATE_DIR/latest.env.tmp.$$"
+{
+  echo "mode=deep-clean"
+  echo "time=$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "schema=clean-result-v2"
+  echo "files=$total_files"
+  echo "regular_files=$total_files"
+  echo "empty_dirs=$total_dirs"
+  echo "bytes=$total_bytes"
+  echo "skipped=$total_skipped"
+  echo "errors=$total_errors"
+  echo "protected_items=$total_skipped"
+  echo "deep_manifest_records=$records"
+  echo "deep_manifest_cursor=$cursor"
+  echo "deep_remaining_records=$remaining"
+  echo "deep_stopped=$stopped"
+  echo "elapsed=$elapsed"
+  echo "engine=deep-manifest-v1"
+  echo "result=$result"
+} >"$latest_tmp" && mv -f "$latest_tmp" "$STATE_DIR/latest.env"
+cp -f "$REPORT_FILE" "$REPORT_DIR/latest.tsv" 2>/dev/null || true
+{
+  echo "----------------------------------------"
+  echo "$result"
+  echo "扫描快照: $snapshot_id"
+  echo "清理进度: $cursor/$records | 剩余: $remaining"
+  echo "累计清理: $total_files 个文件 / $total_dirs 个目录 / $(human_bytes "$total_bytes")"
+  echo "保护跳过: $total_skipped | 失败: $total_errors | 本次耗时: ${elapsed}s"
+} >>"$LOG_FILE"
+cp -f "$LOG_FILE" "$LOG_DIR/latest.log"
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$(date '+%Y-%m-%d %H:%M:%S')" deep-clean "$run_bytes" "$run_files" "$run_dirs" "$run_errors" \
+  "$result" "$TRIGGER" "深度不可变快照|$run_bytes|$run_files" "$snapshot_id" >>"$HISTORY_FILE"
+tail -n 100 "$HISTORY_FILE" >"$HISTORY_FILE.tmp.$$" 2>/dev/null && mv -f "$HISTORY_FILE.tmp.$$" "$HISTORY_FILE"
+
+echo "$result"
+echo "进度: $cursor/$records | 剩余: $remaining | 文件: $total_files | 目录: $total_dirs | 跳过: $total_skipped | 失败: $total_errors"
+[ "$code" -eq 9 ] && exit 9
+exit "$code"

--- a/v2/module/deep-scan-manifest.sh
+++ b/v2/module/deep-scan-manifest.sh
@@ -1,0 +1,103 @@
+#!/system/bin/sh
+set -u
+
+MODDIR=${0%/*}
+TRIGGER=${2:-manual}
+STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
+LOCK_DIR="$STATE_DIR/run.lock"
+RUNNING_FILE="$STATE_DIR/running.env"
+STOP_FILE="$STATE_DIR/stop"
+STATE_FILE="$STATE_DIR/deep_scan.env"
+TARGETS_FILE="$STATE_DIR/deep_scan.targets"
+MANIFEST_FILE="$STATE_DIR/deep_scan.manifest0"
+CURSOR_FILE="$STATE_DIR/deep_scan.cursor"
+BUILD_SUMMARY="$STATE_DIR/deep_scan.manifest.env"
+NATIVE_SCANNER="$MODDIR/native-cleaner.sh"
+SNAPSHOT_ENGINE="$MODDIR/bin/arm64-v8a/baize_deep_snapshot"
+
+mkdir -p "$STATE_DIR"
+
+proc_start_ticks() { [ -r "/proc/$1/stat" ] && awk '{print $22}' "/proc/$1/stat" 2>/dev/null || echo 0; }
+pid_is_task() {
+  pid=$1
+  [ "$pid" -gt 1 ] 2>/dev/null || return 1
+  [ -r "/proc/$pid/cmdline" ] || return 1
+  cmdline=$(tr '\000' ' ' <"/proc/$pid/cmdline" 2>/dev/null)
+  case "$cmdline" in *deep-scan-manifest.sh*|*native-scan.sh*|*native-cleaner.sh*|*cleaner.sh*|*task-worker.sh*|*worker-runner.sh*) return 0 ;; esac
+  return 1
+}
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  old_pid=$(sed -n '1p' "$LOCK_DIR/pid" 2>/dev/null)
+  case "$old_pid" in ''|*[!0-9]*) old_pid=0 ;; esac
+  if [ "$old_pid" -gt 1 ] && kill -0 "$old_pid" 2>/dev/null && pid_is_task "$old_pid"; then
+    echo "已有扫描或清理任务正在运行"
+    exit 3
+  fi
+  rm -rf -- "$LOCK_DIR" 2>/dev/null
+  rm -f "$RUNNING_FILE" 2>/dev/null
+  mkdir "$LOCK_DIR" 2>/dev/null || { echo "无法恢复任务锁，请重试"; exit 4; }
+fi
+printf '%s\n' "$$" >"$LOCK_DIR/pid"
+printf '%s\n' "$(proc_start_ticks $$)" >"$LOCK_DIR/start_ticks"
+cleanup_lock() { rm -f "$RUNNING_FILE" 2>/dev/null; rm -rf -- "$LOCK_DIR" 2>/dev/null; }
+trap cleanup_lock EXIT
+rm -f "$STOP_FILE" "$MANIFEST_FILE" "$CURSOR_FILE" "$BUILD_SUMMARY"
+
+[ -x "$SNAPSHOT_ENGINE" ] || { echo "深度不可变快照引擎缺失，请重新刷入完整模块" >&2; exit 8; }
+[ -f "$NATIVE_SCANNER" ] || { echo "原生深度扫描器缺失" >&2; exit 8; }
+
+BAIZE_LOCK_HELD=1 "$NATIVE_SCANNER" deep-scan "$TRIGGER"
+scan_code=$?
+if [ "$scan_code" -ne 0 ]; then
+  rm -f "$MANIFEST_FILE" "$CURSOR_FILE" "$BUILD_SUMMARY"
+  exit "$scan_code"
+fi
+
+[ -f "$STATE_FILE" ] && [ -f "$TARGETS_FILE" ] || {
+  echo "深度扫描未生成有效目标快照" >&2
+  rm -f "$STATE_FILE" "$TARGETS_FILE"
+  exit 7
+}
+
+max_file_bytes=$(sed -n 's/^max_file_bytes=//p' "$STATE_FILE" 2>/dev/null | tail -n 1)
+case "$max_file_bytes" in ''|*[!0-9]*) max_file_bytes=268435456 ;; esac
+manifest_tmp="$LOCK_DIR/deep_scan.manifest0"
+summary_tmp="$LOCK_DIR/deep_scan.manifest.env"
+"$SNAPSHOT_ENGINE" build \
+  --targets "$TARGETS_FILE" \
+  --manifest "$manifest_tmp" \
+  --summary "$summary_tmp" \
+  --progress "$RUNNING_FILE" \
+  --stop "$STOP_FILE" \
+  --max-file-bytes "$max_file_bytes"
+build_code=$?
+if [ "$build_code" -ne 0 ]; then
+  rm -f "$STATE_FILE" "$TARGETS_FILE" "$manifest_tmp" "$summary_tmp"
+  [ "$build_code" -eq 9 ] && echo "深度扫描已停止，未保留不完整快照"
+  exit "$build_code"
+fi
+
+mv -f "$manifest_tmp" "$MANIFEST_FILE"
+mv -f "$summary_tmp" "$BUILD_SUMMARY"
+printf '0\n' >"$CURSOR_FILE"
+manifest_sha=$(sha256sum "$MANIFEST_FILE" 2>/dev/null | awk 'NR==1{print $1}')
+manifest_records=$(sed -n 's/^records=//p' "$BUILD_SUMMARY" 2>/dev/null | tail -n 1)
+case "$manifest_records" in ''|*[!0-9]*) manifest_records=0 ;; esac
+snapshot_epoch=$(sed -n 's/^epoch=//p' "$STATE_FILE" 2>/dev/null | tail -n 1)
+case "$snapshot_epoch" in ''|*[!0-9]*) snapshot_epoch=$(date +%s) ;; esac
+snapshot_id="${snapshot_epoch}-$(printf '%s' "$manifest_sha" | cut -c1-16)"
+state_tmp="$STATE_FILE.tmp.$$"
+sed '/^snapshot_id=/d;/^manifest_/d;/^cursor_/d;/^snapshot_schema=/d' "$STATE_FILE" >"$state_tmp"
+{
+  echo "snapshot_id=$snapshot_id"
+  echo "snapshot_schema=deep-file-manifest-v1"
+  echo "manifest_sha=$manifest_sha"
+  echo "manifest_records=$manifest_records"
+  echo "cursor_file=deep_scan.cursor"
+  echo "manifest_engine=deep-manifest-v1"
+} >>"$state_tmp"
+mv -f "$state_tmp" "$STATE_FILE"
+chmod 0600 "$STATE_FILE" "$TARGETS_FILE" "$MANIFEST_FILE" "$CURSOR_FILE" "$BUILD_SUMMARY" 2>/dev/null || true
+
+echo "深度逐文件快照已固化：$manifest_records 条记录，可直接清理且不会重新遍历文件"

--- a/v2/module/service.sh
+++ b/v2/module/service.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 # Canonical Magisk module root: /data/adb/modules/baize_v2; MODDIR remains portable for KernelSU and APatch.
-# Runtime migration supersedes the previous deep-pipeline-v1 schema and clears stale single-lane locks.
+# Runtime migration clears stale queues, locks and pre-manifest deep snapshots.
 MODDIR=${0%/*}
 APP_ID=io.github.xgl34222220.baize
 STATE_DIR=/data/adb/baize-v2
@@ -9,14 +9,16 @@ CONFIG="$STATE_DIR/config.conf"
 rm -rf "$MODDIR/webroot" "$MODDIR/webui" "$MODDIR/www" "$MODDIR/ksu-webui" 2>/dev/null || true
 mkdir -p "$STATE_DIR" "$STATE_DIR/logs" "$STATE_DIR/reports"
 chmod 0700 "$STATE_DIR"
-RUNTIME_SCHEMA=concurrent-lanes-v1
+RUNTIME_SCHEMA=deep-manifest-v1
 SCHEMA_FILE="$STATE_DIR/runtime-schema"
 current_schema=$(sed -n '1p' "$SCHEMA_FILE" 2>/dev/null)
 if [ "$current_schema" != "$RUNTIME_SCHEMA" ]; then
   rm -rf "$STATE_DIR/run.lock" "$STATE_DIR/cache-lane.lock" "$STATE_DIR/cache-lane" "$STATE_DIR/scheduler-requests" "$STATE_DIR/scheduler-skips"
   rm -f "$STATE_DIR/running.env" "$STATE_DIR/worker.env" "$STATE_DIR/scheduler.env" \
     "$STATE_DIR/supervisor.env" "$STATE_DIR/scheduler-queue.tsv" "$STATE_DIR/supervisor.stop" \
-    "$STATE_DIR/stop" "$STATE_DIR/deep_scan.env" "$STATE_DIR/deep_scan.targets"
+    "$STATE_DIR/stop" "$STATE_DIR/deep_scan.env" "$STATE_DIR/deep_scan.targets" \
+    "$STATE_DIR/deep_scan.manifest0" "$STATE_DIR/deep_scan.cursor" \
+    "$STATE_DIR/deep_scan.manifest.env" "$STATE_DIR/deep_clean.accum.env"
   rm -f "$STATE_DIR"/scheduler-retry-*.count "$STATE_DIR"/scheduler-retry-*.until \
     "$STATE_DIR"/scheduler-fail-*.count "$STATE_DIR"/scheduler-pause-*.until 2>/dev/null || true
   mkdir -p "$STATE_DIR/scheduler-requests" "$STATE_DIR/scheduler-skips"

--- a/v2/module/service.sh
+++ b/v2/module/service.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 # Canonical Magisk module root: /data/adb/modules/baize_v2; MODDIR remains portable for KernelSU and APatch.
-# Runtime migration clears stale queues, locks and pre-manifest deep snapshots.
+# Runtime migration supersedes deep-pipeline-v1 and clears stale queues, locks and pre-manifest deep snapshots.
 MODDIR=${0%/*}
 APP_ID=io.github.xgl34222220.baize
 STATE_DIR=/data/adb/baize-v2

--- a/v2/native/baize_deep_snapshot.c
+++ b/v2/native/baize_deep_snapshot.c
@@ -1,0 +1,541 @@
+#define _GNU_SOURCE
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#define MANIFEST_FIELDS 11U
+#define ENGINE_VERSION "deep-manifest-v1"
+
+typedef struct {
+    const char *targets;
+    const char *manifest;
+    const char *cursor;
+    const char *report;
+    const char *summary;
+    const char *whitelist;
+    const char *progress;
+    const char *stop;
+    uint64_t max_file_bytes;
+} Options;
+
+typedef struct {
+    char **items;
+    size_t count;
+    size_t capacity;
+} StringList;
+
+typedef struct {
+    char *field[MANIFEST_FIELDS];
+    size_t capacity[MANIFEST_FIELDS];
+} Record;
+
+typedef struct {
+    uint64_t records;
+    uint64_t files;
+    uint64_t dirs;
+    uint64_t bytes;
+    uint64_t targets;
+    uint64_t processed;
+    uint64_t skipped;
+    uint64_t errors;
+} Summary;
+
+static Options g_options;
+static StringList g_whitelist;
+static uint64_t g_started_epoch;
+
+static void die(const char *message) {
+    fprintf(stderr, "%s\n", message);
+    exit(2);
+}
+
+static void *checked_realloc(void *pointer, size_t size) {
+    void *result = realloc(pointer, size ? size : 1U);
+    if (!result) die("out of memory");
+    return result;
+}
+
+static char *checked_strdup(const char *value) {
+    char *result = strdup(value ? value : "");
+    if (!result) die("out of memory");
+    return result;
+}
+
+static void list_add(StringList *list, const char *value) {
+    if (list->count == list->capacity) {
+        list->capacity = list->capacity ? list->capacity * 2U : 64U;
+        list->items = checked_realloc(list->items, list->capacity * sizeof(*list->items));
+    }
+    list->items[list->count++] = checked_strdup(value);
+}
+
+static void list_free(StringList *list) {
+    for (size_t i = 0; i < list->count; ++i) free(list->items[i]);
+    free(list->items);
+    memset(list, 0, sizeof(*list));
+}
+
+static void normalize_path(char *path) {
+    size_t length = path ? strlen(path) : 0U;
+    while (length > 1U && path[length - 1U] == '/') path[--length] = '\0';
+}
+
+static bool path_relation(const char *parent, const char *child) {
+    if (!parent || !child) return false;
+    size_t length = strlen(parent);
+    return strcmp(parent, child) == 0 ||
+           (strncmp(parent, child, length) == 0 && child[length] == '/');
+}
+
+static bool deep_allowed(const char *path) {
+    if (!path || path[0] != '/' || strcmp(path, "/") == 0) return false;
+    const char *deny[] = {
+        "/data/adb", "/data/app", "/data/system", "/data/misc", "/data/dalvik-cache",
+        "/system", "/vendor", "/product", "/apex"
+    };
+    for (size_t i = 0; i < sizeof(deny) / sizeof(deny[0]); ++i) {
+        if (path_relation(deny[i], path)) return false;
+    }
+    return strncmp(path, "/data/data/", 11U) == 0 ||
+           strncmp(path, "/data/user/", 11U) == 0 ||
+           strncmp(path, "/data/user_de/", 14U) == 0 ||
+           strncmp(path, "/data/cache/", 12U) == 0 ||
+           strncmp(path, "/data/media/", 12U) == 0 ||
+           strncmp(path, "/data_mirror/data_ce/", 21U) == 0;
+}
+
+static bool valid_risk(const char *risk) {
+    return risk && (strcmp(risk, "low") == 0 || strcmp(risk, "medium") == 0 ||
+                    strcmp(risk, "high") == 0 || strcmp(risk, "critical") == 0);
+}
+
+static void load_whitelist(void) {
+    if (!g_options.whitelist) return;
+    FILE *file = fopen(g_options.whitelist, "r");
+    if (!file) return;
+    char *line = NULL;
+    size_t capacity = 0;
+    while (getline(&line, &capacity, file) >= 0) {
+        char *start = line;
+        while (isspace((unsigned char)*start)) ++start;
+        char *end = start + strlen(start);
+        while (end > start && isspace((unsigned char)end[-1])) *--end = '\0';
+        if (*start != '/') continue;
+        normalize_path(start);
+        list_add(&g_whitelist, start);
+    }
+    free(line);
+    fclose(file);
+}
+
+static bool whitelist_conflict(const char *path) {
+    for (size_t i = 0; i < g_whitelist.count; ++i) {
+        if (path_relation(g_whitelist.items[i], path) || path_relation(path, g_whitelist.items[i])) return true;
+    }
+    return false;
+}
+
+static bool stop_requested(void) {
+    return g_options.stop && access(g_options.stop, F_OK) == 0;
+}
+
+static void sanitize_text(char *value) {
+    for (; value && *value; ++value) {
+        if (*value == '\t' || *value == '\r' || *value == '\n') *value = ' ';
+    }
+}
+
+static void write_progress(const char *mode, const char *phase, uint64_t current,
+                           uint64_t total, const char *path) {
+    if (!g_options.progress) return;
+    char temporary[PATH_MAX];
+    if (snprintf(temporary, sizeof(temporary), "%s.tmp.%ld", g_options.progress, (long)getpid()) < 0) return;
+    FILE *file = fopen(temporary, "w");
+    if (!file) return;
+    char clean_path[PATH_MAX];
+    snprintf(clean_path, sizeof(clean_path), "%s", path ? path : "");
+    sanitize_text(clean_path);
+    fprintf(file,
+            "mode=%s\nphase=%s\nstarted=%" PRIu64 "\nprogress_current=%" PRIu64
+            "\nprogress_total=%" PRIu64 "\ncurrent_path=%s\nengine=%s\n",
+            mode, phase, g_started_epoch, current, total, clean_path, ENGINE_VERSION);
+    fclose(file);
+    rename(temporary, g_options.progress);
+}
+
+static bool write_nul_field(FILE *file, const char *value) {
+    size_t length = strlen(value) + 1U;
+    return fwrite(value, 1U, length, file) == length;
+}
+
+static bool write_nul_u64(FILE *file, uint64_t value) {
+    char text[32];
+    snprintf(text, sizeof(text), "%" PRIu64, value);
+    return write_nul_field(file, text);
+}
+
+static bool write_record(FILE *file, const char *kind, const char *risk, const char *target,
+                         const struct stat *status, uint64_t size, const char *path) {
+    return write_nul_field(file, kind) && write_nul_field(file, risk) &&
+           write_nul_field(file, target) &&
+           write_nul_u64(file, (uint64_t)status->st_dev) &&
+           write_nul_u64(file, (uint64_t)status->st_ino) &&
+           write_nul_u64(file, size) &&
+           write_nul_u64(file, (uint64_t)status->st_mtim.tv_sec) &&
+           write_nul_u64(file, (uint64_t)status->st_mtim.tv_nsec) &&
+           write_nul_u64(file, (uint64_t)status->st_ctim.tv_sec) &&
+           write_nul_u64(file, (uint64_t)status->st_ctim.tv_nsec) &&
+           write_nul_field(file, path);
+}
+
+static int copy_stream(FILE *source, FILE *destination) {
+    rewind(source);
+    char buffer[16384];
+    size_t count;
+    while ((count = fread(buffer, 1U, sizeof(buffer), source)) > 0U) {
+        if (fwrite(buffer, 1U, count, destination) != count) return -1;
+    }
+    return ferror(source) ? -1 : 0;
+}
+
+static int snapshot_path(const char *path, const char *target, const char *risk,
+                         dev_t root_device, FILE *manifest, Summary *summary, unsigned depth) {
+    if (depth > 512U) return -1;
+    if (stop_requested()) return 9;
+    struct stat status;
+    if (lstat(path, &status) != 0) return -1;
+    if (S_ISLNK(status.st_mode)) return 0;
+    if (S_ISREG(status.st_mode)) {
+        uint64_t size = status.st_size > 0 ? (uint64_t)status.st_size : 0U;
+        if (size > g_options.max_file_bytes) return 8;
+        if (!write_record(manifest, "file", risk, target, &status, size, path)) return -1;
+        summary->records++;
+        summary->files++;
+        summary->bytes += size;
+        return 0;
+    }
+    if (!S_ISDIR(status.st_mode)) return 0;
+    if (depth > 0U && status.st_dev != root_device) return 8;
+    DIR *directory = opendir(path);
+    if (!directory) return -1;
+    struct dirent *entry;
+    int result = 0;
+    while ((entry = readdir(directory)) != NULL) {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) continue;
+        char child[PATH_MAX];
+        int written = snprintf(child, sizeof(child), "%s/%s", path, entry->d_name);
+        if (written < 0 || (size_t)written >= sizeof(child)) { result = -1; break; }
+        result = snapshot_path(child, target, risk, root_device, manifest, summary, depth + 1U);
+        if (result != 0) break;
+    }
+    closedir(directory);
+    if (result != 0) return result;
+    if (lstat(path, &status) != 0 || !S_ISDIR(status.st_mode) || S_ISLNK(status.st_mode)) return -1;
+    if (!write_record(manifest, "dir", risk, target, &status, 0U, path)) return -1;
+    summary->records++;
+    summary->dirs++;
+    return 0;
+}
+
+static int build_manifest(void) {
+    if (!g_options.targets || !g_options.manifest || !g_options.summary) die("missing build paths");
+    FILE *targets = fopen(g_options.targets, "r");
+    FILE *manifest = fopen(g_options.manifest, "wb");
+    if (!targets || !manifest) {
+        if (targets) fclose(targets);
+        if (manifest) fclose(manifest);
+        return 71;
+    }
+    Summary total = {0};
+    char *line = NULL;
+    size_t capacity = 0;
+    uint64_t current = 0;
+    int result = 0;
+    while (getline(&line, &capacity, targets) >= 0) {
+        char *end = line + strlen(line);
+        while (end > line && (end[-1] == '\n' || end[-1] == '\r')) *--end = '\0';
+        if (!*line) continue;
+        char *tab = strrchr(line, '\t');
+        if (!tab) { result = 7; break; }
+        *tab = '\0';
+        const char *target = line;
+        const char *risk = tab + 1;
+        normalize_path(line);
+        if (!deep_allowed(target) || !valid_risk(risk)) { result = 7; break; }
+        struct stat root;
+        if (lstat(target, &root) != 0 || S_ISLNK(root.st_mode)) { result = 7; break; }
+        current++;
+        write_progress("deep-scan", "正在固化逐文件深度快照", current, 0U, target);
+        FILE *temporary = tmpfile();
+        if (!temporary) { result = 71; break; }
+        Summary target_summary = {0};
+        int code = snapshot_path(target, target, risk, root.st_dev, temporary, &target_summary, 0U);
+        if (code == 0) code = copy_stream(temporary, manifest);
+        fclose(temporary);
+        if (code != 0) { result = code; break; }
+        total.records += target_summary.records;
+        total.files += target_summary.files;
+        total.dirs += target_summary.dirs;
+        total.bytes += target_summary.bytes;
+        total.targets++;
+    }
+    free(line);
+    fclose(targets);
+    fflush(manifest);
+    fsync(fileno(manifest));
+    fclose(manifest);
+    if (result != 0) {
+        unlink(g_options.manifest);
+        return result;
+    }
+    FILE *summary = fopen(g_options.summary, "w");
+    if (!summary) return 71;
+    fprintf(summary,
+            "records=%" PRIu64 "\nfiles=%" PRIu64 "\ndirs=%" PRIu64
+            "\nbytes=%" PRIu64 "\ntargets=%" PRIu64 "\nengine=%s\n",
+            total.records, total.files, total.dirs, total.bytes, total.targets, ENGINE_VERSION);
+    fclose(summary);
+    return 0;
+}
+
+static int read_nul_field(FILE *file, char **value, size_t *capacity) {
+    ssize_t length = getdelim(value, capacity, '\0', file);
+    if (length < 0) return feof(file) ? 0 : -1;
+    if (length == 0 || (*value)[length - 1] != '\0') return -1;
+    (*value)[length - 1] = '\0';
+    return 1;
+}
+
+static int read_record(FILE *file, Record *record) {
+    int first = read_nul_field(file, &record->field[0], &record->capacity[0]);
+    if (first <= 0) return first;
+    for (size_t i = 1; i < MANIFEST_FIELDS; ++i) {
+        if (read_nul_field(file, &record->field[i], &record->capacity[i]) != 1) return -1;
+    }
+    return 1;
+}
+
+static void free_record(Record *record) {
+    for (size_t i = 0; i < MANIFEST_FIELDS; ++i) free(record->field[i]);
+    memset(record, 0, sizeof(*record));
+}
+
+static bool parse_u64(const char *text, uint64_t *value) {
+    if (!text || !*text) return false;
+    char *end = NULL;
+    errno = 0;
+    unsigned long long parsed = strtoull(text, &end, 10);
+    if (errno != 0 || !end || *end != '\0') return false;
+    *value = (uint64_t)parsed;
+    return true;
+}
+
+static bool file_metadata_matches(const struct stat *status, uint64_t device, uint64_t inode,
+                                  uint64_t size, uint64_t mtime_sec, uint64_t mtime_nsec,
+                                  uint64_t ctime_sec, uint64_t ctime_nsec) {
+    uint64_t actual_size = status->st_size > 0 ? (uint64_t)status->st_size : 0U;
+    return S_ISREG(status->st_mode) && !S_ISLNK(status->st_mode) &&
+           (uint64_t)status->st_dev == device && (uint64_t)status->st_ino == inode &&
+           actual_size == size &&
+           (uint64_t)status->st_mtim.tv_sec == mtime_sec &&
+           (uint64_t)status->st_mtim.tv_nsec == mtime_nsec &&
+           (uint64_t)status->st_ctim.tv_sec == ctime_sec &&
+           (uint64_t)status->st_ctim.tv_nsec == ctime_nsec;
+}
+
+static uint64_t read_cursor(void) {
+    if (!g_options.cursor) return 0U;
+    FILE *file = fopen(g_options.cursor, "r");
+    if (!file) return 0U;
+    unsigned long long value = 0U;
+    int matched = fscanf(file, "%llu", &value);
+    fclose(file);
+    return matched == 1 ? (uint64_t)value : 0U;
+}
+
+static int write_cursor(uint64_t value) {
+    if (!g_options.cursor) return 0;
+    char temporary[PATH_MAX];
+    if (snprintf(temporary, sizeof(temporary), "%s.tmp.%ld", g_options.cursor, (long)getpid()) < 0) return -1;
+    FILE *file = fopen(temporary, "w");
+    if (!file) return -1;
+    fprintf(file, "%" PRIu64 "\n", value);
+    fflush(file);
+    fsync(fileno(file));
+    fclose(file);
+    return rename(temporary, g_options.cursor);
+}
+
+static FILE *open_report(void) {
+    FILE *file = fopen(g_options.report, "w");
+    if (file) fprintf(file, "action\trisk\tcategory\titems\tbytes\tpath\n");
+    return file;
+}
+
+static void report_row(FILE *file, const char *action, const char *risk, uint64_t bytes, const char *path) {
+    if (!file) return;
+    char clean[PATH_MAX];
+    snprintf(clean, sizeof(clean), "%s", path ? path : "");
+    sanitize_text(clean);
+    fprintf(file, "%s\t%s\t深度不可变快照\t1\t%" PRIu64 "\t%s\n",
+            action, risk, bytes, clean);
+}
+
+static int clean_manifest(void) {
+    if (!g_options.manifest || !g_options.cursor || !g_options.report || !g_options.summary) die("missing clean paths");
+    load_whitelist();
+    FILE *manifest = fopen(g_options.manifest, "rb");
+    FILE *report = open_report();
+    if (!manifest || !report) {
+        if (manifest) fclose(manifest);
+        if (report) fclose(report);
+        return 71;
+    }
+    Record record = {0};
+    uint64_t total = 0U;
+    int read_code;
+    while ((read_code = read_record(manifest, &record)) == 1) total++;
+    if (read_code < 0) { free_record(&record); fclose(manifest); fclose(report); return 7; }
+    uint64_t cursor = read_cursor();
+    if (cursor > total) { free_record(&record); fclose(manifest); fclose(report); return 7; }
+    rewind(manifest);
+    for (uint64_t i = 0; i < cursor; ++i) {
+        if (read_record(manifest, &record) != 1) { free_record(&record); fclose(manifest); fclose(report); return 7; }
+    }
+    Summary summary = {0};
+    summary.records = total;
+    uint64_t current = cursor;
+    int result = 0;
+    while ((read_code = read_record(manifest, &record)) == 1) {
+        if (stop_requested()) { result = 9; break; }
+        const char *kind = record.field[0];
+        const char *risk = record.field[1];
+        const char *target = record.field[2];
+        const char *path = record.field[10];
+        if (current == cursor || current % 128U == 0U || current + 1U == total) {
+            write_progress("deep-clean", "正在消费逐文件深度快照", current, total, path);
+        }
+        uint64_t device, inode, size, mtime_sec, mtime_nsec, ctime_sec, ctime_nsec;
+        bool metadata_ok = parse_u64(record.field[3], &device) &&
+                           parse_u64(record.field[4], &inode) &&
+                           parse_u64(record.field[5], &size) &&
+                           parse_u64(record.field[6], &mtime_sec) &&
+                           parse_u64(record.field[7], &mtime_nsec) &&
+                           parse_u64(record.field[8], &ctime_sec) &&
+                           parse_u64(record.field[9], &ctime_nsec);
+        bool common_ok = metadata_ok && valid_risk(risk) && deep_allowed(target) &&
+                         deep_allowed(path) && path_relation(target, path) &&
+                         !whitelist_conflict(path) && size <= g_options.max_file_bytes;
+        if (!common_ok || (strcmp(kind, "file") != 0 && strcmp(kind, "dir") != 0)) {
+            summary.skipped++;
+            report_row(report, "protected", valid_risk(risk) ? risk : "high", 0U, path);
+        } else if (strcmp(kind, "file") == 0) {
+            struct stat first;
+            struct stat second;
+            if (lstat(path, &first) != 0) {
+                summary.skipped++;
+                report_row(report, "missing", risk, 0U, path);
+            } else if (!file_metadata_matches(&first, device, inode, size, mtime_sec, mtime_nsec, ctime_sec, ctime_nsec) ||
+                       lstat(path, &second) != 0 ||
+                       !file_metadata_matches(&second, device, inode, size, mtime_sec, mtime_nsec, ctime_sec, ctime_nsec)) {
+                summary.skipped++;
+                report_row(report, "changed", risk, size, path);
+            } else if (unlink(path) == 0) {
+                summary.files++;
+                summary.bytes += size;
+                report_row(report, "cleaned", risk, size, path);
+            } else {
+                summary.errors++;
+                report_row(report, "failed", risk, size, path);
+            }
+        } else {
+            struct stat status;
+            if (lstat(path, &status) != 0) {
+                summary.skipped++;
+                report_row(report, "missing", risk, 0U, path);
+            } else if (!S_ISDIR(status.st_mode) || S_ISLNK(status.st_mode) ||
+                       (uint64_t)status.st_dev != device || (uint64_t)status.st_ino != inode) {
+                summary.skipped++;
+                report_row(report, "changed", risk, 0U, path);
+            } else if (rmdir(path) == 0) {
+                summary.dirs++;
+                report_row(report, "cleaned", risk, 0U, path);
+            } else if (errno == ENOTEMPTY || errno == EEXIST) {
+                summary.skipped++;
+                report_row(report, "protected", risk, 0U, path);
+            } else {
+                summary.errors++;
+                report_row(report, "failed", risk, 0U, path);
+            }
+        }
+        current++;
+        summary.processed++;
+        if (write_cursor(current) != 0) { result = 71; break; }
+    }
+    if (read_code < 0) result = 7;
+    free_record(&record);
+    fclose(manifest);
+    fclose(report);
+    FILE *summary_file = fopen(g_options.summary, "w");
+    if (!summary_file) return 71;
+    uint64_t remaining = total > current ? total - current : 0U;
+    fprintf(summary_file,
+            "records=%" PRIu64 "\nprocessed=%" PRIu64 "\nfiles=%" PRIu64
+            "\ndirs=%" PRIu64 "\nbytes=%" PRIu64 "\nskipped=%" PRIu64
+            "\nerrors=%" PRIu64 "\nremaining=%" PRIu64 "\ncursor=%" PRIu64
+            "\nengine=%s\n",
+            total, summary.processed, summary.files, summary.dirs, summary.bytes,
+            summary.skipped, summary.errors, remaining, current, ENGINE_VERSION);
+    fclose(summary_file);
+    return result;
+}
+
+static const char *option_value(int argc, char **argv, int *index) {
+    if (*index + 1 >= argc) die("missing option value");
+    return argv[++*index];
+}
+
+static void parse_options(int argc, char **argv) {
+    memset(&g_options, 0, sizeof(g_options));
+    g_options.max_file_bytes = 256ULL * 1024ULL * 1024ULL;
+    for (int i = 2; i < argc; ++i) {
+        const char *argument = argv[i];
+        if (strcmp(argument, "--targets") == 0) g_options.targets = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--manifest") == 0) g_options.manifest = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--cursor") == 0) g_options.cursor = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--report") == 0) g_options.report = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--summary") == 0) g_options.summary = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--whitelist") == 0) g_options.whitelist = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--progress") == 0) g_options.progress = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--stop") == 0) g_options.stop = option_value(argc, argv, &i);
+        else if (strcmp(argument, "--max-file-bytes") == 0) g_options.max_file_bytes = strtoull(option_value(argc, argv, &i), NULL, 10);
+        else die("unknown option");
+    }
+}
+
+int main(int argc, char **argv) {
+    if (argc < 2) die("usage: baize_deep_snapshot <build|clean> [options]");
+    g_started_epoch = (uint64_t)time(NULL);
+    parse_options(argc, argv);
+    int result;
+    if (strcmp(argv[1], "build") == 0) result = build_manifest();
+    else if (strcmp(argv[1], "clean") == 0) result = clean_manifest();
+    else die("unsupported command");
+    list_free(&g_whitelist);
+    return result;
+}

--- a/v2/scripts/build-native.sh
+++ b/v2/scripts/build-native.sh
@@ -3,7 +3,8 @@ set -eu
 
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 OUT="$ROOT/build/native/arm64-v8a"
-SOURCE="$ROOT/native/baize_engine_42_4.c"
+ENGINE_SOURCE="$ROOT/native/baize_engine_42_4.c"
+DEEP_SOURCE="$ROOT/native/baize_deep_snapshot.c"
 API=${ANDROID_API:-26}
 
 find_ndk() {
@@ -26,12 +27,16 @@ CC="$TOOLCHAIN/aarch64-linux-android${API}-clang"
 STRIP="$TOOLCHAIN/llvm-strip"
 
 [ -x "$CC" ] || { echo "未找到编译器：$CC" >&2; exit 1; }
-[ -f "$SOURCE" ] || { echo "未找到白泽 v2 原生引擎源码：$SOURCE" >&2; exit 1; }
+[ -f "$ENGINE_SOURCE" ] || { echo "未找到白泽原生扫描引擎源码：$ENGINE_SOURCE" >&2; exit 1; }
+[ -f "$DEEP_SOURCE" ] || { echo "未找到深度不可变快照源码：$DEEP_SOURCE" >&2; exit 1; }
 mkdir -p "$OUT"
-"$CC" -std=c11 -O2 -fPIE -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 \
-  -Wall -Wextra -Wformat=2 -Wshadow -Wconversion \
-  "$SOURCE" -o "$OUT/baize_engine"
-"$STRIP" --strip-unneeded "$OUT/baize_engine"
-chmod 0755 "$OUT/baize_engine"
-file "$OUT/baize_engine"
-echo "已生成白泽 v2.1.0 Alpha 4 有限并发/路径索引/不可变快照引擎：$OUT/baize_engine"
+
+COMMON_FLAGS='-std=c11 -O2 -fPIE -pie -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wall -Wextra -Wformat=2 -Wshadow -Wconversion'
+# shellcheck disable=SC2086
+"$CC" $COMMON_FLAGS "$ENGINE_SOURCE" -o "$OUT/baize_engine"
+# shellcheck disable=SC2086
+"$CC" $COMMON_FLAGS "$DEEP_SOURCE" -o "$OUT/baize_deep_snapshot"
+"$STRIP" --strip-unneeded "$OUT/baize_engine" "$OUT/baize_deep_snapshot"
+chmod 0755 "$OUT/baize_engine" "$OUT/baize_deep_snapshot"
+file "$OUT/baize_engine" "$OUT/baize_deep_snapshot"
+echo "已生成白泽 ARM64 扫描引擎与深度不可变快照引擎：$OUT"

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -8,12 +8,15 @@ MODULE="$ROOT/module"
 STAGE="$ROOT/build/module-stage"
 APK="$ROOT/app/build/outputs/apk/release/app-release.apk"
 NATIVE="$ROOT/build/native/arm64-v8a/baize_engine"
+DEEP_NATIVE="$ROOT/build/native/arm64-v8a/baize_deep_snapshot"
 OUTPUT="$OUT/BaiZe-v2.5.1-Module.zip"
 
 [ -f "$APK" ] || { echo "未找到已构建 APK：$APK" >&2; exit 1; }
 [ -x "$NATIVE" ] || { echo "未找到 arm64 原生扫描器：$NATIVE" >&2; exit 1; }
+[ -x "$DEEP_NATIVE" ] || { echo "未找到 arm64 深度不可变快照引擎：$DEEP_NATIVE" >&2; exit 1; }
 bash "$ROOT/tests/test-concurrent-scheduler.sh"
 bash "$ROOT/tests/test-deep-clean-budget.sh"
+bash "$ROOT/tests/test-deep-manifest.sh"
 
 rm -rf "$STAGE"
 mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
@@ -35,9 +38,10 @@ sed -i 's|STATE_DIR=/data/adb/safesweep|STATE_DIR=/data/adb/baize-v2|g' "$STAGE/
 sed -i 's|\*safesweep\*cleaner.sh\*|*baize_v2*cleaner.sh*|g; s|\*safesweep\*job-runner.sh\*|*baize_v2*job-runner.sh*|g; s|\*safesweep\*webctl.sh\*|*baize_v2*webctl.sh*|g' "$STAGE/cleaner.sh.compat"
 
 cp -f "$NATIVE" "$STAGE/bin/arm64-v8a/baize_engine"
+cp -f "$DEEP_NATIVE" "$STAGE/bin/arm64-v8a/baize_deep_snapshot"
 chmod 0755 "$STAGE/storage-index.sh" "$STAGE/task-worker.sh" "$STAGE/cache-lane-worker.sh" "$STAGE/organizer-worker.sh"
-chmod 0755 "$STAGE/cleaner.sh" "$STAGE/native-cleaner.sh" "$STAGE/cache-snapshot-clean.sh" "$STAGE/cache-transaction.sh" "$STAGE/one-pass-scan.sh" "$STAGE/profile-cleaner.sh" "$STAGE/apk-scanner.sh" "$STAGE/apk-cleaner.sh"
-chmod 0755 "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine"
+chmod 0755 "$STAGE/cleaner.sh" "$STAGE/native-cleaner.sh" "$STAGE/cache-snapshot-clean.sh" "$STAGE/cache-transaction.sh" "$STAGE/one-pass-scan.sh" "$STAGE/profile-cleaner.sh" "$STAGE/deep-scan-manifest.sh" "$STAGE/deep-manifest-clean.sh" "$STAGE/apk-scanner.sh" "$STAGE/apk-cleaner.sh"
+chmod 0755 "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine" "$STAGE/bin/arm64-v8a/baize_deep_snapshot"
 chmod 0755 "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh"
 chmod 0755 "$STAGE/quarantine-manager.sh" "$STAGE/large-file-scanner.sh" "$STAGE/duplicate-scanner.sh" "$STAGE/storage-analyzer.sh" "$STAGE/diagnostics-export.sh" "$STAGE/app-installer.sh" "$STAGE/supervisor.sh" "$STAGE/worker-runner.sh" "$STAGE/task-worker.sh" "$STAGE/rules-validator.sh" "$STAGE/organizer-worker.sh" "$STAGE/cache-lane-worker.sh"
 
@@ -66,17 +70,25 @@ unzip -p "$OUTPUT" cache-lane-worker.sh | grep -q 'BAIZE_ROOT_STATE_DIR'
 unzip -l "$OUTPUT" | grep -q 'organizer-worker.sh'
 unzip -p "$OUTPUT" scheduler.sh | grep -q 'resource-lane scheduler'
 unzip -p "$OUTPUT" scheduler.sh | grep -q 'run_parallel_pair'
+unzip -p "$OUTPUT" scheduler.sh | grep -q 'fixed-seven-fields-v1'
 unzip -p "$OUTPUT" task-worker.sh | grep -q 'detached-root-worker-v2.5.1'
 unzip -p "$OUTPUT" task-worker.sh | grep -q 'organize'
 unzip -p "$OUTPUT" organizer-worker.sh | grep -q 'organizer-result.env'
 unzip -p "$OUTPUT" organizer-worker.sh | grep -q 'operation=module-organize'
 unzip -p "$OUTPUT" organizer-worker.sh | grep -q 'build_fallback_index'
 unzip -l "$OUTPUT" | grep -q 'profile-cleaner.sh'
-unzip -p "$OUTPUT" profile-cleaner.sh | grep -q 'profile-snapshot-v42.8-stream-batch'
-unzip -p "$OUTPUT" profile-cleaner.sh | grep -q 'deep_clean_batch_files'
-unzip -p "$OUTPUT" profile-cleaner.sh | grep -q '正在连续批量清理'
-if unzip -p "$OUTPUT" profile-cleaner.sh | grep -Eq '跳过.*慢目标|目录超时保护|deep_clean_target_timeout_seconds|deep_clean_stage_limit_seconds'; then
-  echo "深度清理器不得通过超时跳过慢目标" >&2
+unzip -l "$OUTPUT" | grep -q 'deep-scan-manifest.sh'
+unzip -l "$OUTPUT" | grep -q 'deep-manifest-clean.sh'
+unzip -l "$OUTPUT" | grep -q 'bin/arm64-v8a/baize_deep_snapshot'
+unzip -p "$OUTPUT" cleaner.sh | grep -q 'deep-scan-manifest.sh'
+unzip -p "$OUTPUT" cleaner.sh | grep -q 'deep-manifest-clean.sh'
+unzip -p "$OUTPUT" deep-scan-manifest.sh | grep -q 'snapshot_schema=deep-file-manifest-v1'
+unzip -p "$OUTPUT" deep-scan-manifest.sh | grep -q 'manifest_sha='
+unzip -p "$OUTPUT" deep-manifest-clean.sh | grep -q 'deep_manifest_cursor'
+unzip -p "$OUTPUT" deep-manifest-clean.sh | grep -q 'deep_remaining_records'
+unzip -p "$OUTPUT" service.sh | grep -q 'RUNTIME_SCHEMA=deep-manifest-v1'
+if unzip -p "$OUTPUT" deep-manifest-clean.sh | grep -Eq '(^|[[:space:]])find[[:space:]]|xargs[[:space:]]'; then
+  echo "深度不可变快照清理器不得重新枚举目录" >&2
   exit 1
 fi
 unzip -l "$OUTPUT" | grep -q 'apk-scanner.sh'
@@ -99,7 +111,6 @@ unzip -p "$OUTPUT" one-pass-scan.sh | grep -q 'pruned_subtrees'
 unzip -p "$OUTPUT" one-pass-scan.sh | grep -q 'BAIZE_ROOT_WORKERS'
 unzip -p "$OUTPUT" one-pass-scan.sh | grep -q 'parallel_overlap_milli'
 unzip -p "$OUTPUT" config/default.conf | grep -q '^scan_root_workers=0$'
-unzip -p "$OUTPUT" config/default.conf | grep -q '^deep_clean_batch_files=512$'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-scanner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'
@@ -122,4 +133,4 @@ if unzip -p "$OUTPUT" cache-snapshot-clean.sh | grep -Eq 'find[[:space:]].*cache
   echo "缓存快照清理器不得重新枚举目录生成删除名单" >&2
   exit 1
 fi
-echo "已生成白泽 v2.5.1 完整强化模块：$OUTPUT"
+echo "已生成白泽 v2.5.1 深度不可变快照模块：$OUTPUT"

--- a/v2/tests/test-deep-manifest.sh
+++ b/v2/tests/test-deep-manifest.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "$0")/.." && pwd)
+BIN=${TMPDIR:-/tmp}/baize-deep-snapshot-test
+HOST_ROOT="/data/media/baize-deep-manifest-test-$$"
+WORK=${TMPDIR:-/tmp}/baize-deep-manifest-state-$$
+
+cleanup() {
+  rm -rf "$WORK" "$BIN"
+  sudo rm -rf "$HOST_ROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+mkdir -p "$WORK"
+sudo mkdir -p "$HOST_ROOT"
+sudo chown -R "$(id -u):$(id -g)" "$HOST_ROOT"
+
+gcc -std=c11 -O2 -Wall -Wextra -Werror "$ROOT/native/baize_deep_snapshot.c" -o "$BIN"
+
+TARGET="$HOST_ROOT/cache"
+mkdir -p "$TARGET/nested"
+printf 'old-a' >"$TARGET/old-a.bin"
+printf 'old-b' >"$TARGET/nested/old-b.bin"
+printf 'change-me' >"$TARGET/changed.bin"
+printf '%s\tlow\n' "$TARGET" >"$WORK/targets.tsv"
+: >"$WORK/whitelist.conf"
+
+"$BIN" build \
+  --targets "$WORK/targets.tsv" \
+  --manifest "$WORK/manifest0" \
+  --summary "$WORK/build.env" \
+  --progress "$WORK/progress.env" \
+  --stop "$WORK/stop" \
+  --max-file-bytes 1048576
+
+grep -q '^engine=deep-manifest-v1$' "$WORK/build.env"
+records=$(sed -n 's/^records=//p' "$WORK/build.env")
+files=$(sed -n 's/^files=//p' "$WORK/build.env")
+dirs=$(sed -n 's/^dirs=//p' "$WORK/build.env")
+[ "$records" -eq 5 ]
+[ "$files" -eq 3 ]
+[ "$dirs" -eq 2 ]
+[ -s "$WORK/manifest0" ]
+
+# A stop request must preserve cursor 0 and every snapshotted file.
+printf 'stop\n' >"$WORK/stop"
+printf '0\n' >"$WORK/cursor"
+set +e
+"$BIN" clean \
+  --manifest "$WORK/manifest0" \
+  --cursor "$WORK/cursor" \
+  --report "$WORK/stopped.tsv" \
+  --summary "$WORK/stopped.env" \
+  --whitelist "$WORK/whitelist.conf" \
+  --progress "$WORK/progress.env" \
+  --stop "$WORK/stop" \
+  --max-file-bytes 1048576
+stopped_code=$?
+set -e
+[ "$stopped_code" -eq 9 ]
+[ "$(cat "$WORK/cursor")" -eq 0 ]
+[ -e "$TARGET/old-a.bin" ]
+[ -e "$TARGET/nested/old-b.bin" ]
+
+# Files changed or created after the snapshot must survive. Unchanged records are consumed directly
+# from the manifest, and the post-order directory record removes only the now-empty old directory.
+rm -f "$WORK/stop"
+sleep 1
+printf 'changed-after-scan' >"$TARGET/changed.bin"
+printf 'new-after-scan' >"$TARGET/new.bin"
+mkdir -p "$TARGET/new-empty-dir"
+"$BIN" clean \
+  --manifest "$WORK/manifest0" \
+  --cursor "$WORK/cursor" \
+  --report "$WORK/clean.tsv" \
+  --summary "$WORK/clean.env" \
+  --whitelist "$WORK/whitelist.conf" \
+  --progress "$WORK/progress.env" \
+  --stop "$WORK/stop" \
+  --max-file-bytes 1048576
+
+[ ! -e "$TARGET/old-a.bin" ]
+[ ! -e "$TARGET/nested/old-b.bin" ]
+[ ! -d "$TARGET/nested" ]
+[ -e "$TARGET/changed.bin" ]
+[ -e "$TARGET/new.bin" ]
+[ -d "$TARGET/new-empty-dir" ]
+[ "$(cat "$WORK/cursor")" -eq "$records" ]
+grep -q '^remaining=0$' "$WORK/clean.env"
+grep -q '^files=2$' "$WORK/clean.env"
+grep -q $'^changed\tlow\t' "$WORK/clean.tsv"
+
+# Re-running at the completed cursor is idempotent and never starts a directory discovery pass.
+"$BIN" clean \
+  --manifest "$WORK/manifest0" \
+  --cursor "$WORK/cursor" \
+  --report "$WORK/idempotent.tsv" \
+  --summary "$WORK/idempotent.env" \
+  --whitelist "$WORK/whitelist.conf" \
+  --progress "$WORK/progress.env" \
+  --stop "$WORK/stop" \
+  --max-file-bytes 1048576
+grep -q '^processed=0$' "$WORK/idempotent.env"
+
+# A whitelist added after scanning protects the exact manifest record while still advancing safely.
+PROTECTED="$HOST_ROOT/protected-cache"
+mkdir -p "$PROTECTED"
+printf 'protected' >"$PROTECTED/item.bin"
+printf '%s\tlow\n' "$PROTECTED" >"$WORK/protected-targets.tsv"
+"$BIN" build \
+  --targets "$WORK/protected-targets.tsv" \
+  --manifest "$WORK/protected.manifest0" \
+  --summary "$WORK/protected-build.env" \
+  --progress "$WORK/progress.env" \
+  --stop "$WORK/stop" \
+  --max-file-bytes 1048576
+printf '%s\n' "$PROTECTED" >"$WORK/whitelist.conf"
+printf '0\n' >"$WORK/protected.cursor"
+"$BIN" clean \
+  --manifest "$WORK/protected.manifest0" \
+  --cursor "$WORK/protected.cursor" \
+  --report "$WORK/protected.tsv" \
+  --summary "$WORK/protected.env" \
+  --whitelist "$WORK/whitelist.conf" \
+  --progress "$WORK/progress.env" \
+  --stop "$WORK/stop" \
+  --max-file-bytes 1048576
+[ -e "$PROTECTED/item.bin" ]
+grep -q '^files=0$' "$WORK/protected.env"
+grep -q $'^protected\tlow\t' "$WORK/protected.tsv"
+
+# Cleanup scripts are manifest consumers; directory rediscovery is forbidden.
+! grep -Eq '(^|[[:space:]])find[[:space:]]|xargs[[:space:]]' "$ROOT/module/deep-manifest-clean.sh"
+grep -q 'snapshot_schema=deep-file-manifest-v1' "$ROOT/module/deep-scan-manifest.sh"
+grep -q 'deep_manifest_cursor' "$ROOT/module/deep-manifest-clean.sh"
+
+echo 'deep immutable manifest and resume cursor: ok'

--- a/v2/tests/test-deep-manifest.sh
+++ b/v2/tests/test-deep-manifest.sh
@@ -130,6 +130,45 @@ printf '0\n' >"$WORK/protected.cursor"
 grep -q '^files=0$' "$WORK/protected.env"
 grep -q $'^protected\tlow\t' "$WORK/protected.tsv"
 
+# Exercise the module wrapper, including state validation, native summary parsing, latest.env and
+# successful snapshot cleanup. This catches integration errors that a direct C test cannot see.
+MODULE="$WORK/module"
+STATE="$WORK/module-state"
+INTEGRATION_TARGET="$HOST_ROOT/integration-cache"
+mkdir -p "$MODULE/bin/arm64-v8a" "$STATE/reports" "$STATE/logs" "$INTEGRATION_TARGET"
+cp "$ROOT/module/deep-manifest-clean.sh" "$MODULE/deep-manifest-clean.sh"
+cp "$BIN" "$MODULE/bin/arm64-v8a/baize_deep_snapshot"
+chmod +x "$MODULE/bin/arm64-v8a/baize_deep_snapshot"
+printf 'integration' >"$INTEGRATION_TARGET/item.bin"
+printf '%s\tlow\n' "$INTEGRATION_TARGET" >"$STATE/deep_scan.targets"
+: >"$STATE/whitelist.conf"
+printf '%s\n' "$INTEGRATION_TARGET" >"$STATE/rules.conf"
+"$BIN" build \
+  --targets "$STATE/deep_scan.targets" \
+  --manifest "$STATE/deep_scan.manifest0" \
+  --summary "$STATE/deep_scan.manifest.env" \
+  --progress "$STATE/progress.env" \
+  --stop "$STATE/stop" \
+  --max-file-bytes 1048576
+printf '0\n' >"$STATE/deep_scan.cursor"
+cat >"$STATE/deep_scan.env" <<EOF
+epoch=$(date +%s)
+snapshot_id=integration-snapshot
+targets_sha=$(sha256sum "$STATE/deep_scan.targets" | awk '{print $1}')
+whitelist_sha=$(sha256sum "$STATE/whitelist.conf" | awk '{print $1}')
+rules_sha=$(sha256sum "$STATE/rules.conf" | awk '{print $1}')
+max_file_bytes=1048576
+manifest_sha=$(sha256sum "$STATE/deep_scan.manifest0" | awk '{print $1}')
+EOF
+BAIZE_STATE_DIR="$STATE" BAIZE_DEEP_RULES="$STATE/rules.conf" \
+  bash "$MODULE/deep-manifest-clean.sh" deep-clean integration >/dev/null
+[ ! -e "$INTEGRATION_TARGET/item.bin" ]
+[ ! -e "$STATE/deep_scan.env" ]
+[ ! -e "$STATE/deep_scan.manifest0" ]
+grep -q '^files=1$' "$STATE/latest.env"
+grep -q '^engine=deep-manifest-v1$' "$STATE/latest.env"
+grep -q '^deep_remaining_records=0$' "$STATE/latest.env"
+
 # Cleanup scripts are manifest consumers; directory rediscovery is forbidden.
 ! grep -Eq '(^|[[:space:]])find[[:space:]]|xargs[[:space:]]' "$ROOT/module/deep-manifest-clean.sh"
 grep -q 'snapshot_schema=deep-file-manifest-v1' "$ROOT/module/deep-scan-manifest.sh"


### PR DESCRIPTION
## 根因

当前深度清理虽然已改成连续批次，但清理阶段仍会对扫描目标重新执行目录遍历。这样既重复读取存储，也只能按目录级状态恢复，无法精确证明正在删除的文件与扫描时看到的是同一个对象。

## 新架构

- 深度扫描完成后，由独立 ARM64 原生快照引擎把每个候选文件固化为不可变 manifest。
- 每条记录保存类型、风险、所属目标、设备号、inode、大小、mtime、ctime 和完整路径。
- 目录记录按后序写入，只有同一 inode 且已经为空时才删除。
- 清理阶段只顺序消费 manifest，不再 `find` 或 `xargs` 重新发现文件。
- 文件删除前执行两次元数据校验；扫描后修改、替换、新增或白名单保护的内容不会删除。
- 每消费一条记录就原子写入 cursor。用户停止、Root 进程中断或设备重启后，可从准确记录位置继续。
- 完成前保留 manifest、cursor 和累计统计；全部完成后才清除快照。
- 新运行时 schema 会清除旧版目录级深度快照，避免混用两种格式。

## 模块与构建

- 新增 `baize_deep_snapshot` 原生引擎，并在 Android NDK 构建中与主扫描器一起编译、剥离和封包。
- 新增深度扫描固化器与 manifest 清理器。
- 安装脚本验证新组件、停止旧进程并迁移为 `deep-manifest-v1`。
- 模块封包检查禁止深度清理器重新出现目录发现命令。

## 回归覆盖

- 原生引擎以 `-Werror` 编译。
- 停止时 cursor 保持并可继续。
- 未变化旧文件删除，扫描后修改或新增文件保留。
- 后序空目录仅在 inode 未变化且为空时删除。
- 扫描后加入白名单会保护对应记录。
- 完成 cursor 重跑幂等，不重复清理。
- 现有调度、每日定时、并发、旧残留清理、增量索引和归类事务回归继续执行。
