### PR TITLE
ci: publish immutable v2.5.2 tag once

### DIFF
--- a/.github/release-v2.5.2.trigger
+++ b/.github/release-v2.5.2.trigger
@@ -1,0 +1,3 @@
+release_tag=v2.5.2
+target_sha=bfd437727d476d3f4a386cf0cea62402abe027ce
+policy=one-time-immutable

--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -13,9 +13,11 @@ on:
       - 'v2/native/**'
       - 'v2/scripts/**'
       - 'v2/tests/**'
+      - '.github/release-v2.5.2.trigger'
       - '.github/workflows/v2.5-concurrent-scheduler-ci.yml'
       - '.github/workflows/v2.5.1-release.yml'
       - '.github/workflows/v2.5.2-release.yml'
+      - '.github/workflows/v2.5.2-tag-publisher.yml'
   push:
     branches: [feat/v2.5.2-stability, feat/v2.5.2-deep-manifest, release/v2.5.2]
 

--- a/.github/workflows/v2.5.2-tag-publisher.yml
+++ b/.github/workflows/v2.5.2-tag-publisher.yml
@@ -34,7 +34,7 @@ jobs:
           git show "$TARGET_SHA:module.prop" | grep -qx 'version=v2.5.2'
           git show "$TARGET_SHA:module.prop" | grep -qx 'versionCode=25002'
           git show "$TARGET_SHA:v2/app/build.gradle.kts" | grep -q 'versionName = "2.5.2"'
-          git show "$TARGET_SHA:.github/workflows/v2.5.2-release.yml" | grep -q "- 'v2.5.2'"
+          git show "$TARGET_SHA:.github/workflows/v2.5.2-release.yml" | grep -q -- "- 'v2.5.2'"
 
       - name: Reject existing tag or release
         shell: bash

--- a/.github/workflows/v2.5.2-tag-publisher.yml
+++ b/.github/workflows/v2.5.2-tag-publisher.yml
@@ -1,0 +1,67 @@
+name: BaiZe v2.5.2 One-Time Tag Publisher
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/release-v2.5.2.trigger'
+      - '.github/workflows/v2.5.2-tag-publisher.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: baize-v2.5.2-one-time-tag
+  cancel-in-progress: false
+
+jobs:
+  create-fixed-tag:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: v2.5.2
+      TARGET_SHA: bfd437727d476d3f4a386cf0cea62402abe027ce
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify fixed release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          git cat-file -e "${TARGET_SHA}^{commit}"
+          git merge-base --is-ancestor "$TARGET_SHA" "$GITHUB_SHA"
+          git show "$TARGET_SHA:module.prop" | grep -qx 'version=v2.5.2'
+          git show "$TARGET_SHA:module.prop" | grep -qx 'versionCode=25002'
+          git show "$TARGET_SHA:v2/app/build.gradle.kts" | grep -q 'versionName = "2.5.2"'
+          git show "$TARGET_SHA:.github/workflows/v2.5.2-release.yml" | grep -q "- 'v2.5.2'"
+
+      - name: Reject existing tag or release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "${RELEASE_TAG} 标签已经存在，拒绝移动或覆盖。" >&2
+            exit 1
+          fi
+          status=$(curl -sS -o /tmp/release.json -w '%{http_code}' \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          [ "$status" = 404 ] || {
+            cat /tmp/release.json >&2 || true
+            echo "${RELEASE_TAG} Release 已存在或查询失败，拒绝发布。HTTP ${status}" >&2
+            exit 1
+          }
+
+      - name: Create immutable annotated tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$RELEASE_TAG" "$TARGET_SHA" -m 'BaiZe v2.5.2'
+          git push origin "refs/tags/${RELEASE_TAG}"


### PR DESCRIPTION
## 目的

当前 GitHub 连接器没有直接创建标签的写入接口。本 PR 增加一次性、仓库内可审计的标签发布器，用于把 `v2.5.2` 固定指向已通过全部 PR CI 的正式发布提交 `bfd437727d476d3f4a386cf0cea62402abe027ce`。

## 安全约束

- 仅在本 PR 合并到 `main` 且一次性触发文件发生变化时执行。
- 标签目标写死为已审核的发布提交，不使用引导 PR 自身的提交。
- 创建前验证版本号、App 版本和正式发布 workflow。
- 若同名标签或 Release 已存在，立即失败，禁止移动和覆盖。
- 只创建 annotated tag；真正 APK、模块 ZIP、SHA-256 与证书产物仍由 `v2.5.2-release.yml` 标签流水线构建发布。
- Root 稳定性 CI 已纳入本引导 workflow 与触发文件的变更范围。
