### PR TITLE
fix: run v2.5.2 release from fixed tag via one-time main trigger

### DIFF
--- a/.github/release-v2.5.2.publish
+++ b/.github/release-v2.5.2.publish
@@ -1,0 +1,4 @@
+release_tag=v2.5.2
+target_sha=bfd437727d476d3f4a386cf0cea62402abe027ce
+source=immutable-tag
+policy=one-time-no-overwrite

--- a/.github/workflows/v2.5.2-release.yml
+++ b/.github/workflows/v2.5.2-release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - 'v2.5.2'
+    branches:
+      - main
+    paths:
+      - '.github/release-v2.5.2.publish'
 
 permissions:
   contents: write
@@ -16,23 +20,29 @@ env:
   BAIZE_VERSION: v2.5.2
   BAIZE_VERSION_NAME: 2.5.2
   BAIZE_VERSION_CODE: '25002'
+  BAIZE_RELEASE_TARGET_SHA: bfd437727d476d3f4a386cf0cea62402abe027ce
   BAIZE_CERT_SHA256: 9efa848001ccdc168ea96753d332b1713e2668ba6a2fa22d5bfd98de65db1f0f
 
 jobs:
   verify-build-release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout immutable tag
+      - name: Checkout immutable v2.5.2 tag
         uses: actions/checkout@v4
         with:
+          ref: v2.5.2
           fetch-depth: 0
 
-      - name: Verify tag and v2.5.2 metadata
+      - name: Verify fixed tag and v2.5.2 metadata
         shell: bash
         run: |
           set -euo pipefail
-          test "$GITHUB_REF" = 'refs/tags/v2.5.2'
-          test "$(git rev-list -n 1 v2.5.2)" = "$GITHUB_SHA"
+          case "$GITHUB_REF" in
+            refs/tags/v2.5.2|refs/heads/main) ;;
+            *) echo "非法发布触发来源：$GITHUB_REF" >&2; exit 1 ;;
+          esac
+          test "$(git rev-parse HEAD)" = "$BAIZE_RELEASE_TARGET_SHA"
+          test "$(git rev-list -n 1 v2.5.2)" = "$BAIZE_RELEASE_TARGET_SHA"
           git diff --check
           cmp module.prop v2/module/module.prop
           grep -q 'versionName = "2.5.2"' v2/app/build.gradle.kts


### PR DESCRIPTION
## 根因

`v2.5.2` 标签由 GitHub Actions 的 `GITHUB_TOKEN` 创建。GitHub 为防止递归工作流，不会让这种标签推送再次触发另一个工作流，因此标签已存在，但原本仅监听标签的正式发布任务没有启动。

## 修复

- 保留 `v2.5.2` 标签触发方式。
- 增加一次性的 `main` 发布标记触发方式。
- 无论触发来源是什么，构建步骤都显式检出 `v2.5.2` 标签。
- 强制验证检出的 HEAD 和标签都等于固定提交 `bfd437727d476d3f4a386cf0cea62402abe027ce`。
- 若同名 Release 已存在则失败，继续禁止移动标签、编辑 Release 或覆盖资产。
- 正式签名、Root 回归、Android Release/Lint、Macrobenchmark、两个 ARM64 引擎、模块封包和 SHA-256 校验流程保持不变。

合并后 `.github/release-v2.5.2.publish` 会触发一次正式发布。