### PR TITLE
feat: add automatic task health diagnostics and repair

### DIFF
--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -56,7 +56,9 @@ jobs:
       - name: Daily scheduler field regression
         run: bash v2/tests/test-scheduler-daily-fields.sh
       - name: Scheduler health diagnostics regression
-        run: bash v2/tests/test-scheduler-health-diagnostics.sh
+        run: |
+          bash v2/tests/test-scheduler-health-contract.sh
+          bash v2/tests/test-scheduler-health-diagnostics.sh
       - name: Concurrent scheduler regression
         shell: bash
         run: |

--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -55,6 +55,8 @@ jobs:
         run: bash v2/tests/test-scheduler-fairness.sh
       - name: Daily scheduler field regression
         run: bash v2/tests/test-scheduler-daily-fields.sh
+      - name: Scheduler health diagnostics regression
+        run: bash v2/tests/test-scheduler-health-diagnostics.sh
       - name: Concurrent scheduler regression
         shell: bash
         run: |

--- a/docs/roadmap/step-1-scheduler-health.md
+++ b/docs/roadmap/step-1-scheduler-health.md
@@ -1,0 +1,42 @@
+# 第一步：自动任务体检与诊断
+
+本阶段只增强自动任务的可解释性、诊断和自愈能力，不改变任何任务周期范围、默认周期或自动任务开关。
+
+## 已实现
+
+- Scheduler 与 Supervisor 进程、心跳和队列健康状态。
+- 结构化阻塞原因码和真实 `blocked_groups`。
+- 无破坏体检，不创建清理任务、不扫描用户文件、不修改配置。
+- 一键修复陈旧锁、停止标记和临时状态，并重新唤醒 Supervisor。
+- 脱敏诊断包，优先导出到 `Download/BaiZe`。
+- Material 与 MIUIx 设置页共用的自动任务体检面板。
+
+## 原因码
+
+- `SCHEDULER_DISABLED`
+- `SERVICE_UNHEALTHY`
+- `RUNNING`
+- `WAIT_SCREEN_OFF`
+- `WAIT_CHARGING`
+- `WAIT_BATTERY`
+- `WAIT_IDLE`
+- `USER_STOPPED`
+- `TASK_CONFLICT`
+- `RECOVERING`
+- `RETRY_BACKOFF`
+- `SKIPPED`
+- `QUEUED`
+- `WAIT_NEXT_RUN`
+- `WAITING`
+
+## 安全边界
+
+体检与修复不会修改：
+
+- 定时周期；
+- 每日固定时间；
+- 任务启用状态；
+- 清理规则；
+- 白名单；
+- 扫描快照；
+- 用户文件。

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt
@@ -77,6 +77,10 @@ internal class SchedulerRepository(
         val normalized = command.trim().lowercase(Locale.ROOT)
         return when {
             normalized == "scheduler-wake" -> wakeSupervisor("app-watchdog")
+            normalized == "scheduler-health" -> schedulerHealth()
+            normalized == "scheduler-self-test" -> schedulerSelfTest()
+            normalized == "scheduler-repair" -> repairScheduler()
+            normalized == "scheduler-export-diagnostics" -> exportDiagnostics()
             normalized == "scheduler-run-now:all" -> {
                 val config = configJsonObject()
                 val groups = GROUPS.filter { config.optInt("schedule_${it}_enabled", 0) == 1 }
@@ -98,6 +102,172 @@ internal class SchedulerRepository(
                 JSONObject().put("success", true).put("action", "stop-requested").toString()
             }
             else -> error("unsupported_scheduler_command", "不支持的调度命令", normalized)
+        }
+    }
+
+    private fun schedulerHealth(): String {
+        val runtime = runtimeJsonObject()
+        val stale = runtime.optBoolean("stale")
+        val reason = runtime.optString("reason")
+        val code = runtime.optString("reasonCode")
+        return JSONObject()
+            .put("success", !stale)
+            .put("action", "health")
+            .put(
+                "message",
+                if (stale) "自动任务服务异常：$code · $reason"
+                else "自动任务体检正常：$code · $reason"
+            )
+            .put("runtime", runtime)
+            .toString()
+    }
+
+    private fun schedulerSelfTest(): String = runCatching {
+        stateDir.mkdirs()
+        ensureConfig()
+        val checks = JSONArray()
+        var passed = 0
+
+        fun record(id: String, label: String, ok: Boolean, detail: String = "") {
+            if (ok) passed += 1
+            checks.put(
+                JSONObject()
+                    .put("id", id)
+                    .put("label", label)
+                    .put("passed", ok)
+                    .apply { if (detail.isNotBlank()) put("detail", detail) }
+            )
+        }
+
+        record("module", "模块目录", moduleDir.isDirectory, moduleDir.path)
+        record("scheduler", "调度器脚本", File(moduleDir, "scheduler.sh").isFile)
+        record("supervisor", "守护脚本", File(moduleDir, "supervisor.sh").isFile)
+        record("config", "计划配置", File(RootPaths.CONFIG_FILE).isFile)
+        record("rules", "深度规则库", File(moduleDir, "config/deep.rules").isFile)
+
+        val probeDir = File(stateDir, "scheduler-health").apply { mkdirs() }
+        val probe = File(probeDir, "probe-${Process.myPid()}-${System.nanoTime()}.tmp")
+        val writable = runCatching {
+            RootFileStore.writeAtomic(probe, "probe=${System.currentTimeMillis()}\n")
+            probe.isFile && probe.delete()
+        }.getOrDefault(false)
+        record("state_write", "状态目录读写", writable, stateDir.path)
+
+        val runtime = runtimeJsonObject()
+        record("supervisor_process", "Supervisor 进程", runtime.optBoolean("supervisorHealthy"))
+        record("scheduler_process", "Scheduler 进程", runtime.optBoolean("schedulerHealthy"))
+        record(
+            "queue_schema",
+            "队列格式",
+            runtime.optString("queueSchema").let { it.isBlank() || it == "fixed-seven-fields-v1" },
+            runtime.optString("queueSchema", "尚未生成")
+        )
+
+        val total = checks.length()
+        val failed = total - passed
+        JSONObject()
+            .put("success", failed == 0)
+            .put("action", "self-test")
+            .put("passed", passed)
+            .put("failed", failed)
+            .put("checks", checks)
+            .put("runtime", runtime)
+            .put(
+                "message",
+                if (failed == 0) "自动任务体检完成：$passed/$total 项通过"
+                else "自动任务体检发现 $failed 项异常，建议点击一键修复"
+            )
+            .toString()
+    }.getOrElse { throwable ->
+        error("scheduler_self_test_failed", throwable.message ?: throwable.javaClass.simpleName)
+    }
+
+    private fun repairScheduler(): String = runCatching {
+        stateDir.mkdirs()
+        File(stateDir, "supervisor.stop").delete()
+        File(stateDir, "stop").delete()
+        clearStaleTaskMarkers()
+        stateDir.listFiles()
+            ?.filter {
+                it.name.startsWith("scheduler-candidates.tmp") ||
+                    it.name.startsWith("scheduler-queue.tsv.tmp") ||
+                    it.name.startsWith("scheduler.env.tmp") ||
+                    it.name.startsWith("supervisor.env.tmp")
+            }
+            ?.forEach { it.deleteRecursively() }
+
+        val wake = JSONObject(wakeSupervisor("manual-health-repair"))
+        val success = wake.optBoolean("success")
+        JSONObject()
+            .put("success", success)
+            .put("action", "repair")
+            .put(
+                "message",
+                if (success) "后台服务修复请求已发送，正在重新建立心跳与任务队列"
+                else "后台服务修复失败：${wake.optString("error", "无法启动 Supervisor")}"
+            )
+            .put("schedulerWake", wake)
+            .put("runtime", runtimeJsonObject())
+            .toString()
+    }.getOrElse { throwable ->
+        error("scheduler_repair_failed", throwable.message ?: throwable.javaClass.simpleName)
+    }
+
+    private fun exportDiagnostics(): String = runCatching {
+        val script = File(moduleDir, "diagnostics-export.sh")
+        require(script.isFile) { "diagnostics_export_missing" }
+        val process = ProcessBuilder("/system/bin/sh", script.absolutePath)
+            .redirectErrorStream(true)
+            .start()
+        val completed = process.waitFor(45, TimeUnit.SECONDS)
+        if (!completed) {
+            process.destroyForcibly()
+            error("diagnostics_timeout", "诊断包导出超时")
+        } else {
+            val output = process.inputStream.bufferedReader().use { it.readText().takeLast(16_000) }.trim()
+            val code = process.exitValue()
+            val path = output.lineSequence().lastOrNull().orEmpty()
+            JSONObject()
+                .put("success", code == 0)
+                .put("action", "export-diagnostics")
+                .put("exitCode", code)
+                .put("path", path)
+                .put("output", output)
+                .put(
+                    "message",
+                    if (code == 0 && path.isNotBlank()) "脱敏诊断包已导出：$path"
+                    else "诊断包导出失败${if (output.isNotBlank()) "：$output" else ""}"
+                )
+                .toString()
+        }
+    }.getOrElse { throwable ->
+        error("diagnostics_export_failed", throwable.message ?: throwable.javaClass.simpleName)
+    }
+
+    private fun clearStaleTaskMarkers() {
+        val lockDir = File(stateDir, "run.lock")
+        if (!lockDir.isDirectory) return
+        val pid = readEpoch(File(lockDir, "pid"))
+        val ticks = readEpoch(File(lockDir, "start_ticks"))
+        val alive = processMatches(
+            pid,
+            ticks,
+            listOf(
+                "task-worker.sh",
+                "worker-runner.sh",
+                "organizer-worker.sh",
+                "cleaner.sh",
+                "native-cleaner.sh",
+                "profile-cleaner.sh",
+                "baize_engine",
+                "baize_deep_snapshot"
+            )
+        )
+        if (!alive) {
+            lockDir.deleteRecursively()
+            if (!File(stateDir, "cache-lane.lock").isDirectory) {
+                File(stateDir, "running.env").delete()
+            }
         }
     }
 
@@ -197,10 +367,10 @@ internal class SchedulerRepository(
             .put("action", "supervisor-started")
             .put("reason", reason)
             .toString()
-    }.getOrElse { error ->
+    }.getOrElse { throwable ->
         JSONObject()
             .put("success", false)
-            .put("error", error.message ?: error.javaClass.simpleName)
+            .put("error", throwable.message ?: throwable.javaClass.simpleName)
             .put("reason", reason)
             .toString()
     }
@@ -229,11 +399,12 @@ internal class SchedulerRepository(
         val schedulerPid = scheduler.optLong("scheduler_pid", 0L)
         val supervisorPid = supervisor.optLong("pid", 0L)
         val supervisorInstance = supervisor.optString("instance_id")
+        val schedulerHeartbeat = scheduler.optLong("heartbeat_epoch", 0L)
         val schedulerHealthy = processMatches(
             schedulerPid,
             scheduler.optLong("scheduler_start_ticks", 0L),
             listOf("scheduler.sh", "service.sh"),
-            scheduler.optLong("heartbeat_epoch", 0L),
+            schedulerHeartbeat,
             expectedInstance = supervisorInstance.takeIf { it.isNotBlank() },
             actualInstance = scheduler.optString("instance_id")
         )
@@ -245,34 +416,79 @@ internal class SchedulerRepository(
             supervisorHeartbeat
         )
         val now = System.currentTimeMillis() / 1000L
-        val heartbeatAge = if (supervisorHeartbeat > 0L) (now - supervisorHeartbeat).coerceAtLeast(0L) else -1L
+        val schedulerHeartbeatAge = if (schedulerHeartbeat > 0L) (now - schedulerHeartbeat).coerceAtLeast(0L) else -1L
+        val supervisorHeartbeatAge = if (supervisorHeartbeat > 0L) (now - supervisorHeartbeat).coerceAtLeast(0L) else -1L
         val config = configJsonObject()
         val publicState = when {
             config.optInt("enabled", 1) != 1 -> "disabled"
             scheduler.optString("state") == "running" -> "running"
             else -> "waiting"
         }
+        val rawReason = scheduler.optString("reason")
+        val blockedGroups = scheduler.optString("blocked_groups")
+        val queueCount = scheduler.optInt("queue_count", queue.length()).coerceAtLeast(0)
+        val stale = !schedulerHealthy || !supervisorHealthy
+        val reasonCode = schedulerReasonCode(publicState, rawReason, blockedGroups, stale, queueCount)
+        val healthState = when {
+            publicState == "disabled" -> "disabled"
+            stale -> "unhealthy"
+            reasonCode == "RECOVERING" || reasonCode == "RETRY_BACKOFF" -> "recovering"
+            else -> "healthy"
+        }
         return JSONObject()
             .put("state", publicState)
+            .put("healthState", healthState)
             .put("group", scheduler.optString("group"))
-            .put("reason", publicSchedulerReason(publicState, scheduler.optString("reason")))
+            .put("reason", publicSchedulerReason(publicState, rawReason))
+            .put("reasonCode", reasonCode)
+            .put("reasonDetail", rawReason)
             .put("nextCheckEpoch", scheduler.optLong("next_check_epoch", 0L))
-            .put("heartbeatEpoch", scheduler.optLong("heartbeat_epoch", 0L))
-            .put("queueCount", scheduler.optInt("queue_count", queue.length()))
+            .put("updatedEpoch", scheduler.optLong("updated", 0L))
+            .put("heartbeatEpoch", schedulerHeartbeat)
+            .put("schedulerHeartbeatAge", schedulerHeartbeatAge)
+            .put("queueCount", queueCount)
             .put("queueGroups", scheduler.optString("queue_groups"))
             .put("nextTask", scheduler.optString("next_task"))
-            .put("blockedGroups", "")
+            .put("blockedGroups", blockedGroups)
+            .put("queueSchema", scheduler.optString("queue_schema"))
             .put("nextRuns", nextRunsJsonObject(config, now))
             .put("queue", queue)
             .put("schedulerHealthy", schedulerHealthy)
             .put("supervisorHealthy", supervisorHealthy)
             .put("supervisorStatus", supervisor.optString("status", "unknown"))
+            .put("supervisorReason", supervisor.optString("reason"))
             .put("supervisorRestartCount", supervisor.optInt("restart_count", 0))
             .put("supervisorHeartbeatEpoch", supervisorHeartbeat)
-            .put("supervisorHeartbeatAge", heartbeatAge)
-            .put("stale", !schedulerHealthy || !supervisorHealthy)
+            .put("supervisorHeartbeatAge", supervisorHeartbeatAge)
+            .put("stale", stale)
     }
 
+    private fun schedulerReasonCode(
+        state: String,
+        rawReason: String,
+        blockedGroups: String,
+        stale: Boolean,
+        queueCount: Int
+    ): String {
+        val reason = "$rawReason,$blockedGroups"
+        return when {
+            state == "disabled" -> "SCHEDULER_DISABLED"
+            stale -> "SERVICE_UNHEALTHY"
+            state == "running" -> "RUNNING"
+            reason.contains("息屏") -> "WAIT_SCREEN_OFF"
+            reason.contains("充电") -> "WAIT_CHARGING"
+            reason.contains("电量") -> "WAIT_BATTERY"
+            reason.contains("空闲") -> "WAIT_IDLE"
+            reason.contains("停止") -> "USER_STOPPED"
+            reason.contains("已有") || reason.contains("当前任务") || reason.contains("手动任务") -> "TASK_CONFLICT"
+            reason.contains("重新拉起") || reason.contains("自动恢复") -> "RECOVERING"
+            reason.contains("重试") -> "RETRY_BACKOFF"
+            reason.contains("跳过") -> "SKIPPED"
+            queueCount > 0 -> "QUEUED"
+            reason.contains("没有到期") || reason.contains("下次") -> "WAIT_NEXT_RUN"
+            else -> "WAITING"
+        }
+    }
 
     private fun publicSchedulerReason(state: String, raw: String): String = when {
         state == "disabled" -> "自动任务已关闭"
@@ -284,6 +500,7 @@ internal class SchedulerRepository(
         raw.contains("已有") || raw.contains("当前任务") -> "等待当前任务完成"
         raw.contains("恢复") || raw.contains("重新拉起") -> "后台正在自动恢复"
         raw.contains("重试") -> "等待自动重试"
+        raw.contains("停止") -> "任务已停止，等待下一次调度"
         raw.contains("没有到期") || raw.contains("下次") -> "等待下次执行"
         else -> "等待自动执行"
     }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -175,10 +174,14 @@ private fun SchedulerHealthDialog(
                 }
                 OutlinedButton(
                     onClick = { actions.onSchedulerCommand("scheduler-repair") },
+                    enabled = !state.running,
                     modifier = Modifier.fillMaxWidth()
                 ) {
                     Icon(Icons.Rounded.Refresh, contentDescription = null)
-                    Text("一键修复后台服务", modifier = Modifier.padding(start = 8.dp))
+                    Text(
+                        if (state.running) "任务执行中，暂不可修复" else "一键修复后台服务",
+                        modifier = Modifier.padding(start = 8.dp)
+                    )
                 }
                 OutlinedButton(
                     onClick = { actions.onSchedulerCommand("scheduler-export-diagnostics") },

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt
@@ -1,0 +1,302 @@
+package io.github.xgl34222220.baize.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.SettingsSuggest
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.SchedulerUiState
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+@Composable
+internal fun SchedulerHealthOverlay(
+    state: SettingsUiState,
+    actions: SettingsUiActions,
+    modifier: Modifier = Modifier
+) {
+    var showDialog by remember { mutableStateOf(false) }
+    val scheduler = state.scheduler
+    val healthy = state.connected && state.ready && !scheduler.runtimeStale
+    val disabled = !scheduler.enabled
+    val container = when {
+        !state.connected || scheduler.runtimeStale -> MaterialTheme.colorScheme.errorContainer
+        disabled -> MaterialTheme.colorScheme.surfaceVariant
+        else -> MaterialTheme.colorScheme.primaryContainer
+    }
+    val content = when {
+        !state.connected || scheduler.runtimeStale -> MaterialTheme.colorScheme.onErrorContainer
+        disabled -> MaterialTheme.colorScheme.onSurfaceVariant
+        else -> MaterialTheme.colorScheme.onPrimaryContainer
+    }
+
+    Surface(
+        modifier = modifier
+            .clip(RoundedCornerShape(18.dp))
+            .clickable { showDialog = true },
+        shape = RoundedCornerShape(18.dp),
+        color = container,
+        shadowElevation = 5.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Icon(
+                imageVector = if (healthy) Icons.Rounded.CheckCircle else Icons.Rounded.ErrorOutline,
+                contentDescription = null,
+                tint = content,
+                modifier = Modifier.size(20.dp)
+            )
+            Text(
+                text = when {
+                    !state.connected || scheduler.runtimeStale -> "自动任务异常"
+                    disabled -> "自动任务已关闭"
+                    scheduler.runtimeState == "running" -> "自动任务执行中"
+                    else -> "自动任务体检"
+                },
+                color = content,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+
+    if (showDialog) {
+        SchedulerHealthDialog(
+            state = state,
+            actions = actions,
+            onDismiss = { showDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun SchedulerHealthDialog(
+    state: SettingsUiState,
+    actions: SettingsUiActions,
+    onDismiss: () -> Unit
+) {
+    val scheduler = state.scheduler
+    val reasonCode = schedulerReasonCode(scheduler, state.connected, state.ready)
+    val blocked = blockedSummary(scheduler.blockedGroups)
+    val healthy = state.connected && state.ready && !scheduler.runtimeStale
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Icon(
+                imageVector = if (healthy) Icons.Rounded.CheckCircle else Icons.Rounded.ErrorOutline,
+                contentDescription = null,
+                tint = if (healthy) BaiZeTokens.colors.success else BaiZeTokens.colors.warning
+            )
+        },
+        title = {
+            Text(
+                when {
+                    !state.connected -> "Root 服务未连接"
+                    scheduler.runtimeStale -> "后台服务需要修复"
+                    !scheduler.enabled -> "自动任务已关闭"
+                    scheduler.runtimeState == "running" -> "自动任务正在执行"
+                    blocked.isNotBlank() -> "任务正在等待条件"
+                    else -> "自动任务运行正常"
+                }
+            )
+        },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                HealthStatusCard(
+                    healthy = healthy,
+                    title = scheduler.runtimeReason,
+                    detail = "原因码：$reasonCode"
+                )
+                HealthLine("Root 引擎", if (state.ready) "组件完整" else state.serviceText)
+                HealthLine("Supervisor", supervisorSummary(scheduler))
+                HealthLine("等待队列", if (scheduler.queueCount > 0) "${scheduler.queueCount} 项 · ${groupLabel(scheduler.nextTask)} 优先" else "当前没有到期任务")
+                if (blocked.isNotBlank()) HealthLine("阻塞详情", blocked)
+                HealthLine("下次检查", nextCheckSummary(scheduler.nextCheckEpoch))
+                Text(
+                    "体检与修复只检查服务、心跳、队列和陈旧锁，不会修改任何定时周期、任务开关或清理规则。",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                    lineHeight = 17.sp
+                )
+                Spacer(Modifier.height(2.dp))
+                Button(
+                    onClick = { actions.onSchedulerCommand("scheduler-self-test") },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Rounded.SettingsSuggest, contentDescription = null)
+                    Text("运行无破坏体检", modifier = Modifier.padding(start = 8.dp))
+                }
+                OutlinedButton(
+                    onClick = { actions.onSchedulerCommand("scheduler-repair") },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Rounded.Refresh, contentDescription = null)
+                    Text("一键修复后台服务", modifier = Modifier.padding(start = 8.dp))
+                }
+                OutlinedButton(
+                    onClick = { actions.onSchedulerCommand("scheduler-export-diagnostics") },
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Icon(Icons.Rounded.Description, contentDescription = null)
+                    Text("导出脱敏诊断包", modifier = Modifier.padding(start = 8.dp))
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("完成") }
+        }
+    )
+}
+
+@Composable
+private fun HealthStatusCard(healthy: Boolean, title: String, detail: String) {
+    val background = if (healthy) {
+        BaiZeTokens.colors.success.copy(alpha = .12f)
+    } else {
+        BaiZeTokens.colors.warning.copy(alpha = .14f)
+    }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(background)
+            .padding(14.dp)
+    ) {
+        Text(title.ifBlank { "等待调度器返回状态" }, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+        Spacer(Modifier.height(3.dp))
+        Text(detail, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun HealthLine(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Text(
+            label,
+            modifier = Modifier.padding(top = 1.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 12.sp
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+            value,
+            modifier = Modifier.fillMaxWidth(.68f),
+            fontSize = 12.sp,
+            lineHeight = 17.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+private fun schedulerReasonCode(scheduler: SchedulerUiState, connected: Boolean, ready: Boolean): String {
+    val reason = "${scheduler.runtimeReason},${scheduler.blockedGroups}"
+    return when {
+        !connected || !ready || scheduler.runtimeStale -> "SERVICE_UNHEALTHY"
+        !scheduler.enabled -> "SCHEDULER_DISABLED"
+        scheduler.runtimeState == "running" -> "RUNNING"
+        reason.contains("息屏") -> "WAIT_SCREEN_OFF"
+        reason.contains("充电") -> "WAIT_CHARGING"
+        reason.contains("电量") -> "WAIT_BATTERY"
+        reason.contains("空闲") -> "WAIT_IDLE"
+        reason.contains("停止") -> "USER_STOPPED"
+        reason.contains("当前任务") || reason.contains("手动任务") -> "TASK_CONFLICT"
+        reason.contains("恢复") || reason.contains("重新拉起") -> "RECOVERING"
+        reason.contains("重试") -> "RETRY_BACKOFF"
+        scheduler.queueCount > 0 -> "QUEUED"
+        else -> "WAIT_NEXT_RUN"
+    }
+}
+
+private fun supervisorSummary(scheduler: SchedulerUiState): String {
+    val status = when (scheduler.supervisorStatus) {
+        "running" -> "运行中"
+        "recovering" -> "自动恢复中"
+        "starting" -> "启动中"
+        "failed" -> "启动失败"
+        "stopped" -> "已停止"
+        else -> scheduler.supervisorStatus.ifBlank { "未知" }
+    }
+    val heartbeat = when {
+        scheduler.supervisorHeartbeatAge < 0L -> "暂无心跳"
+        scheduler.supervisorHeartbeatAge < 60L -> "${scheduler.supervisorHeartbeatAge} 秒前心跳"
+        scheduler.supervisorHeartbeatAge < 3_600L -> "${scheduler.supervisorHeartbeatAge / 60L} 分钟前心跳"
+        else -> "${scheduler.supervisorHeartbeatAge / 3_600L} 小时前心跳"
+    }
+    return "$status · $heartbeat"
+}
+
+private fun blockedSummary(raw: String): String = raw
+    .split(',')
+    .mapNotNull { item ->
+        val value = item.trim()
+        if (value.isBlank()) return@mapNotNull null
+        val group = value.substringBefore(':')
+        val reason = value.substringAfter(':', "等待执行条件")
+        "${groupLabel(group)}：$reason"
+    }
+    .joinToString("\n")
+
+private fun groupLabel(group: String): String = when (group) {
+    "cache" -> "应用缓存"
+    "empty" -> "空文件与目录"
+    "rules" -> "规则垃圾与日志"
+    "fragment" -> "残留碎片"
+    "deep" -> "深度清理"
+    "organize" -> "文件自动归类"
+    "cache+organize" -> "缓存与文件归类"
+    else -> group.ifBlank { "下一项任务" }
+}
+
+private fun nextCheckSummary(epoch: Long): String {
+    if (epoch <= 0L) return "等待首次检查"
+    val seconds = (epoch - System.currentTimeMillis() / 1000L).coerceAtLeast(0L)
+    return when {
+        seconds < 60L -> "$seconds 秒后"
+        seconds < 3_600L -> "${seconds / 60L} 分钟后"
+        seconds < 86_400L -> "${seconds / 3_600L} 小时后"
+        else -> "${seconds / 86_400L} 天后"
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -149,7 +149,14 @@ private fun SchedulerHealthDialog(
                 )
                 HealthLine("Root 引擎", if (state.ready) "组件完整" else state.serviceText)
                 HealthLine("Supervisor", supervisorSummary(scheduler))
-                HealthLine("等待队列", if (scheduler.queueCount > 0) "${scheduler.queueCount} 项 · ${groupLabel(scheduler.nextTask)} 优先" else "当前没有到期任务")
+                HealthLine(
+                    "等待队列",
+                    if (scheduler.queueCount > 0) {
+                        "${scheduler.queueCount} 项 · ${groupLabel(scheduler.nextTask)} 优先"
+                    } else {
+                        "当前没有到期任务"
+                    }
+                )
                 if (blocked.isNotBlank()) HealthLine("阻塞详情", blocked)
                 HealthLine("下次检查", nextCheckSummary(scheduler.nextCheckEpoch))
                 Text(

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
@@ -1,6 +1,13 @@
 package io.github.xgl34222220.baize.ui.settings
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.SchedulerUiState
@@ -30,8 +37,18 @@ fun SettingsRoute(
         onOpenCrashDiagnostics = dashboardActions.crash
     )
 
-    when (style) {
-        UiStyle.MATERIAL -> SettingsScreenMaterial(state, actions)
-        UiStyle.MIUIX -> SettingsScreenMiuix(state, actions)
+    Box(Modifier.fillMaxSize()) {
+        when (style) {
+            UiStyle.MATERIAL -> SettingsScreenMaterial(state, actions)
+            UiStyle.MIUIX -> SettingsScreenMiuix(state, actions)
+        }
+        SchedulerHealthOverlay(
+            state = state,
+            actions = actions,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .navigationBarsPadding()
+                .padding(end = 18.dp, bottom = 96.dp)
+        )
     }
 }

--- a/v2/module/diagnostics-export.sh
+++ b/v2/module/diagnostics-export.sh
@@ -31,7 +31,18 @@ done
 
 # Paths are privacy-sensitive: retain only basename and a stable short hash.
 if [ -f "$STATE_DIR/reports/latest.tsv" ]; then
-  awk -F '\t' 'BEGIN{OFS="\t"} NR==1{print;next} {path=$6; cmd="printf %s \\"" path "\\" | sha256sum"; cmd|getline hash; close(cmd); n=split(path,a,"/"); $6="…/" a[n] "#" substr(hash,1,10); print}' "$STATE_DIR/reports/latest.tsv" >"$STAGE/latest-redacted.tsv" 2>/dev/null || true
+  tab=$(printf '\t')
+  {
+    IFS= read -r header || true
+    [ -n "${header:-}" ] && printf '%s\n' "$header"
+    while IFS="$tab" read -r action risk category items bytes path extra; do
+      [ -n "${action:-}${risk:-}${category:-}${items:-}${bytes:-}${path:-}" ] || continue
+      hash=$(printf '%s' "$path" | sha256sum 2>/dev/null | awk '{print substr($1,1,10)}')
+      [ -n "$hash" ] || hash=unavailable
+      base=${path##*/}
+      printf '%s\t%s\t%s\t%s\t%s\t…/%s#%s\n' "$action" "$risk" "$category" "$items" "$bytes" "$base" "$hash"
+    done
+  } <"$STATE_DIR/reports/latest.tsv" >"$STAGE/latest-redacted.tsv" 2>/dev/null || true
 fi
 
 for log in $(ls -1t "$STATE_DIR"/logs/*.log 2>/dev/null | head -n 3); do

--- a/v2/module/diagnostics-export.sh
+++ b/v2/module/diagnostics-export.sh
@@ -1,33 +1,67 @@
 #!/system/bin/sh
 set -eu
+
 MODDIR=${0%/*}
 STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
-OUT_DIR="$STATE_DIR/exports"
+PRIVATE_OUT="$STATE_DIR/exports"
+USER_ID=$(cmd activity get-current-user 2>/dev/null || echo 0)
+case "$USER_ID" in ''|*[!0-9]*) USER_ID=0 ;; esac
+PUBLIC_OUT=${BAIZE_DIAG_PUBLIC_DIR:-/storage/emulated/$USER_ID/Download/BaiZe}
 STAMP=$(date '+%Y%m%d-%H%M%S')
-STAGE="$OUT_DIR/diag-$STAMP"
+STAGE="$PRIVATE_OUT/.diag-stage-$STAMP-$$"
+OUT_DIR=$PRIVATE_OUT
+PUBLIC=0
+
+mkdir -p "$PRIVATE_OUT" "$STAGE"
+if mkdir -p "$PUBLIC_OUT" 2>/dev/null && : >"$PUBLIC_OUT/.baize-write-test-$$" 2>/dev/null; then
+  rm -f "$PUBLIC_OUT/.baize-write-test-$$"
+  OUT_DIR=$PUBLIC_OUT
+  PUBLIC=1
+fi
 ZIP="$OUT_DIR/BaiZe-diagnostics-$STAMP.zip"
-mkdir -p "$STAGE"
-for f in module.env supervisor.env scheduler.env worker.env running.env latest.env totals.env app-install.env root-worker-profile.env; do
+trap 'rm -rf "$STAGE"' EXIT INT TERM
+
+for f in module.env supervisor.env scheduler.env worker.env running.env latest.env totals.env app-install.env root-worker-profile.env runtime-schema; do
   [ -f "$STATE_DIR/$f" ] && cp -f "$STATE_DIR/$f" "$STAGE/$f"
 done
+[ -f "$STATE_DIR/config.conf" ] && sed -E 's#^([^=]*(path|dir|folder)[^=]*)=.*$#\1=<redacted>#I' "$STATE_DIR/config.conf" >"$STAGE/config-redacted.conf" 2>/dev/null || true
+[ -f "$STATE_DIR/scheduler-queue.tsv" ] && awk -F '\t' 'BEGIN{OFS="\t"} {if (NF>=6 && $6!="-") {$6="<request-file>"}; print}' "$STATE_DIR/scheduler-queue.tsv" >"$STAGE/scheduler-queue-redacted.tsv" 2>/dev/null || true
 [ -f "$MODDIR/module.prop" ] && cp -f "$MODDIR/module.prop" "$STAGE/module.prop"
 [ -f "$MODDIR/config/rules.meta.env" ] && cp -f "$MODDIR/config/rules.meta.env" "$STAGE/rules.meta.env"
+
 # Paths are privacy-sensitive: retain only basename and a stable short hash.
 if [ -f "$STATE_DIR/reports/latest.tsv" ]; then
-  awk -F '\t' 'BEGIN{OFS="\t"} NR==1{print;next} {path=$6; cmd="printf %s \\"" path "\\" | sha256sum"; cmd|getline hash; close(cmd); n=split(path,a,"/"); $6="…/" a[n] "#" substr(hash,1,10); print}' "$STATE_DIR/reports/latest.tsv" >"$STAGE/latest-redacted.tsv" 2>/dev/null || true
+  awk -F '\t' 'BEGIN{OFS="\t"} NR==1{print;next} {
+    path=$6
+    safe=path
+    gsub(/[^[:alnum:]_.-]/,"_",safe)
+    cmd="printf %s \'" safe "\' | sha256sum"
+    cmd|getline hash
+    close(cmd)
+    n=split(path,a,"/")
+    $6="…/" a[n] "#" substr(hash,1,10)
+    print
+  }' "$STATE_DIR/reports/latest.tsv" >"$STAGE/latest-redacted.tsv" 2>/dev/null || true
 fi
+
 for log in $(ls -1t "$STATE_DIR"/logs/*.log 2>/dev/null | head -n 3); do
-  sed -E 's#/(data|storage|sdcard|mnt)/[^ ]+#<redacted-path>#g' "$log" >"$STAGE/$(basename "$log")" 2>/dev/null || true
+  sed -E 's#/(data|storage|sdcard|mnt)/[^ ]+#<redacted-path>#g; s#(package=)[A-Za-z0-9._-]+#\1<redacted-package>#g' "$log" >"$STAGE/$(basename "$log")" 2>/dev/null || true
 done
+
+root_framework=Magisk
+[ -d /data/adb/ksu ] && root_framework=KernelSU
+[ -d /data/adb/ap ] && root_framework=APatch
 {
   echo "date=$(date '+%Y-%m-%d %H:%M:%S')"
   echo "kernel=$(uname -a 2>/dev/null)"
   echo "android=$(getprop ro.build.version.release 2>/dev/null)"
   echo "sdk=$(getprop ro.build.version.sdk 2>/dev/null)"
   echo "device=$(getprop ro.product.manufacturer 2>/dev/null)/$(getprop ro.product.model 2>/dev/null)"
-  echo "root_framework=$([ -n "${KSU:-}" ] && echo KernelSU || { [ -n "${APATCH:-}" ] && echo APatch || echo Magisk; })"
+  echo "root_framework=$root_framework"
+  echo "export_location=$([ "$PUBLIC" = 1 ] && echo public-downloads || echo private-state)"
 } >"$STAGE/device.env"
+
+umask 077
 (cd "$STAGE" && zip -qr "$ZIP" .)
-rm -rf "$STAGE"
-chmod 0600 "$ZIP" 2>/dev/null || true
-echo "$ZIP"
+if [ "$PUBLIC" = 1 ]; then chmod 0644 "$ZIP" 2>/dev/null || true; else chmod 0600 "$ZIP" 2>/dev/null || true; fi
+printf '%s\n' "$ZIP"

--- a/v2/module/diagnostics-export.sh
+++ b/v2/module/diagnostics-export.sh
@@ -24,24 +24,14 @@ trap 'rm -rf "$STAGE"' EXIT INT TERM
 for f in module.env supervisor.env scheduler.env worker.env running.env latest.env totals.env app-install.env root-worker-profile.env runtime-schema; do
   [ -f "$STATE_DIR/$f" ] && cp -f "$STATE_DIR/$f" "$STAGE/$f"
 done
-[ -f "$STATE_DIR/config.conf" ] && sed -E 's#^([^=]*(path|dir|folder)[^=]*)=.*$#\1=<redacted>#I' "$STATE_DIR/config.conf" >"$STAGE/config-redacted.conf" 2>/dev/null || true
+[ -f "$STATE_DIR/config.conf" ] && sed -E 's#^([^=]*(path|dir|folder)[^=]*)=.*$#\1=<redacted>#' "$STATE_DIR/config.conf" >"$STAGE/config-redacted.conf" 2>/dev/null || true
 [ -f "$STATE_DIR/scheduler-queue.tsv" ] && awk -F '\t' 'BEGIN{OFS="\t"} {if (NF>=6 && $6!="-") {$6="<request-file>"}; print}' "$STATE_DIR/scheduler-queue.tsv" >"$STAGE/scheduler-queue-redacted.tsv" 2>/dev/null || true
 [ -f "$MODDIR/module.prop" ] && cp -f "$MODDIR/module.prop" "$STAGE/module.prop"
 [ -f "$MODDIR/config/rules.meta.env" ] && cp -f "$MODDIR/config/rules.meta.env" "$STAGE/rules.meta.env"
 
 # Paths are privacy-sensitive: retain only basename and a stable short hash.
 if [ -f "$STATE_DIR/reports/latest.tsv" ]; then
-  awk -F '\t' 'BEGIN{OFS="\t"} NR==1{print;next} {
-    path=$6
-    safe=path
-    gsub(/[^[:alnum:]_.-]/,"_",safe)
-    cmd="printf %s \'" safe "\' | sha256sum"
-    cmd|getline hash
-    close(cmd)
-    n=split(path,a,"/")
-    $6="…/" a[n] "#" substr(hash,1,10)
-    print
-  }' "$STATE_DIR/reports/latest.tsv" >"$STAGE/latest-redacted.tsv" 2>/dev/null || true
+  awk -F '\t' 'BEGIN{OFS="\t"} NR==1{print;next} {path=$6; cmd="printf %s \\"" path "\\" | sha256sum"; cmd|getline hash; close(cmd); n=split(path,a,"/"); $6="…/" a[n] "#" substr(hash,1,10); print}' "$STATE_DIR/reports/latest.tsv" >"$STAGE/latest-redacted.tsv" 2>/dev/null || true
 fi
 
 for log in $(ls -1t "$STATE_DIR"/logs/*.log 2>/dev/null | head -n 3); do

--- a/v2/tests/test-scheduler-health-contract.sh
+++ b/v2/tests/test-scheduler-health-contract.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+REPOSITORY="$ROOT/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt"
+OVERLAY="$ROOT/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SchedulerHealthOverlay.kt"
+
+for command in scheduler-health scheduler-self-test scheduler-repair scheduler-export-diagnostics; do
+  grep -q "\"$command\"" "$REPOSITORY"
+done
+for code in SERVICE_UNHEALTHY WAIT_SCREEN_OFF WAIT_CHARGING WAIT_BATTERY WAIT_IDLE TASK_CONFLICT RECOVERING RETRY_BACKOFF QUEUED WAIT_NEXT_RUN; do
+  grep -q "\"$code\"" "$REPOSITORY"
+done
+grep -q 'put("blockedGroups", blockedGroups)' "$REPOSITORY"
+grep -q '不会修改任何定时周期' "$OVERLAY"
+
+# User requirement: health diagnostics must not tighten scheduler intervals.
+grep -q '"schedule_cache_minutes" to 5..43_200' "$REPOSITORY"
+grep -q '"schedule_empty_minutes" to 5..43_200' "$REPOSITORY"
+grep -q '"schedule_rules_minutes" to 5..43_200' "$REPOSITORY"
+grep -q '"schedule_fragment_minutes" to 5..43_200' "$REPOSITORY"
+grep -q '"schedule_deep_minutes" to 5..43_200' "$REPOSITORY"
+grep -q '"schedule_organize_minutes" to 15..43_200' "$REPOSITORY"
+
+echo "scheduler health contract regression passed"

--- a/v2/tests/test-scheduler-health-diagnostics.sh
+++ b/v2/tests/test-scheduler-health-diagnostics.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+WORK=${TMPDIR:-/tmp}/baize-scheduler-health-diagnostics-test
+MODULE="$WORK/module"
+STATE="$WORK/state"
+PUBLIC="$WORK/public"
+rm -rf "$WORK"
+mkdir -p "$MODULE/config" "$STATE/logs" "$STATE/reports" "$PUBLIC"
+cp "$ROOT/module/diagnostics-export.sh" "$MODULE/diagnostics-export.sh"
+chmod +x "$MODULE/diagnostics-export.sh"
+
+cat >"$MODULE/module.prop" <<'EOF'
+id=baize_v2
+name=BaiZe
+version=v-test
+versionCode=1
+EOF
+cat >"$MODULE/config/rules.meta.env" <<'EOF'
+rules_version=test
+EOF
+cat >"$STATE/scheduler.env" <<'EOF'
+state=waiting
+reason=cache:等待息屏
+queue_count=1
+blocked_groups=cache:等待息屏
+queue_schema=fixed-seven-fields-v1
+EOF
+cat >"$STATE/supervisor.env" <<'EOF'
+status=running
+reason=scheduler_running
+EOF
+cat >"$STATE/config.conf" <<'EOF'
+enabled=1
+custom_path=/storage/emulated/0/Private/Secret
+schedule_cache_minutes=5
+EOF
+printf '0\t1\tcache\tcache-auto\tmanual\t%s\t-\n' "$STATE/scheduler-requests/private-cache.env" >"$STATE/scheduler-queue.tsv"
+printf 'action\trisk\tcategory\titems\tbytes\tpath\ncleaned\tlow\tcache\t1\t128\t/storage/emulated/0/Private/secret.log\n' >"$STATE/reports/latest.tsv"
+printf 'package=com.example.private path=/storage/emulated/0/Private/secret.log\n' >"$STATE/logs/scheduler-cache.log"
+
+OUTPUT=$(BAIZE_STATE_DIR="$STATE" BAIZE_DIAG_PUBLIC_DIR="$PUBLIC" sh "$MODULE/diagnostics-export.sh")
+[ -f "$OUTPUT" ]
+case "$OUTPUT" in "$PUBLIC"/BaiZe-diagnostics-*.zip) ;; *) echo "unexpected export path: $OUTPUT" >&2; exit 1 ;; esac
+
+LIST=$(unzip -Z1 "$OUTPUT")
+printf '%s\n' "$LIST" | grep -qx 'scheduler.env'
+printf '%s\n' "$LIST" | grep -qx 'supervisor.env'
+printf '%s\n' "$LIST" | grep -qx 'config-redacted.conf'
+printf '%s\n' "$LIST" | grep -qx 'scheduler-queue-redacted.tsv'
+printf '%s\n' "$LIST" | grep -qx 'latest-redacted.tsv'
+
+CONFIG=$(unzip -p "$OUTPUT" config-redacted.conf)
+printf '%s\n' "$CONFIG" | grep -q '^custom_path=<redacted>$'
+! printf '%s\n' "$CONFIG" | grep -q '/Private/Secret'
+
+QUEUE=$(unzip -p "$OUTPUT" scheduler-queue-redacted.tsv)
+printf '%s\n' "$QUEUE" | grep -q '<request-file>'
+! printf '%s\n' "$QUEUE" | grep -q 'private-cache.env'
+
+REPORT=$(unzip -p "$OUTPUT" latest-redacted.tsv)
+printf '%s\n' "$REPORT" | grep -q 'secret.log#'
+! printf '%s\n' "$REPORT" | grep -q '/storage/emulated/0/Private'
+
+LOG=$(unzip -p "$OUTPUT" scheduler-cache.log)
+printf '%s\n' "$LOG" | grep -q 'package=<redacted-package>'
+printf '%s\n' "$LOG" | grep -q '<redacted-path>'
+! printf '%s\n' "$LOG" | grep -q 'com.example.private'
+
+echo "scheduler health diagnostics regression passed"


### PR DESCRIPTION
## 第一步：自动任务可靠性与可诊断性

针对自动任务“已开启但没有执行记录”时难以定位的问题，增加完整的自动任务体检、自愈和脱敏诊断闭环。

### 调度状态

- 返回真实 `blocked_groups`，不再丢弃各任务的阻塞详情。
- 增加统一原因码，包括等待息屏、充电、电量、系统空闲、任务冲突、恢复、重试和服务异常。
- 暴露 Scheduler / Supervisor 心跳年龄、健康状态、重启次数、队列格式和原始原因。

### 无破坏体检与修复

- 新增 `scheduler-self-test`：检查模块组件、配置、状态目录写入、进程、心跳与队列格式，不创建清理任务、不扫描用户文件。
- 新增 `scheduler-repair`：清理陈旧锁、停止标记和临时状态，重新唤醒或启动 Supervisor。
- 新增 `scheduler-health`：返回结构化运行状态与体检结论。

### 设置页

- Material 与 MIUIx 共用自动任务体检入口。
- 展示当前原因、原因码、Supervisor 心跳、等待队列、阻塞详情和下次检查。
- 提供无破坏体检、一键修复和诊断包导出。

### 脱敏诊断包

- 优先导出到 `Download/BaiZe`，不可写时回退到模块私有目录。
- 路径只保留文件名和短哈希。
- 配置路径、队列请求文件、日志中的包名与用户路径全部脱敏。

## 明确不改动

按当前产品要求，本 PR **不限制定时设置**，没有修改任何任务周期范围、默认周期、固定时间、任务开关或清理规则。

## 验证

- `sh -n` / `bash -n` 诊断脚本通过。
- 诊断 ZIP 端到端回归通过，验证配置、队列、报告、包名和路径脱敏。
- 增加调度健康契约测试，锁定原因码、命令和原有周期范围。
- PR CI 继续执行 Android 编译、Lint、Macrobenchmark 与完整 Root 稳定性回归。