### PR TITLE
feat: add structured cleaning audit center

### DIFF
--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -63,6 +63,8 @@ jobs:
         run: bash v2/tests/test-scan-workbench-contract.sh
       - name: Quarantine authorization and restore contract
         run: bash v2/tests/test-quarantine-contract.sh
+      - name: Cleaning audit center contract
+        run: bash v2/tests/test-audit-center-contract.sh
       - name: Concurrent scheduler regression
         shell: bash
         run: |

--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
         <activity android:name=".FileOrganizerActivity" android:exported="false" />
         <activity android:name=".CleanCenterActivity" android:exported="false" />
         <activity android:name=".QuarantineActivity" android:exported="false" />
+        <activity android:name=".AuditActivity" android:exported="false" />
         <activity android:name=".WhitelistActivity" android:exported="false" android:windowSoftInputMode="adjustResize" />
         <activity android:name=".ThemeSettingsActivity" android:exported="false" />
         <activity android:name=".DashboardActivity" android:exported="false" />

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl
@@ -21,6 +21,8 @@ interface IProfileRootService {
     String getModuleState();
     String getTaskHistory(int limit);
     String getTaskHistoryPage(int offset, int limit);
+    String getAuditTimelinePage(int offset, int limit);
+    String clearAuditTimeline();
     String getScanCoverage();
     String clearTaskHistory();
     String getRawLog(int maxChars);

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/AuditActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/AuditActivity.kt
@@ -1,0 +1,696 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.graphics.Color
+import android.os.Bundle
+import android.os.IBinder
+import android.text.format.Formatter
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.DeleteOutline
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material.icons.rounded.ErrorOutline
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.BaiZeProfileRootService
+import io.github.xgl34222220.baize.root.IProfileRootService
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.appearance.ThemeMode
+import io.github.xgl34222220.baize.ui.appearance.UiStyle
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+class AuditActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private var service: IProfileRootService? = null
+    private var bound = false
+    private var state by mutableStateOf(AuditUiState())
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            service = IProfileRootService.Stub.asInterface(binder)
+            bound = true
+            state = state.copy(connected = true, message = "Root 审计服务已连接")
+            loadTimeline()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            service = null
+            bound = false
+            state = state.copy(connected = false, loading = false, message = "Root 审计服务已断开")
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+        setContent {
+            val appearance = appearanceViewModel.settings.collectAsStateWithLifecycle().value
+            val systemDark = isSystemInDarkTheme()
+            val dark = when (appearance.themeMode) {
+                ThemeMode.SYSTEM -> systemDark
+                ThemeMode.LIGHT -> false
+                ThemeMode.DARK -> true
+            }
+            SideEffect {
+                WindowCompat.getInsetsController(window, window.decorView).apply {
+                    isAppearanceLightStatusBars = !dark
+                    isAppearanceLightNavigationBars = !dark
+                }
+            }
+            BaiZeTheme(appearance) {
+                CompositionLocalProvider(LocalAppearanceSettings provides appearance) {
+                    AuditScreen(
+                        state = state,
+                        style = appearance.uiStyle,
+                        onBack = ::finish,
+                        onRefresh = ::loadTimeline,
+                        onClear = ::clearTimeline
+                    )
+                }
+            }
+        }
+        connect()
+    }
+
+    override fun onDestroy() {
+        if (bound) runCatching { RootService.unbind(connection) }
+        super.onDestroy()
+    }
+
+    private fun connect() {
+        state = state.copy(message = "正在连接 Root 审计服务…")
+        runCatching {
+            RootService.bind(
+                Intent(this, BaiZeProfileRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                connection
+            )
+            bound = true
+        }.onFailure {
+            bound = false
+            state = state.copy(message = "Root 审计服务启动失败：${it.message.orEmpty()}")
+        }
+    }
+
+    private fun loadTimeline() {
+        val root = service ?: return
+        if (state.loading) return
+        state = state.copy(loading = true, message = "正在读取结构化审计时间线…")
+        lifecycleScope.launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) { JSONObject(root.getAuditTimelinePage(0, 100)) }
+            }
+            result.onSuccess { json ->
+                if (!json.optBoolean("success")) {
+                    state = state.copy(loading = false, message = json.optString("message", "读取审计记录失败"))
+                    return@onSuccess
+                }
+                val array = json.optJSONArray("events") ?: JSONArray()
+                val events = buildList {
+                    for (index in 0 until array.length()) {
+                        val item = array.optJSONObject(index) ?: continue
+                        add(parseEvent(item))
+                    }
+                }
+                state = state.copy(
+                    loading = false,
+                    events = events,
+                    total = json.optInt("total", events.size).coerceAtLeast(events.size),
+                    successCount = json.optInt("successCount").coerceAtLeast(0),
+                    failedCount = json.optInt("failedCount").coerceAtLeast(0),
+                    cancelledCount = json.optInt("cancelledCount").coerceAtLeast(0),
+                    releasedBytes = json.optLong("releasedBytes").coerceAtLeast(0L),
+                    quarantinedBytes = json.optLong("quarantinedBytes").coerceAtLeast(0L),
+                    protectedCount = json.optLong("protectedCount").coerceAtLeast(0L),
+                    message = if (events.isEmpty()) "暂无审计事件" else "已载入 ${events.size} / ${json.optInt("total", events.size)} 条事件"
+                )
+            }.onFailure {
+                state = state.copy(loading = false, message = "读取审计记录失败：${it.message ?: it.javaClass.simpleName}")
+            }
+        }
+    }
+
+    private fun clearTimeline() {
+        val root = service ?: return
+        if (state.loading) return
+        state = state.copy(loading = true, message = "正在清空审计时间线…")
+        lifecycleScope.launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) { JSONObject(root.clearAuditTimeline()) }
+            }
+            result.onSuccess { json ->
+                state = state.copy(loading = false, message = json.optString("message", "审计时间线已清空"))
+                if (json.optBoolean("success")) loadTimeline()
+            }.onFailure {
+                state = state.copy(loading = false, message = "清空失败：${it.message ?: it.javaClass.simpleName}")
+            }
+        }
+    }
+
+    private fun parseEvent(json: JSONObject): AuditEvent = AuditEvent(
+        id = json.optString("id"),
+        time = json.optString("time"),
+        operation = json.optString("operation"),
+        kind = json.optString("kind", "clean"),
+        source = json.optString("source", "app"),
+        status = json.optString("status", "success"),
+        message = json.optString("message"),
+        errorCode = json.optString("errorCode"),
+        profile = json.optString("profile"),
+        snapshotId = json.optString("snapshotId"),
+        selected = json.optLong("selected").coerceAtLeast(0L),
+        processed = json.optLong("processed").coerceAtLeast(0L),
+        skipped = json.optLong("skipped").coerceAtLeast(0L),
+        protected = json.optLong("protected").coerceAtLeast(0L),
+        bytes = json.optLong("bytes").coerceAtLeast(0L),
+        files = json.optLong("files").coerceAtLeast(0L),
+        directories = json.optLong("directories").coerceAtLeast(0L),
+        errors = json.optLong("errors").coerceAtLeast(0L),
+        elapsedMs = json.optLong("elapsedMs").coerceAtLeast(0L),
+        reasons = json.optJSONArray("reasonCodes").toStringList(),
+        details = json.optJSONArray("details").toDetailList(),
+        legacy = json.optBoolean("legacy")
+    )
+}
+
+private data class AuditUiState(
+    val connected: Boolean = false,
+    val loading: Boolean = false,
+    val events: List<AuditEvent> = emptyList(),
+    val total: Int = 0,
+    val successCount: Int = 0,
+    val failedCount: Int = 0,
+    val cancelledCount: Int = 0,
+    val releasedBytes: Long = 0L,
+    val quarantinedBytes: Long = 0L,
+    val protectedCount: Long = 0L,
+    val message: String = "等待连接 Root 审计服务"
+)
+
+private data class AuditEvent(
+    val id: String,
+    val time: String,
+    val operation: String,
+    val kind: String,
+    val source: String,
+    val status: String,
+    val message: String,
+    val errorCode: String,
+    val profile: String,
+    val snapshotId: String,
+    val selected: Long,
+    val processed: Long,
+    val skipped: Long,
+    val protected: Long,
+    val bytes: Long,
+    val files: Long,
+    val directories: Long,
+    val errors: Long,
+    val elapsedMs: Long,
+    val reasons: List<String>,
+    val details: List<AuditDetail>,
+    val legacy: Boolean
+)
+
+private data class AuditDetail(
+    val action: String,
+    val category: String,
+    val risk: String,
+    val reason: String,
+    val pathTail: String,
+    val bytes: Long,
+    val files: Long,
+    val directories: Long
+)
+
+@Composable
+private fun AuditScreen(
+    state: AuditUiState,
+    style: UiStyle,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onClear: () -> Unit
+) {
+    var filter by rememberSaveable { mutableStateOf("all") }
+    var confirmClear by remember { mutableStateOf(false) }
+    val miuix = style == UiStyle.MIUIX
+    val horizontal = if (miuix) 18.dp else 20.dp
+    val cardShape = if (miuix) RoundedCornerShape(26.dp) else MaterialTheme.shapes.extraLarge
+    val filtered = remember(state.events, filter) {
+        state.events.filter { event ->
+            when (filter) {
+                "scan" -> event.kind == "scan"
+                "clean" -> event.kind == "clean" || event.kind == "organize"
+                "safety" -> event.kind == "safety"
+                "failed" -> event.status in setOf("failed", "partial", "cancelled")
+                else -> true
+            }
+        }
+    }
+
+    Box(Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(13.dp)
+        ) {
+            item {
+                AuditHeader(
+                    message = state.message,
+                    loading = state.loading,
+                    onBack = onBack,
+                    onRefresh = onRefresh,
+                    onClear = { confirmClear = true }
+                )
+            }
+            item { AuditSummary(state, horizontal, cardShape) }
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = horizontal),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    listOf(
+                        "all" to "全部",
+                        "scan" to "扫描",
+                        "clean" to "清理",
+                        "safety" to "隔离与恢复",
+                        "failed" to "异常"
+                    ).forEach { (id, label) ->
+                        FilterChip(selected = filter == id, onClick = { filter = id }, label = { Text(label) })
+                    }
+                }
+            }
+            if (filtered.isEmpty() && !state.loading) {
+                item { AuditEmptyCard(horizontal, cardShape, filter) }
+            } else {
+                items(filtered, key = { it.id }) { event ->
+                    AuditEventCard(event, horizontal, cardShape)
+                }
+            }
+            item { Spacer(Modifier.navigationBarsPadding()) }
+        }
+    }
+
+    if (confirmClear) {
+        AlertDialog(
+            onDismissRequest = { confirmClear = false },
+            title = { Text("清空审计时间线？") },
+            text = { Text("只隐藏当前时间点之前的审计事件，不会删除累计统计、白名单、隔离内容或原始清理历史。") },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmClear = false
+                    onClear()
+                }) { Text("清空") }
+            },
+            dismissButton = { TextButton(onClick = { confirmClear = false }) { Text("取消") } }
+        )
+    }
+}
+
+@Composable
+private fun AuditHeader(
+    message: String,
+    loading: Boolean,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onClear: () -> Unit
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .padding(horizontal = 10.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
+        Spacer(Modifier.width(5.dp))
+        Column(Modifier.weight(1f)) {
+            Text("清理审计", fontSize = 30.sp, fontWeight = FontWeight.Black)
+            Text(
+                message,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 11.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        IconButton(onClick = onRefresh, enabled = !loading) { Icon(Icons.Rounded.Refresh, contentDescription = "刷新") }
+        IconButton(onClick = onClear, enabled = !loading) { Icon(Icons.Rounded.DeleteOutline, contentDescription = "清空审计") }
+    }
+}
+
+@Composable
+private fun AuditSummary(state: AuditUiState, horizontal: androidx.compose.ui.unit.Dp, shape: androidx.compose.ui.graphics.Shape) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    Card(
+        modifier = Modifier.padding(horizontal = horizontal).fillMaxWidth(),
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Column(Modifier.padding(20.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    modifier = Modifier.size(50.dp),
+                    shape = RoundedCornerShape(17.dp),
+                    color = MaterialTheme.colorScheme.primary.copy(alpha = .13f)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(Icons.Rounded.Description, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    }
+                }
+                Spacer(Modifier.width(13.dp))
+                Column(Modifier.weight(1f)) {
+                    Text("${state.total} 条可追溯事件", fontSize = 21.sp, fontWeight = FontWeight.Black)
+                    Text(
+                        "实际释放 ${Formatter.formatFileSize(context, state.releasedBytes)}",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+            Spacer(Modifier.height(14.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                AuditMetric("成功", state.successCount.toString(), Modifier.weight(1f))
+                AuditMetric("异常", state.failedCount.toString(), Modifier.weight(1f))
+                AuditMetric("受保护", state.protectedCount.toString(), Modifier.weight(1f))
+            }
+            if (state.quarantinedBytes > 0L || state.cancelledCount > 0) {
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    "隔离 ${Formatter.formatFileSize(context, state.quarantinedBytes)} · 已停止 ${state.cancelledCount} 次",
+                    color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = .72f),
+                    fontSize = 11.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AuditMetric(label: String, value: String, modifier: Modifier = Modifier) {
+    Surface(modifier, shape = RoundedCornerShape(14.dp), color = MaterialTheme.colorScheme.surface.copy(alpha = .55f)) {
+        Column(Modifier.padding(horizontal = 11.dp, vertical = 9.dp)) {
+            Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp)
+            Text(value, fontWeight = FontWeight.Black, fontSize = 17.sp)
+        }
+    }
+}
+
+@Composable
+private fun AuditEmptyCard(
+    horizontal: androidx.compose.ui.unit.Dp,
+    shape: androidx.compose.ui.graphics.Shape,
+    filter: String
+) {
+    Card(
+        modifier = Modifier.padding(horizontal = horizontal).fillMaxWidth(),
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+    ) {
+        Column(Modifier.padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Icon(Icons.Rounded.History, contentDescription = null, modifier = Modifier.size(42.dp), tint = MaterialTheme.colorScheme.outline)
+            Spacer(Modifier.height(10.dp))
+            Text(if (filter == "all") "暂无审计事件" else "当前筛选没有事件", fontWeight = FontWeight.Bold)
+            Text(
+                "后续扫描、清理、隔离和恢复会自动写入 Root 审计时间线。",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 12.sp
+            )
+        }
+    }
+}
+
+@Composable
+private fun AuditEventCard(
+    event: AuditEvent,
+    horizontal: androidx.compose.ui.unit.Dp,
+    shape: androidx.compose.ui.graphics.Shape
+) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    var expanded by rememberSaveable(event.id) { mutableStateOf(false) }
+    val visual = auditVisual(event)
+    val hasMore = event.reasons.isNotEmpty() || event.details.isNotEmpty() || event.snapshotId.isNotBlank() || event.errorCode.isNotBlank()
+    Card(
+        modifier = Modifier
+            .padding(horizontal = horizontal)
+            .fillMaxWidth()
+            .animateContentSize()
+            .clickable(enabled = hasMore) { expanded = !expanded },
+        shape = shape,
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    modifier = Modifier.size(42.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    color = visual.tint.copy(alpha = .12f)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(visual.icon, contentDescription = null, tint = visual.tint, modifier = Modifier.size(21.dp))
+                    }
+                }
+                Spacer(Modifier.width(11.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(operationTitle(event.operation), fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                    Text(
+                        "${event.time} · ${sourceLabel(event.source)}${if (event.legacy) " · 旧记录" else ""}",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 10.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                StatusBadge(event.status)
+                if (hasMore) {
+                    Spacer(Modifier.width(5.dp))
+                    Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, contentDescription = null)
+                }
+            }
+            Spacer(Modifier.height(10.dp))
+            Text(event.message.ifBlank { "任务未提供结果说明" }, fontSize = 12.sp, lineHeight = 17.sp)
+            Spacer(Modifier.height(10.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+                if (event.bytes > 0L) AuditPill(Formatter.formatFileSize(context, event.bytes))
+                if (event.selected > 0L) AuditPill("选择 ${event.selected}")
+                if (event.processed > 0L) AuditPill("处理 ${event.processed}")
+                if (event.skipped > 0L || event.protected > 0L) AuditPill("保护 ${event.skipped + event.protected}")
+                if (event.errors > 0L) AuditPill("异常 ${event.errors}")
+            }
+            if (event.elapsedMs > 0L) {
+                Spacer(Modifier.height(7.dp))
+                Text("耗时 ${formatAuditElapsed(event.elapsedMs)}", color = MaterialTheme.colorScheme.outline, fontSize = 9.sp)
+            }
+            if (expanded) {
+                Spacer(Modifier.height(13.dp))
+                Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+                    Column(Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (event.profile.isNotBlank()) AuditKeyValue("配置", event.profile)
+                        if (event.snapshotId.isNotBlank()) AuditKeyValue("快照", event.snapshotId.take(12))
+                        if (event.errorCode.isNotBlank()) AuditKeyValue("错误码", event.errorCode)
+                        event.reasons.forEach { reason -> AuditKeyValue("原因", reason) }
+                        event.details.forEach { detail ->
+                            Column {
+                                Text(
+                                    detail.category.ifBlank { detail.action.ifBlank { "候选明细" } },
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 11.sp
+                                )
+                                val line = buildString {
+                                    if (detail.reason.isNotBlank()) append(detail.reason)
+                                    if (detail.pathTail.isNotBlank()) {
+                                        if (isNotEmpty()) append("\n")
+                                        append(detail.pathTail)
+                                    }
+                                }
+                                if (line.isNotBlank()) Text(line, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp, lineHeight = 13.sp)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBadge(status: String) {
+    val (label, color) = when (status) {
+        "success" -> "成功" to BaiZeTokens.colors.success
+        "scanned" -> "已扫描" to MaterialTheme.colorScheme.primary
+        "accepted" -> "后台执行" to MaterialTheme.colorScheme.primary
+        "partial" -> "部分异常" to BaiZeTokens.colors.warning
+        "cancelled" -> "已停止" to BaiZeTokens.colors.warning
+        else -> "失败" to MaterialTheme.colorScheme.error
+    }
+    Surface(shape = CircleShape, color = color.copy(alpha = .13f)) {
+        Text(label, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), color = color, fontSize = 9.sp, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun AuditPill(text: String) {
+    Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = .09f)) {
+        Text(text, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp), color = MaterialTheme.colorScheme.primary, fontSize = 9.sp)
+    }
+}
+
+@Composable
+private fun AuditKeyValue(label: String, value: String) {
+    Row(verticalAlignment = Alignment.Top) {
+        Text(label, color = MaterialTheme.colorScheme.primary, fontSize = 9.sp, fontWeight = FontWeight.Bold, modifier = Modifier.width(44.dp))
+        Text(value, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp, lineHeight = 13.sp, modifier = Modifier.weight(1f))
+    }
+}
+
+private data class AuditVisual(val icon: ImageVector, val tint: androidx.compose.ui.graphics.Color)
+
+@Composable
+private fun auditVisual(event: AuditEvent): AuditVisual = when {
+    event.status == "failed" -> AuditVisual(Icons.Rounded.ErrorOutline, MaterialTheme.colorScheme.error)
+    event.status == "partial" || event.status == "cancelled" -> AuditVisual(Icons.Rounded.ErrorOutline, BaiZeTokens.colors.warning)
+    event.kind == "scan" -> AuditVisual(Icons.Rounded.Search, MaterialTheme.colorScheme.primary)
+    event.kind == "safety" -> AuditVisual(Icons.Rounded.Security, MaterialTheme.colorScheme.primary)
+    event.kind == "clean" || event.kind == "organize" -> AuditVisual(Icons.Rounded.CleaningServices, BaiZeTokens.colors.success)
+    else -> AuditVisual(Icons.Rounded.CheckCircle, BaiZeTokens.colors.success)
+}
+
+private fun operationTitle(operation: String): String = when (operation) {
+    "scan", "profile-scan" -> "安全扫描"
+    "clean", "smart-clean" -> "智能自动清理"
+    "snapshot-clean" -> "扫描快照清理"
+    "workbench-clean" -> "工作台所选清理"
+    "profile-clean" -> "分类候选清理"
+    "profile-quarantine" -> "高风险隔离"
+    "quarantine-restore" -> "恢复隔离内容"
+    "quarantine-purge" -> "永久删除隔离内容"
+    "quarantine-expire" -> "清理过期隔离项"
+    "instant-cache" -> "应用缓存清理"
+    "file-organizer-scan" -> "文件归类扫描"
+    "file-organizer-apply", "organize", "organizer" -> "文件自动归类"
+    "file-organizer-undo" -> "撤销文件归类"
+    "deep-scan" -> "完整深度扫描"
+    "deep-clean" -> "完整深度清理"
+    "corpse-scan" -> "卸载残留扫描"
+    "corpse-clean" -> "卸载残留清理"
+    else -> operation.replace('-', ' ').replaceFirstChar { it.uppercase() }
+}
+
+private fun sourceLabel(source: String): String = when {
+    source.startsWith("scheduled:") -> "自动定时"
+    source.startsWith("daily:") -> "每日定时"
+    source == "app-native" -> "App 快照"
+    source == "app" -> "App 手动"
+    source == "manual" -> "手动执行"
+    source == "history" -> "历史记录"
+    else -> source.ifBlank { "Root 服务" }
+}
+
+private fun formatAuditElapsed(ms: Long): String = when {
+    ms >= 3_600_000L -> "${ms / 3_600_000L}小时${ms % 3_600_000L / 60_000L}分"
+    ms >= 60_000L -> "${ms / 60_000L}分${ms % 60_000L / 1_000L}秒"
+    else -> "${ms / 1_000L}.${(ms % 1_000L) / 100L}秒"
+}
+
+private fun JSONArray?.toStringList(): List<String> = buildList {
+    val array = this@toStringList ?: return@buildList
+    for (index in 0 until array.length()) {
+        val value = array.optString(index).trim()
+        if (value.isNotBlank()) add(value)
+    }
+}
+
+private fun JSONArray?.toDetailList(): List<AuditDetail> = buildList {
+    val array = this@toDetailList ?: return@buildList
+    for (index in 0 until array.length()) {
+        val item = array.optJSONObject(index) ?: continue
+        add(
+            AuditDetail(
+                action = item.optString("action"),
+                category = item.optString("category"),
+                risk = item.optString("risk"),
+                reason = item.optString("reason"),
+                pathTail = item.optString("pathTail"),
+                bytes = item.optLong("bytes").coerceAtLeast(0L),
+                files = item.optLong("files").coerceAtLeast(0L),
+                directories = item.optLong("directories").coerceAtLeast(0L)
+            )
+        )
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/AuditRepository.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/AuditRepository.kt
@@ -1,0 +1,351 @@
+package io.github.xgl34222220.baize.root
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Root-owned structured audit timeline.
+ *
+ * New engine results are persisted as bounded JSONL events. Existing history.tsv rows are merged at
+ * read time so upgrades keep their old task records without a destructive migration. Paths are
+ * reduced to a tail before persistence; the audit UI never receives arbitrary full filesystem paths.
+ */
+internal class AuditRepository(
+    private val stateDir: File = File(RootPaths.STATE_DIR)
+) {
+    private val auditFile = File(stateDir, "audit.jsonl")
+    private val metaFile = File(stateDir, "audit.meta")
+    private val historyFile = File(stateDir, "history.tsv")
+
+    @Synchronized
+    fun recordResult(
+        operation: String,
+        source: String,
+        rawResult: String,
+        startedEpoch: Long = System.currentTimeMillis()
+    ) {
+        val result = runCatching { JSONObject(rawResult) }.getOrElse {
+            JSONObject()
+                .put("success", false)
+                .put("error", "invalid_result")
+                .put("message", it.message ?: "无法解析任务结果")
+        }
+        appendEvent(buildEvent(operation, source, result, startedEpoch))
+    }
+
+    @Synchronized
+    fun recordNativeTask(taskJson: String, historyResult: String) {
+        val task = runCatching { JSONObject(taskJson) }.getOrNull() ?: return
+        val history = runCatching { JSONObject(historyResult) }.getOrNull()
+        val result = JSONObject(task.toString())
+        if (history?.optBoolean("success") != true) {
+            result.put("success", false)
+            result.put("error", history?.optString("error").orEmpty().ifBlank { "history_record_failed" })
+        }
+        appendEvent(buildEvent(task.optString("mode", "native-task"), "app-native", result, System.currentTimeMillis()))
+    }
+
+    @Synchronized
+    fun timelinePageJson(offset: Int, requestedLimit: Int): String {
+        val clearEpoch = readClearEpoch()
+        val combined = (readAuditEvents(clearEpoch) + readLegacyEvents(clearEpoch))
+            .distinctBy { it.optString("id") }
+            .sortedByDescending { it.optLong("timeEpoch") }
+            .take(MAX_EVENTS)
+
+        val safeOffset = offset.coerceIn(0, combined.size)
+        val safeLimit = requestedLimit.coerceIn(1, MAX_PAGE_SIZE)
+        val end = (safeOffset + safeLimit).coerceAtMost(combined.size)
+        val page = JSONArray()
+        for (index in safeOffset until end) page.put(combined[index])
+
+        var successCount = 0
+        var failedCount = 0
+        var cancelledCount = 0
+        var releasedBytes = 0L
+        var quarantinedBytes = 0L
+        var protectedCount = 0L
+        combined.forEach { event ->
+            when (event.optString("status")) {
+                "success", "partial", "scanned", "accepted" -> successCount += 1
+                "cancelled" -> cancelledCount += 1
+                else -> failedCount += 1
+            }
+            val kind = event.optString("kind")
+            val bytes = event.optLong("bytes").coerceAtLeast(0L)
+            if (kind == "clean" && event.optString("status") in setOf("success", "partial")) releasedBytes += bytes
+            if (kind == "safety" && event.optString("operation").contains("quarantine") && event.optString("status") in setOf("success", "partial")) {
+                quarantinedBytes += bytes
+            }
+            protectedCount += event.optLong("protected").coerceAtLeast(0L)
+        }
+
+        return JSONObject()
+            .put("success", true)
+            .put("schema", SCHEMA_VERSION)
+            .put("total", combined.size)
+            .put("offset", safeOffset)
+            .put("nextOffset", end)
+            .put("hasMore", end < combined.size)
+            .put("successCount", successCount)
+            .put("failedCount", failedCount)
+            .put("cancelledCount", cancelledCount)
+            .put("releasedBytes", releasedBytes)
+            .put("quarantinedBytes", quarantinedBytes)
+            .put("protectedCount", protectedCount)
+            .put("events", page)
+            .toString()
+    }
+
+    @Synchronized
+    fun clearTimelineJson(): String = runCatching {
+        stateDir.mkdirs()
+        RootFileStore.writeAtomic(auditFile, "")
+        RootFileStore.writeAtomic(metaFile, "cleared_at=${System.currentTimeMillis()}\n")
+        JSONObject().put("success", true).put("message", "审计时间线已清空，累计统计和清理历史未修改").toString()
+    }.getOrElse {
+        JSONObject().put("success", false).put("error", it.message ?: it.javaClass.simpleName).toString()
+    }
+
+    private fun buildEvent(operationRaw: String, sourceRaw: String, result: JSONObject, startedEpoch: Long): JSONObject {
+        val operation = sanitize(operationRaw, 80).ifBlank { "unknown" }
+        val latest = result.optJSONObject("latest") ?: JSONObject()
+        val now = System.currentTimeMillis()
+        val time = TIME_FORMAT.get().format(Date(now))
+        val errorCode = sanitize(result.optString("error"), 120)
+        val cancelled = result.optBoolean("cancelled") || latest.optBoolean("cancelled")
+        val accepted = result.optBoolean("accepted")
+        val failures = number(result, latest, "failures", "errors").coerceAtLeast(0L)
+        val success = result.optBoolean("success", errorCode.isBlank())
+        val status = when {
+            cancelled -> "cancelled"
+            accepted -> "accepted"
+            errorCode.isNotBlank() || !success -> "failed"
+            failures > 0L -> "partial"
+            operation.contains("scan") -> "scanned"
+            else -> "success"
+        }
+        val source = sanitize(
+            result.optString("trigger").ifBlank { latest.optString("trigger") }.ifBlank { sourceRaw },
+            100
+        )
+        val message = sanitize(
+            result.optString("message").ifBlank { latest.optString("result") }
+                .ifBlank { result.optString("result") }
+                .ifBlank { errorCode.ifBlank { defaultMessage(operation, status) } },
+            600
+        )
+        val bytes = number(result, latest, "deletedBytes", "quarantinedBytes", "bytes").coerceAtLeast(0L)
+        val files = number(result, latest, "deletedFiles", "quarantinedFiles", "files", "regular_files").coerceAtLeast(0L)
+        val directories = number(result, latest, "deletedDirectories", "quarantinedDirectories", "directories", "empty_dirs").coerceAtLeast(0L)
+        val selected = number(result, latest, "selected", "selectedCandidates", "totalCandidates").coerceAtLeast(0L)
+        val processed = number(result, latest, "cleanedCandidates", "quarantinedCandidates", "purged", "processed").coerceAtLeast(0L)
+        val skipped = number(result, latest, "skippedCandidates", "skipped").coerceAtLeast(0L)
+        val elapsedMs = when {
+            result.has("elapsedMs") -> result.optLong("elapsedMs")
+            latest.has("elapsedMs") -> latest.optLong("elapsedMs")
+            result.has("elapsedSeconds") -> result.optLong("elapsedSeconds") * 1_000L
+            latest.has("elapsed") -> latest.optLong("elapsed") * 1_000L
+            else -> (now - startedEpoch).coerceAtLeast(0L)
+        }.coerceAtLeast(0L)
+        val details = sanitizeDetails(result.optJSONArray("details"))
+        val protected = (0 until details.length()).count {
+            val action = details.optJSONObject(it)?.optString("action").orEmpty()
+            action == "protected" || action == "partial" || action == "skipped"
+        }.toLong()
+        val reasons = collectReasons(errorCode, message, details)
+        val snapshot = sanitize(
+            result.optString("snapshotId").ifBlank { latest.optString("snapshotId") },
+            100
+        )
+        val profile = sanitize(result.optString("profile").ifBlank { latest.optString("profile") }, 80)
+        val id = stableId("$time\u0000$operation\u0000$bytes\u0000$files\u0000$message")
+
+        return JSONObject()
+            .put("schema", SCHEMA_VERSION)
+            .put("id", id)
+            .put("timeEpoch", now)
+            .put("time", time)
+            .put("operation", operation)
+            .put("kind", kindFor(operation))
+            .put("source", source.ifBlank { "app" })
+            .put("status", status)
+            .put("message", message)
+            .put("errorCode", errorCode)
+            .put("profile", profile)
+            .put("snapshotId", snapshot)
+            .put("selected", selected)
+            .put("processed", processed)
+            .put("skipped", skipped)
+            .put("protected", protected)
+            .put("bytes", bytes)
+            .put("files", files)
+            .put("directories", directories)
+            .put("errors", failures)
+            .put("elapsedMs", elapsedMs)
+            .put("reasonCodes", reasons)
+            .put("details", details)
+            .put("legacy", false)
+    }
+
+    private fun sanitizeDetails(raw: JSONArray?): JSONArray {
+        val output = JSONArray()
+        if (raw == null) return output
+        for (index in 0 until raw.length().coerceAtMost(MAX_DETAILS)) {
+            val item = raw.optJSONObject(index) ?: continue
+            val path = item.optString("path").ifBlank { item.optString("restoredPath") }
+            output.put(
+                JSONObject()
+                    .put("action", sanitize(item.optString("action"), 60))
+                    .put("category", sanitize(item.optString("category").ifBlank { item.optString("label") }, 100))
+                    .put("risk", sanitize(item.optString("risk"), 40))
+                    .put("reason", sanitize(item.optString("reason").ifBlank { item.optString("message") }, 240))
+                    .put("pathTail", sanitize(pathTail(path), 160))
+                    .put("bytes", item.optLong("bytes").coerceAtLeast(0L))
+                    .put("files", item.optLong("files").coerceAtLeast(0L))
+                    .put("directories", item.optLong("directories").coerceAtLeast(0L))
+            )
+        }
+        return output
+    }
+
+    private fun collectReasons(errorCode: String, message: String, details: JSONArray): JSONArray {
+        val values = linkedSetOf<String>()
+        errorCode.takeIf { it.isNotBlank() }?.let(values::add)
+        if (errorCode.isNotBlank()) message.takeIf { it.isNotBlank() }?.let(values::add)
+        for (index in 0 until details.length()) {
+            val reason = details.optJSONObject(index)?.optString("reason").orEmpty()
+            if (reason.isNotBlank()) values += reason
+            if (values.size >= MAX_REASONS) break
+        }
+        return JSONArray(values.take(MAX_REASONS))
+    }
+
+    private fun appendEvent(event: JSONObject) {
+        stateDir.mkdirs()
+        val lines = runCatching { if (auditFile.isFile) auditFile.readLines() else emptyList() }
+            .getOrDefault(emptyList())
+            .asSequence()
+            .filter { it.isNotBlank() }
+            .takeLast(MAX_EVENTS - 1)
+            .toMutableList()
+        lines += event.toString()
+        RootFileStore.writeAtomic(auditFile, lines.joinToString("\n", postfix = "\n"))
+    }
+
+    private fun readAuditEvents(clearEpoch: Long): List<JSONObject> = runCatching {
+        if (!auditFile.isFile) return@runCatching emptyList()
+        auditFile.readLines().asSequence()
+            .mapNotNull { line -> runCatching { JSONObject(line) }.getOrNull() }
+            .filter { it.optLong("timeEpoch") > clearEpoch }
+            .takeLast(MAX_EVENTS)
+            .toList()
+    }.getOrDefault(emptyList())
+
+    private fun readLegacyEvents(clearEpoch: Long): List<JSONObject> = runCatching {
+        if (!historyFile.isFile) return@runCatching emptyList()
+        historyFile.readLines().takeLast(MAX_LEGACY).mapNotNull { raw ->
+            val columns = raw.split('\t', limit = 10)
+            if (columns.size < 7) return@mapNotNull null
+            val time = sanitize(columns[0], 40)
+            val epoch = runCatching { TIME_FORMAT.get().parse(time)?.time ?: 0L }.getOrDefault(0L)
+            if (epoch <= clearEpoch) return@mapNotNull null
+            val operation = sanitize(columns[1], 80)
+            val bytes = columns[2].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+            val files = columns[3].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+            val directories = columns[4].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+            val errors = columns[5].toLongOrNull()?.coerceAtLeast(0L) ?: 0L
+            val message = sanitize(columns[6], 600)
+            val source = sanitize(columns.getOrNull(7).orEmpty(), 100).ifBlank { "history" }
+            val scan = operation == "scan" || operation.endsWith("-scan")
+            val status = when {
+                errors > 0L -> "partial"
+                scan -> "scanned"
+                else -> "success"
+            }
+            JSONObject()
+                .put("schema", SCHEMA_VERSION)
+                .put("id", stableId("$time\u0000$operation\u0000$bytes\u0000$files\u0000$message"))
+                .put("timeEpoch", epoch)
+                .put("time", time)
+                .put("operation", operation)
+                .put("kind", kindFor(operation))
+                .put("source", source)
+                .put("status", status)
+                .put("message", message)
+                .put("errorCode", "")
+                .put("profile", "")
+                .put("snapshotId", "")
+                .put("selected", files)
+                .put("processed", files)
+                .put("skipped", 0)
+                .put("protected", 0)
+                .put("bytes", bytes)
+                .put("files", files)
+                .put("directories", directories)
+                .put("errors", errors)
+                .put("elapsedMs", 0)
+                .put("reasonCodes", JSONArray())
+                .put("details", JSONArray())
+                .put("legacy", true)
+        }
+    }.getOrDefault(emptyList())
+
+    private fun readClearEpoch(): Long = RootFileStore.readEnv(metaFile).optLong("cleared_at", 0L).coerceAtLeast(0L)
+
+    private fun number(primary: JSONObject, fallback: JSONObject, vararg keys: String): Long {
+        keys.forEach { key -> if (primary.has(key)) return primary.optLong(key) }
+        keys.forEach { key -> if (fallback.has(key)) return fallback.optLong(key) }
+        return 0L
+    }
+
+    private fun kindFor(operation: String): String = when {
+        operation.contains("quarantine") || operation.contains("restore") || operation.contains("purge") || operation.contains("expire") -> "safety"
+        operation.contains("scan") -> "scan"
+        operation.contains("organize") -> "organize"
+        else -> "clean"
+    }
+
+    private fun defaultMessage(operation: String, status: String): String = when (status) {
+        "accepted" -> "$operation 已交给后台执行"
+        "scanned" -> "$operation 扫描完成"
+        "cancelled" -> "$operation 已停止"
+        "failed" -> "$operation 执行失败"
+        else -> "$operation 执行完成"
+    }
+
+    private fun pathTail(path: String): String {
+        val normalized = path.trim().replace('\\', '/')
+        if (normalized.isBlank()) return ""
+        val segments = normalized.split('/').filter { it.isNotBlank() }
+        return if (segments.size <= 4) normalized else "…/" + segments.takeLast(4).joinToString("/")
+    }
+
+    private fun sanitize(value: String, limit: Int): String = value
+        .replace('\u0000', ' ')
+        .replace('\t', ' ')
+        .replace('\n', ' ')
+        .replace('\r', ' ')
+        .trim()
+        .take(limit)
+
+    private fun stableId(value: String): String = "audit-" + MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .joinToString("") { "%02x".format(it) }
+        .take(24)
+
+    companion object {
+        private const val SCHEMA_VERSION = 1
+        private const val MAX_EVENTS = 500
+        private const val MAX_LEGACY = 100
+        private const val MAX_PAGE_SIZE = 100
+        private const val MAX_DETAILS = 24
+        private const val MAX_REASONS = 10
+        private val TIME_FORMAT = ThreadLocal.withInitial { SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US) }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/AuditRepository.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/AuditRepository.kt
@@ -230,7 +230,6 @@ internal class AuditRepository(
         stateDir.mkdirs()
         val lines = runCatching { if (auditFile.isFile) auditFile.readLines() else emptyList() }
             .getOrDefault(emptyList())
-            .asSequence()
             .filter { it.isNotBlank() }
             .takeLast(MAX_EVENTS - 1)
             .toMutableList()
@@ -240,11 +239,10 @@ internal class AuditRepository(
 
     private fun readAuditEvents(clearEpoch: Long): List<JSONObject> = runCatching {
         if (!auditFile.isFile) return@runCatching emptyList()
-        auditFile.readLines().asSequence()
+        auditFile.readLines()
             .mapNotNull { line -> runCatching { JSONObject(line) }.getOrNull() }
             .filter { it.optLong("timeEpoch") > clearEpoch }
             .takeLast(MAX_EVENTS)
-            .toList()
     }.getOrDefault(emptyList())
 
     private fun readLegacyEvents(clearEpoch: Long): List<JSONObject> = runCatching {
@@ -323,7 +321,7 @@ internal class AuditRepository(
         val normalized = path.trim().replace('\\', '/')
         if (normalized.isBlank()) return ""
         val segments = normalized.split('/').filter { it.isNotBlank() }
-        return if (segments.size <= 4) normalized else "…/" + segments.takeLast(4).joinToString("/")
+        return if (segments.isEmpty()) "" else "…/" + segments.takeLast(4).joinToString("/")
     }
 
     private fun sanitize(value: String, limit: Int): String = value

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
@@ -18,6 +18,7 @@ class BaiZeProfileRootService : RootService() {
     private val schedulerRepository = SchedulerRepository()
     private val diagnostics = DiagnosticRepository()
     private val historyRepository = HistoryRepository()
+    private val auditRepository = AuditRepository()
     private val packageCatalog = PackageCatalog()
     private val whitelistRepository = WhitelistRepository()
     private val cacheSelectionRepository = CacheSelectionRepository()
@@ -38,12 +39,12 @@ class BaiZeProfileRootService : RootService() {
             .put("cleaner", File(RootPaths.MODULE_DIR, "cleaner.sh").isFile)
             .put("deepRules", File(RootPaths.MODULE_DIR, "config/deep.rules").isFile)
             .put("scheduler", File(RootPaths.MODULE_DIR, "scheduler.sh").isFile)
-            .put("engine", "unified-root-task-coordinator-v2-quarantine")
+            .put("engine", "unified-root-task-coordinator-v2-audit")
             .toString()
 
         override fun getProfileCatalog(): String = profileEngine.catalog()
 
-        override fun scanProfile(profile: String?, optionsJson: String?): String =
+        override fun scanProfile(profile: String?, optionsJson: String?): String = audited("profile-scan") {
             coordinator.runExclusive(
                 operation = "profile-scan",
                 phase = "正在扫描保护项",
@@ -63,6 +64,7 @@ class BaiZeProfileRootService : RootService() {
                     )
                 }
             }
+        }
 
         override fun getProfilePage(snapshotId: String?, offset: Int, limit: Int): String {
             if (coordinator.isBusy()) return coordinator.busy("profile-page")
@@ -74,23 +76,25 @@ class BaiZeProfileRootService : RootService() {
             snapshotId: String?,
             selectionJson: String?,
             optionsJson: String?
-        ): String = coordinator.runExclusive(
-            operation = "profile-clean",
-            phase = "正在清理已选择项目",
-            failureCode = "profile_clean_failed"
-        ) { started ->
-            profileEngine.clean(snapshotId.orEmpty(), selectionJson.orEmpty(), optionsJson.orEmpty()) { progress ->
-                coordinator.update(
-                    operation = "profile-clean",
-                    phase = progress.phase,
-                    current = progress.current,
-                    total = progress.total,
-                    currentPath = progress.path,
-                    startedRealtime = started,
-                    deletedBytes = progress.bytes,
-                    deletedFiles = progress.files,
-                    failures = progress.failures
-                )
+        ): String = audited("profile-clean") {
+            coordinator.runExclusive(
+                operation = "profile-clean",
+                phase = "正在清理已选择项目",
+                failureCode = "profile_clean_failed"
+            ) { started ->
+                profileEngine.clean(snapshotId.orEmpty(), selectionJson.orEmpty(), optionsJson.orEmpty()) { progress ->
+                    coordinator.update(
+                        operation = "profile-clean",
+                        phase = progress.phase,
+                        current = progress.current,
+                        total = progress.total,
+                        currentPath = progress.path,
+                        startedRealtime = started,
+                        deletedBytes = progress.bytes,
+                        deletedFiles = progress.files,
+                        failures = progress.failures
+                    )
+                }
             }
         }
 
@@ -98,23 +102,25 @@ class BaiZeProfileRootService : RootService() {
             snapshotId: String?,
             selectionJson: String?,
             optionsJson: String?
-        ): String = coordinator.runExclusive(
-            operation = "profile-quarantine",
-            phase = "正在隔离高风险项目",
-            failureCode = "profile_quarantine_failed"
-        ) { started ->
-            profileEngine.quarantine(snapshotId.orEmpty(), selectionJson.orEmpty(), optionsJson.orEmpty()) { progress ->
-                coordinator.update(
-                    operation = "profile-quarantine",
-                    phase = progress.phase,
-                    current = progress.current,
-                    total = progress.total,
-                    currentPath = progress.path,
-                    startedRealtime = started,
-                    deletedBytes = progress.bytes,
-                    deletedFiles = progress.files,
-                    failures = progress.failures
-                )
+        ): String = audited("profile-quarantine") {
+            coordinator.runExclusive(
+                operation = "profile-quarantine",
+                phase = "正在隔离高风险项目",
+                failureCode = "profile_quarantine_failed"
+            ) { started ->
+                profileEngine.quarantine(snapshotId.orEmpty(), selectionJson.orEmpty(), optionsJson.orEmpty()) { progress ->
+                    coordinator.update(
+                        operation = "profile-quarantine",
+                        phase = progress.phase,
+                        current = progress.current,
+                        total = progress.total,
+                        currentPath = progress.path,
+                        startedRealtime = started,
+                        deletedBytes = progress.bytes,
+                        deletedFiles = progress.files,
+                        failures = progress.failures
+                    )
+                }
             }
         }
 
@@ -126,23 +132,29 @@ class BaiZeProfileRootService : RootService() {
             return quarantineRepository.page(offset, limit)
         }
 
-        override fun restoreQuarantineItem(id: String?): String = coordinator.runExclusive(
-            operation = "quarantine-restore",
-            phase = "正在恢复隔离内容",
-            failureCode = "quarantine_restore_failed"
-        ) { quarantineRepository.restore(id) }
+        override fun restoreQuarantineItem(id: String?): String = audited("quarantine-restore") {
+            coordinator.runExclusive(
+                operation = "quarantine-restore",
+                phase = "正在恢复隔离内容",
+                failureCode = "quarantine_restore_failed"
+            ) { quarantineRepository.restore(id) }
+        }
 
-        override fun purgeQuarantineItem(id: String?): String = coordinator.runExclusive(
-            operation = "quarantine-purge",
-            phase = "正在永久删除隔离内容",
-            failureCode = "quarantine_purge_failed"
-        ) { quarantineRepository.purge(id) }
+        override fun purgeQuarantineItem(id: String?): String = audited("quarantine-purge") {
+            coordinator.runExclusive(
+                operation = "quarantine-purge",
+                phase = "正在永久删除隔离内容",
+                failureCode = "quarantine_purge_failed"
+            ) { quarantineRepository.purge(id) }
+        }
 
-        override fun purgeExpiredQuarantine(): String = coordinator.runExclusive(
-            operation = "quarantine-expire",
-            phase = "正在清理过期隔离项",
-            failureCode = "quarantine_expire_failed"
-        ) { quarantineRepository.purgeExpired() }
+        override fun purgeExpiredQuarantine(): String = audited("quarantine-expire") {
+            coordinator.runExclusive(
+                operation = "quarantine-expire",
+                phase = "正在清理过期隔离项",
+                failureCode = "quarantine_expire_failed"
+            ) { quarantineRepository.purgeExpired() }
+        }
 
         override fun runMaintenanceTool(tool: String?, optionsJson: String?): String =
             diagnostics.runMaintenanceTool(tool, optionsJson)
@@ -160,15 +172,17 @@ class BaiZeProfileRootService : RootService() {
                 "organize" -> "正在启动文件归类"
                 else -> "正在执行 Root 任务"
             }
-            return coordinator.runExclusive(
-                operation = "module-$normalized",
-                phase = phase,
-                failureCode = "module_task_failed"
-            ) { started ->
-                if (normalized in DETACHED_TASKS) {
-                    moduleTasks.startDetachedModuleTask(normalized, started)
-                } else {
-                    moduleTasks.executeModuleTask(normalized, started)
+            return audited(normalized) {
+                coordinator.runExclusive(
+                    operation = "module-$normalized",
+                    phase = phase,
+                    failureCode = "module_task_failed"
+                ) { started ->
+                    if (normalized in DETACHED_TASKS) {
+                        moduleTasks.startDetachedModuleTask(normalized, started)
+                    } else {
+                        moduleTasks.executeModuleTask(normalized, started)
+                    }
                 }
             }
         }
@@ -177,51 +191,43 @@ class BaiZeProfileRootService : RootService() {
         override fun getTaskHistory(limit: Int): String = historyRepository.taskHistoryJson(limit)
         override fun getTaskHistoryPage(offset: Int, limit: Int): String =
             historyRepository.taskHistoryPageJson(offset, limit)
+        override fun getAuditTimelinePage(offset: Int, limit: Int): String =
+            auditRepository.timelinePageJson(offset, limit)
+        override fun clearAuditTimeline(): String = auditRepository.clearTimelineJson()
         override fun getScanCoverage(): String = diagnostics.scanCoverageJson()
         override fun clearTaskHistory(): String = historyRepository.clearTaskHistoryJson()
         override fun getRawLog(maxChars: Int): String = diagnostics.rawLogJson(maxChars)
         override fun clearRawLogs(): String = diagnostics.clearRawLogsJson()
-        override fun recordNativeTask(taskJson: String?): String =
-            historyRepository.recordNativeTaskJson(taskJson.orEmpty())
+        override fun recordNativeTask(taskJson: String?): String {
+            val raw = taskJson.orEmpty()
+            val result = historyRepository.recordNativeTaskJson(raw)
+            runCatching { auditRepository.recordNativeTask(raw, result) }
+            return result
+        }
         override fun getSchedulerConfig(): String = schedulerRepository.configJson()
         override fun saveSchedulerConfig(configJson: String?): String =
             schedulerRepository.saveConfig(configJson.orEmpty())
         override fun resetScanWorkerProfile(): String = diagnostics.resetScanWorkerProfileJson()
 
-        override fun clearPackageCaches(requestJson: String?): String = coordinator.runExclusive(
-            operation = "instant-cache",
-            phase = "正在清理应用缓存",
-            failureCode = "instant_cache_failed"
-        ) { started ->
-            instantCacheEngine.run(requestJson.orEmpty(), started)
-        }
-
-        override fun scanFileOrganizer(): String = coordinator.runExclusive(
-            operation = "file-organizer-scan",
-            phase = "正在扫描可归类文件",
-            failureCode = "file_organizer_scan_failed"
-        ) { started ->
-            organizerController.scan { progress ->
-                coordinator.update(
-                    operation = "file-organizer-scan",
-                    phase = progress.phase,
-                    current = progress.current,
-                    total = progress.total,
-                    currentPath = progress.path,
-                    startedRealtime = started
-                )
+        override fun clearPackageCaches(requestJson: String?): String = audited("instant-cache") {
+            coordinator.runExclusive(
+                operation = "instant-cache",
+                phase = "正在清理应用缓存",
+                failureCode = "instant_cache_failed"
+            ) { started ->
+                instantCacheEngine.run(requestJson.orEmpty(), started)
             }
         }
 
-        override fun applyFileOrganizer(snapshotId: String?, selectionJson: String?): String =
+        override fun scanFileOrganizer(): String = audited("file-organizer-scan") {
             coordinator.runExclusive(
-                operation = "file-organizer-apply",
-                phase = "正在归类文件",
-                failureCode = "file_organizer_apply_failed"
+                operation = "file-organizer-scan",
+                phase = "正在扫描可归类文件",
+                failureCode = "file_organizer_scan_failed"
             ) { started ->
-                organizerController.apply(snapshotId.orEmpty(), selectionJson.orEmpty()) { progress ->
+                organizerController.scan { progress ->
                     coordinator.update(
-                        operation = "file-organizer-apply",
+                        operation = "file-organizer-scan",
                         phase = progress.phase,
                         current = progress.current,
                         total = progress.total,
@@ -230,21 +236,44 @@ class BaiZeProfileRootService : RootService() {
                     )
                 }
             }
+        }
 
-        override fun undoFileOrganizer(): String = coordinator.runExclusive(
-            operation = "file-organizer-undo",
-            phase = "正在撤销上次归类",
-            failureCode = "file_organizer_undo_failed"
-        ) { started ->
-            organizerController.undo { progress ->
-                coordinator.update(
-                    operation = "file-organizer-undo",
-                    phase = progress.phase,
-                    current = progress.current,
-                    total = progress.total,
-                    currentPath = progress.path,
-                    startedRealtime = started
-                )
+        override fun applyFileOrganizer(snapshotId: String?, selectionJson: String?): String =
+            audited("file-organizer-apply") {
+                coordinator.runExclusive(
+                    operation = "file-organizer-apply",
+                    phase = "正在归类文件",
+                    failureCode = "file_organizer_apply_failed"
+                ) { started ->
+                    organizerController.apply(snapshotId.orEmpty(), selectionJson.orEmpty()) { progress ->
+                        coordinator.update(
+                            operation = "file-organizer-apply",
+                            phase = progress.phase,
+                            current = progress.current,
+                            total = progress.total,
+                            currentPath = progress.path,
+                            startedRealtime = started
+                        )
+                    }
+                }
+            }
+
+        override fun undoFileOrganizer(): String = audited("file-organizer-undo") {
+            coordinator.runExclusive(
+                operation = "file-organizer-undo",
+                phase = "正在撤销上次归类",
+                failureCode = "file_organizer_undo_failed"
+            ) { started ->
+                organizerController.undo { progress ->
+                    coordinator.update(
+                        operation = "file-organizer-undo",
+                        phase = progress.phase,
+                        current = progress.current,
+                        total = progress.total,
+                        currentPath = progress.path,
+                        startedRealtime = started
+                    )
+                }
             }
         }
 
@@ -259,6 +288,13 @@ class BaiZeProfileRootService : RootService() {
         override fun registerTaskProgressCallback(callback: ITaskProgressCallback?) = coordinator.register(callback)
         override fun unregisterTaskProgressCallback(callback: ITaskProgressCallback?) = coordinator.unregister(callback)
         override fun cancelCurrentTask() = coordinator.cancelCurrentTask()
+    }
+
+    private fun audited(operation: String, source: String = "app", block: () -> String): String {
+        val started = System.currentTimeMillis()
+        val result = block()
+        runCatching { auditRepository.recordResult(operation, source, result, started) }
+        return result
     }
 
     override fun onBind(intent: Intent): IBinder = binder

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/HistoryRepository.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/HistoryRepository.kt
@@ -97,7 +97,7 @@ internal class HistoryRepository(
     fun recordNativeTaskJson(raw: String): String = runCatching {
         val input = JSONObject(raw)
         val mode = input.optString("mode").trim()
-        require(mode in setOf("smart-clean", "snapshot-clean")) { "unsupported_native_mode" }
+        require(mode in NATIVE_MODES) { "unsupported_native_mode" }
         val success = input.optBoolean("success", true)
         val cancelled = input.optBoolean("cancelled", false)
         val bytes = input.optLong("bytes", 0L).coerceIn(0L, Long.MAX_VALUE / 4)
@@ -211,5 +211,17 @@ internal class HistoryRepository(
             bytes >= 1024.0 -> String.format(Locale.US, "%.2f KB", bytes / 1024.0)
             else -> "${bytes.toLong()} B"
         }
+    }
+
+    companion object {
+        private val NATIVE_MODES = setOf(
+            "smart-clean",
+            "snapshot-clean",
+            "workbench-clean",
+            "profile-clean",
+            "instant-cache",
+            "file-organizer-apply",
+            "file-organizer-undo"
+        )
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt
@@ -1,6 +1,21 @@
 package io.github.xgl34222220.baize.ui.history
 
+import android.content.Intent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Description
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import io.github.xgl34222220.baize.AuditActivity
 import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
@@ -13,6 +28,7 @@ fun HistoryRoute(
     dashboard: DashboardUiState,
     dashboardActions: DashboardActions
 ) {
+    val context = LocalContext.current
     val state = dashboard.toHistoryUiState()
     val actions = HistoryUiActions(
         onRefresh = dashboardActions.refresh,
@@ -20,8 +36,19 @@ fun HistoryRoute(
         onReviewProtected = dashboardActions.reviewProtected
     )
 
-    when (style) {
-        UiStyle.MATERIAL -> HistoryScreenMaterial(state, actions)
-        UiStyle.MIUIX -> HistoryScreenMiuix(state, actions)
+    Box(Modifier.fillMaxSize()) {
+        when (style) {
+            UiStyle.MATERIAL -> HistoryScreenMaterial(state, actions)
+            UiStyle.MIUIX -> HistoryScreenMiuix(state, actions)
+        }
+        ExtendedFloatingActionButton(
+            onClick = { context.startActivity(Intent(context, AuditActivity::class.java)) },
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .navigationBarsPadding()
+                .padding(end = 18.dp, bottom = 88.dp),
+            icon = { Icon(Icons.Rounded.Description, contentDescription = null) },
+            text = { Text("审计中心") }
+        )
     }
 }

--- a/v2/tests/test-audit-center-contract.sh
+++ b/v2/tests/test-audit-center-contract.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+AIDL="$ROOT/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl"
+SERVICE="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt"
+AUDIT="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/root/AuditRepository.kt"
+HISTORY="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/root/HistoryRepository.kt"
+ACTIVITY="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/AuditActivity.kt"
+ROUTE="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt"
+MANIFEST="$ROOT/v2/app/src/main/AndroidManifest.xml"
+SCHEDULER="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt"
+
+for file in "$AIDL" "$SERVICE" "$AUDIT" "$HISTORY" "$ACTIVITY" "$ROUTE" "$MANIFEST" "$SCHEDULER"; do
+  test -f "$file" || { echo "missing audit contract file: $file" >&2; exit 1; }
+done
+
+grep -Fq 'String getAuditTimelinePage(int offset, int limit);' "$AIDL"
+grep -Fq 'String clearAuditTimeline();' "$AIDL"
+grep -Fq 'private val auditRepository = AuditRepository()' "$SERVICE"
+grep -Fq 'auditRepository.timelinePageJson(offset, limit)' "$SERVICE"
+grep -Fq 'auditRepository.recordNativeTask(raw, result)' "$SERVICE"
+
+# Every important mutation family is written by the Root service rather than trusted to App UI.
+for operation in profile-scan profile-clean profile-quarantine quarantine-restore quarantine-purge quarantine-expire instant-cache file-organizer-scan file-organizer-apply file-organizer-undo; do
+  grep -Fq "audited(\"$operation\"" "$SERVICE"
+done
+
+# Audit storage is bounded, backward compatible and path-minimized.
+grep -Fq 'private const val MAX_EVENTS = 500' "$AUDIT"
+grep -Fq 'readLegacyEvents(clearEpoch)' "$AUDIT"
+grep -Fq 'history.tsv' "$AUDIT"
+grep -Fq '.put("pathTail"' "$AUDIT"
+! grep -Fq '.put("path", path)' "$AUDIT"
+grep -Fq 'segments.takeLast(4)' "$AUDIT"
+grep -Fq 'cleared_at=' "$AUDIT"
+grep -Fq '累计统计和清理历史未修改' "$AUDIT"
+
+# Workbench-native results must no longer be rejected by the legacy history writer.
+grep -Fq '"workbench-clean"' "$HISTORY"
+grep -Fq 'require(mode in NATIVE_MODES)' "$HISTORY"
+
+# Both themes reach the same audit activity from the history page.
+grep -Fq 'AuditActivity::class.java' "$ROUTE"
+grep -Fq 'Text("审计中心")' "$ROUTE"
+grep -Fq '<activity android:name=".AuditActivity"' "$MANIFEST"
+grep -Fq 'getAuditTimelinePage(0, 100)' "$ACTIVITY"
+grep -Fq '只隐藏当前时间点之前的审计事件' "$ACTIVITY"
+
+# This step must not tighten any scheduler interval ranges.
+for pattern in \
+  'cacheMinutes.coerceIn(5, 43_200)' \
+  'emptyMinutes.coerceIn(5, 43_200)' \
+  'rulesMinutes.coerceIn(5, 43_200)' \
+  'fragmentMinutes.coerceIn(5, 43_200)' \
+  'deepMinutes.coerceIn(5, 43_200)' \
+  'organizeMinutes.coerceIn(15, 43_200)'; do
+  grep -Fq "$pattern" "$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt"
+done
+
+echo "audit center contract passed"


### PR DESCRIPTION
## 第四步：清理报告与审计中心

- 新增 Root 侧结构化审计时间线，最多保留 500 条事件。
- 扫描、所选清理、高风险隔离、恢复、永久删除、过期清理、应用缓存与文件归类均由 Root 服务写入审计记录。
- 每条事件记录来源、状态、实际释放或隔离空间、选择/处理/跳过/保护数量、耗时、错误码、原因与候选明细。
- 旧 `history.tsv` 在读取时自动合并，无需破坏性迁移。
- 审计路径仅保留末尾片段，不向 UI 暴露完整文件系统路径。
- 清空审计只设置时间边界，不修改累计统计、白名单、隔离内容或原始清理历史。
- 新增 Material/MIUIx 共用审计中心，可按扫描、清理、隔离与恢复、异常筛选并展开详情。
- 修复工作台 `workbench-clean` 记录被旧历史仓库拒绝的问题。
- 未修改任何定时任务周期范围或默认值。

## 验证计划

- Android Kotlin 编译、Lint、Macrobenchmark 装配。
- Root 全量回归。
- 新增审计中心安全契约，锁定事件上限、旧记录兼容、路径脱敏、清空边界、Root 侧写入与调度范围不变。