### PR TITLE
feat: add guarded cleanup policy profiles

### DIFF
--- a/.github/workflows/agent-cleanup-policy-patch-v2.yml
+++ b/.github/workflows/agent-cleanup-policy-patch-v2.yml
@@ -1,0 +1,245 @@
+name: Agent Cleanup Policy Patch V2
+
+on:
+  pull_request:
+    branches: [main]
+    types: [reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/cleanup-policy-profiles
+          fetch-depth: 0
+      - name: Apply cleanup policy integration
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          from pathlib import Path
+          import re
+
+          def patch(path, transforms):
+              p = Path(path)
+              text = p.read_text()
+              for label, pattern, replacement, flags in transforms:
+                  text, count = re.subn(pattern, replacement, text, count=1, flags=flags)
+                  if count != 1:
+                      raise SystemExit(f"{path}: {label}: {count}")
+                  print(f"patched {label}")
+              p.write_text(text)
+
+          patch('v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt', [
+              ('import', r'import android\.os\.Process\n', 'import android.os.Process\nimport io.github.xgl34222220.baize.CleanupPolicy\n', 0),
+              ('save block', r'''        val previous = configJsonObject\(\)\n        val updates = LinkedHashMap<String, String>\(\)\n        val keys = input\.keys\(\)\n        while \(keys\.hasNext\(\)\) \{.*?\n        \}\n        if \(updates\.isEmpty\(\)\) return error\("empty_config", "没有可保存的计划配置"\)''', '''        val previous = configJsonObject()
+        val updates = LinkedHashMap<String, String>()
+        val requestedPolicy = if (input.has("cleanup_policy")) {
+            val value = input.optInt("cleanup_policy", Int.MIN_VALUE)
+            if (value !in ALLOWED_CONFIG.getValue("cleanup_policy")) {
+                return error("invalid_value", "配置值超出范围", "cleanup_policy")
+            }
+            CleanupPolicy.fromId(value)
+        } else null
+        requestedPolicy?.let { policy ->
+            updates["cleanup_policy"] = policy.id.toString()
+            policy.values.forEach { (key, value) ->
+                if (key in ALLOWED_CONFIG && !key.startsWith("schedule_")) updates[key] = value.toString()
+            }
+        }
+        val keys = input.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            val range = ALLOWED_CONFIG[key] ?: continue
+            val value = input.optInt(key, Int.MIN_VALUE)
+            if (value == Int.MIN_VALUE || value !in range) {
+                return error("invalid_value", "配置值超出范围", key)
+            }
+            updates[key] = value.toString()
+        }
+        if (updates.isEmpty()) return error("empty_config", "没有可保存的计划配置")''', re.S),
+              ('response', r'(\.put\("config", configJsonObject\(\)\.put\("runtime", runtimeJsonObject\(\)\)\)\n)', r'\1            .put("policyApplied", requestedPolicy != null)\n', 0),
+              ('config function', r'''    private fun configJsonObject\(\): JSONObject \{.*?\n    \}\n\n    private fun ensureConfig''', '''    private fun configJsonObject(): JSONObject {
+        ensureConfig()
+        val result = JSONObject()
+        File(RootPaths.CONFIG_FILE).takeIf { it.isFile }?.forEachLine { raw ->
+            val line = raw.trim()
+            if (line.isBlank() || line.startsWith("#") || !line.contains('=')) return@forEachLine
+            val key = line.substringBefore('=').trim()
+            val value = line.substringAfter('=').trim()
+            if (key in ALLOWED_CONFIG) result.put(key, value.toIntOrNull() ?: value)
+        }
+        val policy = CleanupPolicy.fromId(result.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+        val customized = policy.values.any { (key, expected) -> result.optInt(key, expected) != expected }
+        return result
+            .put("cleanup_policy", policy.id)
+            .put("cleanup_policy_name", policy.key)
+            .put("cleanup_policy_customized", customized)
+    }
+
+    private fun ensureConfig''', re.S),
+              ('allowed', r'            "enabled" to 0\.\.1,\n', '            "enabled" to 0..1,\n            "cleanup_policy" to 0..2,\n', 0),
+          ])
+
+          patch('v2/app/src/main/java/io/github/xgl34222220/baize/root/QuarantineRepository.kt', [
+              ('constructor', r'''internal class QuarantineRepository\(\n    private val stateDir: File = File\(RootPaths\.STATE_DIR\)\n\)''', '''internal class QuarantineRepository(
+    private val stateDir: File = File(RootPaths.STATE_DIR),
+    private val configFile: File = File(RootPaths.CONFIG_FILE)
+)''', 0),
+              ('local retention', r'(        val now = System\.currentTimeMillis\(\)\n)', r'\1        val retentionDays = retentionDays()\n', 0),
+              ('expiry', r'expiresAt = now \+ RETENTION_MS,', 'expiresAt = now + retentionDays * DAY_MS,', 0),
+              ('message', r'"已安全隔离，可在 7 天内恢复"', '"已安全隔离，可在 $retentionDays 天内恢复"', 0),
+              ('page retention', r'\.put\("retentionDays", RETENTION_DAYS\)', '.put("retentionDays", retentionDays())', 0),
+              ('reader', r'    private fun quarantineRootFor\(path: String\): File \{', '''    private fun retentionDays(): Int = RootFileStore.readEnv(configFile)
+        .optInt("quarantine_retention_days", DEFAULT_RETENTION_DAYS)
+        .coerceIn(1, 30)
+
+    private fun quarantineRootFor(path: String): File {''', 0),
+              ('constants', r'''        private const val RETENTION_DAYS = 7\n        private const val RETENTION_MS = RETENTION_DAYS \* 24L \* 60L \* 60L \* 1_000L''', '''        private const val DEFAULT_RETENTION_DAYS = 7
+        private const val DAY_MS = 24L * 60L * 60L * 1_000L''', 0),
+          ])
+
+          patch('v2/app/src/main/java/io/github/xgl34222220/baize/root/NativeProfileEngine.kt', [
+              ('option fields', r'''        val fragmentDays: Int,\n        val allowHighRisk: Boolean\n''', '''        val fragmentDays: Int,
+        val allowHighRisk: Boolean,
+        val maxAutoRisk: String,
+        val highRiskMode: String
+''', 0),
+              ('scan output', r'(            \.put\("ruleTargets", list\.count \{ it\.profile == "rules" \}\)\n)', r'\1            .put("maxAutoRisk", options.maxAutoRisk)\n            .put("highRiskMode", options.highRiskMode)\n', 0),
+              ('auto risk', r'explicit \|\| \(selectAllSafe && \(candidate\.risk == "low" \|\| candidate\.risk == "medium"\)\)', 'explicit || (selectAllSafe && (candidate.risk == "low" || (candidate.risk == "medium" && snapshot.options.maxAutoRisk == "medium")))', 0),
+              ('quarantine guard', r'(    val selection = parseSelection\(selectionJson\)\n    val selected = snapshot\.candidates\.filter \{ candidate ->)', '''    if (snapshot.options.highRiskMode == "audit") {
+        return JSONObject().put("error", "policy_audit_only").put("message", "当前保守策略仅审计高风险项目，请切换策略并重新扫描").toString()
+    }
+\1''', 0),
+              ('parse options', r'''            json\.optInt\("fragmentDays", 7\)\.coerceIn\(0, 365\),\n            json\.optBoolean\("allowHighRisk", false\)\n''', '''            json.optInt("fragmentDays", 7).coerceIn(0, 365),
+            json.optBoolean("allowHighRisk", false),
+            json.optString("maxAutoRisk", "medium").lowercase().let { if (it == "low") "low" else "medium" },
+            json.optString("highRiskMode", "manual_quarantine").lowercase().let {
+                if (it in setOf("audit", "manual_quarantine", "recommended_quarantine")) it else "manual_quarantine"
+            }
+''', 0),
+          ])
+
+          patch('v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchActivity.kt', [
+              ('policy member', r'(    private var snapshotExpiresAtRealtime = 0L\n)', r'\1    private var cleanupPolicy = CleanupPolicy.BALANCED\n', 0),
+              ('scan config', r'''                    val packageWhitelist = profile\.getWhitelistPackages\(\)\n                    val options = optionsJson\(profile\)''', '''                    val packageWhitelist = profile.getWhitelistPackages()
+                    val config = JSONObject(profile.getSchedulerConfig())
+                    cleanupPolicy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+                    val options = optionsJson(profile, config)''', 0),
+              ('default selection', r'''            val selected = items\.asSequence\(\)\.filter \{ it\.selectable \}\.mapTo\(linkedSetOf\(\)\) \{ it\.id \}''', '''            val selected = items.asSequence()
+                .filter { it.selectable && cleanupPolicy.defaultSelected(it.risk) }
+                .mapTo(linkedSetOf()) { it.id }''', 0),
+              ('state policy', r'''                expiresAtRealtime = snapshotExpiresAtRealtime,\n                resultText = if \(items\.isEmpty\(\)\) "当前设备很干净" else "默认勾选全部低风险与中风险项目"''', '''                expiresAtRealtime = snapshotExpiresAtRealtime,
+                policyTitle = cleanupPolicy.title,
+                policyKey = cleanupPolicy.key,
+                highRiskMode = cleanupPolicy.highRiskMode,
+                resultText = if (items.isEmpty()) "当前设备很干净" else if (cleanupPolicy == CleanupPolicy.CONSERVATIVE) {
+                    "保守档默认只勾选低风险项目；中风险仍可手动选择"
+                } else {
+                    "${cleanupPolicy.title}档默认勾选低风险与中风险项目"
+                }''', 0),
+              ('reason', r'reason = note\.ifBlank \{ riskReason\(risk, label\) \},', 'reason = note.ifBlank { riskReason(risk, label, cleanupPolicy) },', 0),
+              ('quarantine guard', r'if \(screenState\.running \|\| item\.source != "profile" \|\| item\.risk != "high"\) return', 'if (screenState.running || item.source != "profile" || item.risk != "high" || !cleanupPolicy.canQuarantineHighRisk) return', 0),
+              ('options function', r'''    private fun optionsJson\(service: IProfileRootService\): String \{.*?\n    \}\n\n    private fun applicationLabel''', '''    private fun optionsJson(service: IProfileRootService, suppliedConfig: JSONObject? = null): String {
+        val config = suppliedConfig ?: runCatching { JSONObject(service.getSchedulerConfig()) }.getOrDefault(JSONObject())
+        val policy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+        val paths = runCatching { JSONArray(service.getWhitelistPaths()) }.getOrDefault(JSONArray())
+        val packages = runCatching { JSONArray(service.getWhitelistPackages()) }.getOrDefault(JSONArray())
+        val maxMb = config.optInt("max_file_mb", 256).coerceIn(16, 16_384)
+        return JSONObject()
+            .put("whitelistPackages", packages)
+            .put("whitelistPaths", paths)
+            .put("maxFileBytes", maxMb * 1_024L * 1_024L)
+            .put("fragmentDays", config.optInt("fragment_days", 7).coerceIn(0, 365))
+            .put("allowHighRisk", false)
+            .put("maxAutoRisk", policy.autoRisk)
+            .put("highRiskMode", policy.highRiskMode)
+            .put("cleanupPolicy", policy.key)
+            .toString()
+    }
+
+    private fun applicationLabel''', re.S),
+              ('state fields', r'    val resultText: String = ""\n', '''    val resultText: String = "",
+    val policyTitle: String = CleanupPolicy.BALANCED.title,
+    val policyKey: String = CleanupPolicy.BALANCED.key,
+    val highRiskMode: String = CleanupPolicy.BALANCED.highRiskMode
+''', 0),
+              ('candidate arg', r'(                            selected = row\.item\.id in state\.selectedIds,\n                            horizontal = horizontal,\n)', r'\1                            highRiskMode = state.highRiskMode,\n', 0),
+              ('policy pill', r'(                SummaryPill\("受保护 \$\{state\.items\.count \{ !it\.selectable \}\}"\)\n)', r'\1                SummaryPill("${state.policyTitle}档")\n', 0),
+              ('candidate signature', r'(    horizontal: androidx\.compose\.ui\.unit\.Dp,\n)', r'\1    highRiskMode: String,\n', 0),
+              ('high action', r'''        if \(item\.risk == "high"\) \{\n            IconButton\(onClick = onQuarantine, modifier = Modifier\.size\(38\.dp\)\) \{\n                Icon\(Icons\.Rounded\.Inventory2, contentDescription = "移入隔离区", modifier = Modifier\.size\(19\.dp\), tint = MaterialTheme\.colorScheme\.error\)\n            \}\n        \} else \{''', '''        if (item.risk == "high" && highRiskMode != "audit") {
+            IconButton(onClick = onQuarantine, modifier = Modifier.size(38.dp)) {
+                Icon(
+                    Icons.Rounded.Inventory2,
+                    contentDescription = if (highRiskMode == "recommended_quarantine") "建议移入隔离区" else "移入隔离区",
+                    modifier = Modifier.size(19.dp),
+                    tint = if (highRiskMode == "recommended_quarantine") BaiZeTokens.colors.warning else MaterialTheme.colorScheme.error
+                )
+            }
+        } else if (item.risk != "high" && item.risk != "critical") {''', 0),
+              ('risk function', r'''private fun riskReason\(risk: String, label: String\): String = when \(risk\) \{.*?\n\}''', '''private fun riskReason(risk: String, label: String, policy: CleanupPolicy): String = when (risk) {
+    "low" -> "$label · 可安全自动处理"
+    "medium" -> "$label · 清理前再次校验白名单与大小限制"
+    "high" -> when (policy.highRiskMode) {
+        "audit" -> "$label · 保守档仅审计，切换策略并重新扫描后才可隔离"
+        "recommended_quarantine" -> "$label · 积极档建议逐项移入隔离区，仍不会直接删除"
+        else -> "$label · 不会直接删除，可单独移入隔离区"
+    }
+    else -> "$label · 关键风险项目，只展示不自动清理"
+}''', re.S),
+          ])
+
+          patch('v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt', [
+              ('options function', r'''    private fun optionsJson\(\): String \{.*?\n    \}\n\n    private fun parseAppDetails''', '''    private fun optionsJson(): String {
+        val paths = preferences.getStringSet("path_whitelist", emptySet()).orEmpty()
+        val config = runCatching { JSONObject(rootService?.getSchedulerConfig().orEmpty()) }.getOrDefault(JSONObject())
+        val policy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+        val maxMb = config.optInt("max_file_mb", schedulerState.value.maxFileMb).coerceIn(16, 16_384)
+        return JSONObject()
+            .put("whitelistPackages", JSONArray(packageWhitelist().toList()))
+            .put("whitelistPaths", JSONArray(paths.toList()))
+            .put("maxFileBytes", maxMb * 1024L * 1024L)
+            .put("fragmentDays", config.optInt("fragment_days", 7).coerceIn(0, 365))
+            .put("allowHighRisk", false)
+            .put("maxAutoRisk", policy.autoRisk)
+            .put("highRiskMode", policy.highRiskMode)
+            .put("cleanupPolicy", policy.key)
+            .toString()
+    }
+
+    private fun parseAppDetails''', re.S),
+          ])
+
+          patch('v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt', [
+              ('import', r'import androidx\.compose\.material\.icons\.rounded\.Storage\n', 'import androidx.compose.material.icons.rounded.Storage\nimport androidx.compose.material.icons.rounded.Tune\n', 0),
+              ('action value', r'(                            onOpenCache = \{ startActivity\(Intent\(this, CacheActivity::class\.java\)\) \},\n)', r'\1                            onOpenPolicy = { startActivity(Intent(this, CleanupPolicyActivity::class.java)) },\n', 0),
+              ('action field', r'(    val onOpenCache: \(\) -> Unit,\n)', r'\1    val onOpenPolicy: () -> Unit,\n', 0),
+          ])
+          p = Path('v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt')
+          text = p.read_text()
+          needle = '    val advanced = listOf(\n        CleanCenterItem(Icons.Rounded.Inventory2, "隔离区"'
+          replacement = '    val advanced = listOf(\n        CleanCenterItem(Icons.Rounded.Tune, "清理策略", "切换保守、均衡或积极档，不影响定时周期", "三档", directAction = actions.onOpenPolicy),\n        CleanCenterItem(Icons.Rounded.Inventory2, "隔离区"'
+          if text.count(needle) != 2:
+              raise SystemExit(f'clean center lists: {text.count(needle)}')
+          p.write_text(text.replace(needle, replacement))
+
+          patch('v2/app/src/main/AndroidManifest.xml', [
+              ('activity', r'(        <activity android:name="\.CleanCenterActivity" android:exported="false" />\n)', r'\1        <activity android:name=".CleanupPolicyActivity" android:exported="false" />\n', 0),
+          ])
+          PY
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/root/QuarantineRepository.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/root/NativeProfileEngine.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchActivity.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt \
+                  v2/app/src/main/AndroidManifest.xml
+          git commit -m "feat: connect guarded cleanup policies"
+          git push origin HEAD:agent/cleanup-policy-profiles

--- a/.github/workflows/agent-cleanup-policy-patch.yml
+++ b/.github/workflows/agent-cleanup-policy-patch.yml
@@ -1,0 +1,440 @@
+name: Agent Cleanup Policy Patch
+
+on:
+  pull_request:
+    branches: [main]
+    types: [reopened]
+
+permissions:
+  contents: write
+
+jobs:
+  patch:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: agent/cleanup-policy-profiles
+          fetch-depth: 0
+      - name: Connect cleanup policy to engines and UI
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 <<'PY'
+          from pathlib import Path
+
+          def read(path):
+              return Path(path).read_text()
+
+          def write(path, text):
+              Path(path).write_text(text)
+
+          def once(text, old, new, label):
+              count = text.count(old)
+              if count != 1:
+                  raise SystemExit(f"{label}: expected one match, found {count}")
+              return text.replace(old, new, 1)
+
+          # SchedulerRepository: applying a policy expands only cleanup-related fields.
+          path = 'v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt'
+          text = read(path)
+          text = once(text, 'import android.os.Process\n', 'import android.os.Process\nimport io.github.xgl34222220.baize.CleanupPolicy\n', 'scheduler import')
+          text = once(text,
+          '''        val previous = configJsonObject()
+                  val updates = LinkedHashMap<String, String>()
+                  val keys = input.keys()
+                  while (keys.hasNext()) {
+                      val key = keys.next()
+                      val range = ALLOWED_CONFIG[key] ?: continue
+                      val value = input.optInt(key, Int.MIN_VALUE)
+                      if (value == Int.MIN_VALUE || value !in range) {
+                          return error("invalid_value", "配置值超出范围", key)
+                      }
+                      updates[key] = value.toString()
+                  }
+          ''',
+          '''        val previous = configJsonObject()
+                  val updates = LinkedHashMap<String, String>()
+                  val requestedPolicy = if (input.has("cleanup_policy")) {
+                      val value = input.optInt("cleanup_policy", Int.MIN_VALUE)
+                      if (value !in ALLOWED_CONFIG.getValue("cleanup_policy")) {
+                          return error("invalid_value", "配置值超出范围", "cleanup_policy")
+                      }
+                      CleanupPolicy.fromId(value)
+                  } else null
+                  requestedPolicy?.let { policy ->
+                      updates["cleanup_policy"] = policy.id.toString()
+                      policy.values.forEach { (key, value) ->
+                          if (key in ALLOWED_CONFIG && !key.startsWith("schedule_")) updates[key] = value.toString()
+                      }
+                  }
+                  val keys = input.keys()
+                  while (keys.hasNext()) {
+                      val key = keys.next()
+                      val range = ALLOWED_CONFIG[key] ?: continue
+                      val value = input.optInt(key, Int.MIN_VALUE)
+                      if (value == Int.MIN_VALUE || value !in range) {
+                          return error("invalid_value", "配置值超出范围", key)
+                      }
+                      updates[key] = value.toString()
+                  }
+          ''', 'scheduler policy expansion')
+          text = once(text,
+          '''            .put("config", configJsonObject().put("runtime", runtimeJsonObject()))
+                      .put("queued", queued)
+          ''',
+          '''            .put("config", configJsonObject().put("runtime", runtimeJsonObject()))
+                      .put("policyApplied", requestedPolicy != null)
+                      .put("queued", queued)
+          ''', 'scheduler response')
+          text = once(text,
+          '''        return result
+              }
+
+              private fun ensureConfig() {
+          ''',
+          '''        val policy = CleanupPolicy.fromId(result.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+                  val customized = policy.values.any { (key, expected) -> result.optInt(key, expected) != expected }
+                  return result
+                      .put("cleanup_policy", policy.id)
+                      .put("cleanup_policy_name", policy.key)
+                      .put("cleanup_policy_customized", customized)
+              }
+
+              private fun ensureConfig() {
+          ''', 'scheduler policy metadata')
+          text = once(text,
+          '''            "enabled" to 0..1,
+          ''',
+          '''            "enabled" to 0..1,
+                      "cleanup_policy" to 0..2,
+          ''', 'scheduler allowed policy')
+          write(path, text)
+
+          # Quarantine retention follows the selected preset for newly quarantined items.
+          path = 'v2/app/src/main/java/io/github/xgl34222220/baize/root/QuarantineRepository.kt'
+          text = read(path)
+          text = once(text,
+          '''internal class QuarantineRepository(
+              private val stateDir: File = File(RootPaths.STATE_DIR)
+          ) {
+          ''',
+          '''internal class QuarantineRepository(
+              private val stateDir: File = File(RootPaths.STATE_DIR),
+              private val configFile: File = File(RootPaths.CONFIG_FILE)
+          ) {
+          ''', 'quarantine constructor')
+          text = once(text,
+          '''        val now = System.currentTimeMillis()
+          val entry = Entry(
+          ''',
+          '''        val now = System.currentTimeMillis()
+          val retentionDays = retentionDays()
+          val entry = Entry(
+          ''', 'quarantine retention local')
+          text = once(text, '    expiresAt = now + RETENTION_MS,\n', '    expiresAt = now + retentionDays * DAY_MS,\n', 'quarantine expiry')
+          text = once(text,
+          '''return Result(true, id, stats.bytes, stats.files, stats.directories, "已安全隔离，可在 7 天内恢复")
+          ''',
+          '''return Result(true, id, stats.bytes, stats.files, stats.directories, "已安全隔离，可在 $retentionDays 天内恢复")
+          ''', 'quarantine message')
+          text = once(text, '.put("retentionDays", RETENTION_DAYS)\n', '.put("retentionDays", retentionDays())\n', 'quarantine page retention')
+          text = once(text,
+          '''    private fun quarantineRootFor(path: String): File {
+          ''',
+          '''    private fun retentionDays(): Int = RootFileStore.readEnv(configFile)
+                  .optInt("quarantine_retention_days", DEFAULT_RETENTION_DAYS)
+                  .coerceIn(1, 30)
+
+              private fun quarantineRootFor(path: String): File {
+          ''', 'quarantine retention reader')
+          text = once(text,
+          '''        private const val RETENTION_DAYS = 7
+                  private const val RETENTION_MS = RETENTION_DAYS * 24L * 60L * 60L * 1_000L
+          ''',
+          '''        private const val DEFAULT_RETENTION_DAYS = 7
+                  private const val DAY_MS = 24L * 60L * 60L * 1_000L
+          ''', 'quarantine constants')
+          write(path, text)
+
+          # NativeProfileEngine binds policy risk limits to the immutable scan snapshot.
+          path = 'v2/app/src/main/java/io/github/xgl34222220/baize/root/NativeProfileEngine.kt'
+          text = read(path)
+          text = once(text,
+          '''        val fragmentDays: Int,
+                  val allowHighRisk: Boolean
+          ''',
+          '''        val fragmentDays: Int,
+                  val allowHighRisk: Boolean,
+                  val maxAutoRisk: String,
+                  val highRiskMode: String
+          ''', 'engine options fields')
+          text = once(text,
+          '''            .put("fragmentFiles", list.count { it.category == "fragment" })
+                      .put("ruleTargets", list.count { it.profile == "rules" })
+          ''',
+          '''            .put("fragmentFiles", list.count { it.category == "fragment" })
+                      .put("ruleTargets", list.count { it.profile == "rules" })
+                      .put("maxAutoRisk", options.maxAutoRisk)
+                      .put("highRiskMode", options.highRiskMode)
+          ''', 'engine scan policy output')
+          text = once(text,
+          '''            explicit || (selectAllSafe && (candidate.risk == "low" || candidate.risk == "medium"))
+          ''',
+          '''            explicit || (selectAllSafe && (
+                          candidate.risk == "low" || (candidate.risk == "medium" && snapshot.options.maxAutoRisk == "medium")
+                      ))
+          ''', 'engine auto risk selection')
+          text = once(text,
+          '''    val selection = parseSelection(selectionJson)
+              val selected = snapshot.candidates.filter { candidate ->
+          ''',
+          '''    if (snapshot.options.highRiskMode == "audit") {
+                  return JSONObject().put("error", "policy_audit_only").put("message", "当前保守策略仅审计高风险项目，请切换策略并重新扫描").toString()
+              }
+              val selection = parseSelection(selectionJson)
+              val selected = snapshot.candidates.filter { candidate ->
+          ''', 'engine quarantine policy guard')
+          text = once(text,
+          '''            json.optInt("fragmentDays", 7).coerceIn(0, 365),
+                      json.optBoolean("allowHighRisk", false)
+          ''',
+          '''            json.optInt("fragmentDays", 7).coerceIn(0, 365),
+                      json.optBoolean("allowHighRisk", false),
+                      json.optString("maxAutoRisk", "medium").lowercase().let { if (it == "low") "low" else "medium" },
+                      json.optString("highRiskMode", "manual_quarantine").lowercase().let {
+                          if (it in setOf("audit", "manual_quarantine", "recommended_quarantine")) it else "manual_quarantine"
+                      }
+          ''', 'engine parse policy options')
+          write(path, text)
+
+          # Workbench reads the policy before scanning and uses it only for defaults and quarantine availability.
+          path = 'v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchActivity.kt'
+          text = read(path)
+          text = once(text,
+          '''    private var snapshotExpiresAtRealtime = 0L
+              private var pollJob: Job? = null
+          ''',
+          '''    private var snapshotExpiresAtRealtime = 0L
+              private var cleanupPolicy = CleanupPolicy.BALANCED
+              private var pollJob: Job? = null
+          ''', 'workbench policy member')
+          text = once(text,
+          '''                    val packageWhitelist = profile.getWhitelistPackages()
+                          val options = optionsJson(profile)
+          ''',
+          '''                    val packageWhitelist = profile.getWhitelistPackages()
+                          val config = JSONObject(profile.getSchedulerConfig())
+                          cleanupPolicy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+                          val options = optionsJson(profile, config)
+          ''', 'workbench scan policy read')
+          text = once(text,
+          '''            val selected = items.asSequence().filter { it.selectable }.mapTo(linkedSetOf()) { it.id }
+          ''',
+          '''            val selected = items.asSequence()
+                      .filter { it.selectable && cleanupPolicy.defaultSelected(it.risk) }
+                      .mapTo(linkedSetOf()) { it.id }
+          ''', 'workbench default selection')
+          text = once(text,
+          '''                expiresAtRealtime = snapshotExpiresAtRealtime,
+                          resultText = if (items.isEmpty()) "当前设备很干净" else "默认勾选全部低风险与中风险项目"
+          ''',
+          '''                expiresAtRealtime = snapshotExpiresAtRealtime,
+                          policyTitle = cleanupPolicy.title,
+                          policyKey = cleanupPolicy.key,
+                          highRiskMode = cleanupPolicy.highRiskMode,
+                          resultText = if (items.isEmpty()) {
+                              "当前设备很干净"
+                          } else if (cleanupPolicy == CleanupPolicy.CONSERVATIVE) {
+                              "保守档默认只勾选低风险项目；中风险仍可手动选择"
+                          } else {
+                              "${cleanupPolicy.title}档默认勾选低风险与中风险项目"
+                          }
+          ''', 'workbench policy state')
+          text = once(text,
+          '''                    reason = note.ifBlank { riskReason(risk, label) },
+          ''',
+          '''                    reason = note.ifBlank { riskReason(risk, label, cleanupPolicy) },
+          ''', 'workbench policy reason')
+          text = once(text,
+          '''    if (screenState.running || item.source != "profile" || item.risk != "high") return
+          ''',
+          '''    if (screenState.running || item.source != "profile" || item.risk != "high" || !cleanupPolicy.canQuarantineHighRisk) return
+          ''', 'workbench quarantine guard')
+          text = once(text,
+          '''    private fun optionsJson(service: IProfileRootService): String {
+                  val config = runCatching { JSONObject(service.getSchedulerConfig()) }.getOrDefault(JSONObject())
+          ''',
+          '''    private fun optionsJson(service: IProfileRootService, suppliedConfig: JSONObject? = null): String {
+                  val config = suppliedConfig ?: runCatching { JSONObject(service.getSchedulerConfig()) }.getOrDefault(JSONObject())
+                  val policy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+          ''', 'workbench options signature')
+          text = once(text,
+          '''            .put("fragmentDays", config.optInt("fragment_days", 7).coerceIn(0, 365))
+                      .put("allowHighRisk", false)
+          ''',
+          '''            .put("fragmentDays", config.optInt("fragment_days", 7).coerceIn(0, 365))
+                      .put("allowHighRisk", false)
+                      .put("maxAutoRisk", policy.autoRisk)
+                      .put("highRiskMode", policy.highRiskMode)
+                      .put("cleanupPolicy", policy.key)
+          ''', 'workbench options policy')
+          text = once(text,
+          '''    val resultText: String = ""
+          ''',
+          '''    val resultText: String = "",
+              val policyTitle: String = CleanupPolicy.BALANCED.title,
+              val policyKey: String = CleanupPolicy.BALANCED.key,
+              val highRiskMode: String = CleanupPolicy.BALANCED.highRiskMode
+          ''', 'workbench state fields')
+          text = once(text,
+          '''                            selected = row.item.id in state.selectedIds,
+                              horizontal = horizontal,
+          ''',
+          '''                            selected = row.item.id in state.selectedIds,
+                              horizontal = horizontal,
+                              highRiskMode = state.highRiskMode,
+          ''', 'workbench candidate policy arg')
+          text = once(text,
+          '''                SummaryPill("受保护 ${state.items.count { !it.selectable }}")
+          ''',
+          '''                SummaryPill("受保护 ${state.items.count { !it.selectable }}")
+                      SummaryPill("${state.policyTitle}档")
+          ''', 'workbench policy pill')
+          text = once(text,
+          '''    horizontal: androidx.compose.ui.unit.Dp,
+              onToggle: () -> Unit,
+          ''',
+          '''    horizontal: androidx.compose.ui.unit.Dp,
+              highRiskMode: String,
+              onToggle: () -> Unit,
+          ''', 'workbench candidate signature')
+          text = once(text,
+          '''        if (item.risk == "high") {
+                  IconButton(onClick = onQuarantine, modifier = Modifier.size(38.dp)) {
+                      Icon(Icons.Rounded.Inventory2, contentDescription = "移入隔离区", modifier = Modifier.size(19.dp), tint = MaterialTheme.colorScheme.error)
+                  }
+              } else {
+          ''',
+          '''        if (item.risk == "high" && highRiskMode != "audit") {
+                  IconButton(onClick = onQuarantine, modifier = Modifier.size(38.dp)) {
+                      Icon(
+                          Icons.Rounded.Inventory2,
+                          contentDescription = if (highRiskMode == "recommended_quarantine") "建议移入隔离区" else "移入隔离区",
+                          modifier = Modifier.size(19.dp),
+                          tint = if (highRiskMode == "recommended_quarantine") BaiZeTokens.colors.warning else MaterialTheme.colorScheme.error
+                      )
+                  }
+              } else if (item.risk != "high" && item.risk != "critical") {
+          ''', 'workbench high risk action')
+          text = once(text,
+          '''private fun riskReason(risk: String, label: String): String = when (risk) {
+              "low" -> "$label · 可安全自动处理"
+              "medium" -> "$label · 清理前再次校验白名单与大小限制"
+              "high" -> "$label · 不会直接删除，可单独移入隔离区"
+              else -> "$label · 关键风险项目，只展示不自动清理"
+          }
+          ''',
+          '''private fun riskReason(risk: String, label: String, policy: CleanupPolicy): String = when (risk) {
+              "low" -> "$label · 可安全自动处理"
+              "medium" -> "$label · 清理前再次校验白名单与大小限制"
+              "high" -> when (policy.highRiskMode) {
+                  "audit" -> "$label · 保守档仅审计，切换策略并重新扫描后才可隔离"
+                  "recommended_quarantine" -> "$label · 积极档建议逐项移入隔离区，仍不会直接删除"
+                  else -> "$label · 不会直接删除，可单独移入隔离区"
+              }
+              else -> "$label · 关键风险项目，只展示不自动清理"
+          }
+          ''', 'workbench risk reason')
+          write(path, text)
+
+          # Existing native snapshot actions use the same policy captured by the profile snapshot.
+          path = 'v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt'
+          text = read(path)
+          text = once(text,
+          '''    private fun optionsJson(): String {
+                  val paths = preferences.getStringSet("path_whitelist", emptySet()).orEmpty()
+                  val maxMb = schedulerState.value.maxFileMb.coerceIn(16, 2048)
+                  return JSONObject()
+                      .put("whitelistPackages", JSONArray(packageWhitelist().toList()))
+                      .put("whitelistPaths", JSONArray(paths.toList()))
+                      .put("maxFileBytes", maxMb * 1024L * 1024L)
+                      .put("fragmentDays", preferences.getInt("fragment_days", 7).coerceIn(0, 365))
+                      .put("allowHighRisk", false)
+                      .toString()
+              }
+          ''',
+          '''    private fun optionsJson(): String {
+                  val paths = preferences.getStringSet("path_whitelist", emptySet()).orEmpty()
+                  val config = runCatching { JSONObject(rootService?.getSchedulerConfig().orEmpty()) }.getOrDefault(JSONObject())
+                  val policy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+                  val maxMb = config.optInt("max_file_mb", schedulerState.value.maxFileMb).coerceIn(16, 16_384)
+                  return JSONObject()
+                      .put("whitelistPackages", JSONArray(packageWhitelist().toList()))
+                      .put("whitelistPaths", JSONArray(paths.toList()))
+                      .put("maxFileBytes", maxMb * 1024L * 1024L)
+                      .put("fragmentDays", config.optInt("fragment_days", 7).coerceIn(0, 365))
+                      .put("allowHighRisk", false)
+                      .put("maxAutoRisk", policy.autoRisk)
+                      .put("highRiskMode", policy.highRiskMode)
+                      .put("cleanupPolicy", policy.key)
+                      .toString()
+              }
+          ''', 'dashboard options policy')
+          write(path, text)
+
+          # Add policy entry to Clean Center and register the Activity.
+          path = 'v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt'
+          text = read(path)
+          text = once(text, 'import androidx.compose.material.icons.rounded.Storage\n', 'import androidx.compose.material.icons.rounded.Storage\nimport androidx.compose.material.icons.rounded.Tune\n', 'clean center tune import')
+          text = once(text,
+          '''                            onOpenCache = { startActivity(Intent(this, CacheActivity::class.java)) },
+                              onOpenQuarantine = { startActivity(Intent(this, QuarantineActivity::class.java)) },
+          ''',
+          '''                            onOpenCache = { startActivity(Intent(this, CacheActivity::class.java)) },
+                              onOpenPolicy = { startActivity(Intent(this, CleanupPolicyActivity::class.java)) },
+                              onOpenQuarantine = { startActivity(Intent(this, QuarantineActivity::class.java)) },
+          ''', 'clean center policy action')
+          text = once(text,
+          '''    val onOpenCache: () -> Unit,
+              val onOpenQuarantine: () -> Unit,
+          ''',
+          '''    val onOpenCache: () -> Unit,
+              val onOpenPolicy: () -> Unit,
+              val onOpenQuarantine: () -> Unit,
+          ''', 'clean center action field')
+          needle = '''    val advanced = listOf(
+                  CleanCenterItem(Icons.Rounded.Inventory2, "隔离区"'''
+          replacement = '''    val advanced = listOf(
+                  CleanCenterItem(Icons.Rounded.Tune, "清理策略", "切换保守、均衡或积极档，不影响定时周期", "三档", directAction = actions.onOpenPolicy),
+                  CleanCenterItem(Icons.Rounded.Inventory2, "隔离区"'''
+          count = text.count(needle)
+          if count != 2:
+              raise SystemExit(f'clean center lists: expected 2 matches, found {count}')
+          text = text.replace(needle, replacement)
+          write(path, text)
+
+          path = 'v2/app/src/main/AndroidManifest.xml'
+          text = read(path)
+          text = once(text,
+          '''        <activity android:name=".CleanCenterActivity" android:exported="false" />
+                  <activity android:name=".QuarantineActivity" android:exported="false" />
+          ''',
+          '''        <activity android:name=".CleanCenterActivity" android:exported="false" />
+                  <activity android:name=".CleanupPolicyActivity" android:exported="false" />
+                  <activity android:name=".QuarantineActivity" android:exported="false" />
+          ''', 'manifest policy activity')
+          write(path, text)
+          PY
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add v2/app/src/main/java/io/github/xgl34222220/baize/root/SchedulerRepository.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/root/QuarantineRepository.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/root/NativeProfileEngine.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchActivity.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt \
+                  v2/app/src/main/java/io/github/xgl34222220/baize/CleanCenterActivity.kt \
+                  v2/app/src/main/AndroidManifest.xml
+          git commit -m "feat: connect guarded cleanup policies" || exit 0
+          git push origin HEAD:agent/cleanup-policy-profiles

--- a/config/default.conf
+++ b/config/default.conf
@@ -46,6 +46,8 @@ daily_schedule_hour=3
 daily_schedule_minute=30
 daily_grace_minutes=240
 
+# 清理策略：0=保守，1=均衡，2=积极。档位不修改任何 schedule_* 周期字段。
+cleanup_policy=1
 clean_app_cache=1
 clean_external_cache=1
 clean_system_logs=1

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanupPolicy.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanupPolicy.kt
@@ -1,0 +1,162 @@
+package io.github.xgl34222220.baize
+
+/**
+ * User-facing cleanup policy presets.
+ *
+ * Presets never contain scheduler cadence fields and never enable direct high-risk deletion. They
+ * only tune ordinary cleanup categories, retention thresholds, the per-file ceiling, default
+ * workbench selection and whether a high-risk snapshot candidate may be manually quarantined.
+ */
+enum class CleanupPolicy(
+    val id: Int,
+    val key: String,
+    val title: String,
+    val subtitle: String,
+    val badge: String,
+    val autoRisk: String,
+    val highRiskMode: String,
+    val values: Map<String, Int>,
+    val highlights: List<String>
+) {
+    CONSERVATIVE(
+        id = 0,
+        key = "conservative",
+        title = "保守",
+        subtitle = "优先避免误清理，适合重要数据较多的设备",
+        badge = "最低干预",
+        autoRisk = "low",
+        highRiskMode = "audit",
+        values = linkedMapOf(
+            "clean_app_cache" to 1,
+            "clean_external_cache" to 1,
+            "clean_system_logs" to 1,
+            "clean_oem_logs" to 0,
+            "clean_empty_files" to 1,
+            "clean_empty_dirs" to 1,
+            "clean_root_shells" to 1,
+            "clean_app_rules" to 1,
+            "clean_hidden_junk" to 0,
+            "clean_fragments" to 1,
+            "clean_custom_rules" to 0,
+            "clean_installer_temp" to 1,
+            "clean_apk_packages" to 1,
+            "deep_high_risk_enabled" to 0,
+            "app_cache_days" to 3,
+            "external_cache_days" to 3,
+            "system_logs_days" to 14,
+            "oem_logs_days" to 14,
+            "empty_file_days" to 3,
+            "hidden_junk_days" to 7,
+            "fragment_days" to 14,
+            "installer_temp_days" to 14,
+            "apk_package_days" to 45,
+            "root_shell_days" to 30,
+            "max_file_mb" to 128,
+            "quarantine_retention_days" to 14
+        ),
+        highlights = listOf(
+            "扫描后只默认勾选低风险项目",
+            "缓存至少保留 3 天，碎片保留 14 天",
+            "高风险候选只审计，不提供隔离操作",
+            "单文件保护上限 128 MB"
+        )
+    ),
+    BALANCED(
+        id = 1,
+        key = "balanced",
+        title = "均衡",
+        subtitle = "兼顾清理效果与安全性，推荐大多数设备使用",
+        badge = "推荐",
+        autoRisk = "medium",
+        highRiskMode = "manual_quarantine",
+        values = linkedMapOf(
+            "clean_app_cache" to 1,
+            "clean_external_cache" to 1,
+            "clean_system_logs" to 1,
+            "clean_oem_logs" to 0,
+            "clean_empty_files" to 1,
+            "clean_empty_dirs" to 1,
+            "clean_root_shells" to 1,
+            "clean_app_rules" to 1,
+            "clean_hidden_junk" to 1,
+            "clean_fragments" to 1,
+            "clean_custom_rules" to 0,
+            "clean_installer_temp" to 1,
+            "clean_apk_packages" to 1,
+            "deep_high_risk_enabled" to 0,
+            "app_cache_days" to 0,
+            "external_cache_days" to 0,
+            "system_logs_days" to 7,
+            "oem_logs_days" to 7,
+            "empty_file_days" to 0,
+            "hidden_junk_days" to 0,
+            "fragment_days" to 7,
+            "installer_temp_days" to 7,
+            "apk_package_days" to 30,
+            "root_shell_days" to 14,
+            "max_file_mb" to 256,
+            "quarantine_retention_days" to 7
+        ),
+        highlights = listOf(
+            "扫描后默认勾选低风险与中风险项目",
+            "日志与碎片保留 7 天",
+            "高风险候选可逐项手动移入隔离区",
+            "单文件保护上限 256 MB"
+        )
+    ),
+    AGGRESSIVE(
+        id = 2,
+        key = "aggressive",
+        title = "积极",
+        subtitle = "扩大普通垃圾覆盖范围，适合空间紧张的设备",
+        badge = "更强清理",
+        autoRisk = "medium",
+        highRiskMode = "recommended_quarantine",
+        values = linkedMapOf(
+            "clean_app_cache" to 1,
+            "clean_external_cache" to 1,
+            "clean_system_logs" to 1,
+            "clean_oem_logs" to 1,
+            "clean_empty_files" to 1,
+            "clean_empty_dirs" to 1,
+            "clean_root_shells" to 1,
+            "clean_app_rules" to 1,
+            "clean_hidden_junk" to 1,
+            "clean_fragments" to 1,
+            "clean_custom_rules" to 0,
+            "clean_installer_temp" to 1,
+            "clean_apk_packages" to 1,
+            "deep_high_risk_enabled" to 0,
+            "app_cache_days" to 0,
+            "external_cache_days" to 0,
+            "system_logs_days" to 3,
+            "oem_logs_days" to 3,
+            "empty_file_days" to 0,
+            "hidden_junk_days" to 0,
+            "fragment_days" to 1,
+            "installer_temp_days" to 3,
+            "apk_package_days" to 14,
+            "root_shell_days" to 7,
+            "max_file_mb" to 1024,
+            "quarantine_retention_days" to 3
+        ),
+        highlights = listOf(
+            "扫描后默认勾选低风险与中风险项目",
+            "启用 OEM 日志，碎片只保留 1 天",
+            "高风险仍不直接删除，仅突出建议手动隔离",
+            "单文件保护上限 1 GB"
+        )
+    );
+
+    fun defaultSelected(risk: String): Boolean = when (autoRisk) {
+        "low" -> risk == "low"
+        else -> risk == "low" || risk == "medium"
+    }
+
+    val canQuarantineHighRisk: Boolean get() = highRiskMode != "audit"
+
+    companion object {
+        fun fromId(id: Int): CleanupPolicy = entries.firstOrNull { it.id == id } ?: BALANCED
+        fun fromKey(key: String): CleanupPolicy = entries.firstOrNull { it.key == key } ?: BALANCED
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanupPolicyActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanupPolicyActivity.kt
@@ -1,0 +1,417 @@
+package io.github.xgl34222220.baize
+
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
+import android.graphics.Color
+import android.os.Bundle
+import android.os.IBinder
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.Tune
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.topjohnwu.superuser.ipc.RootService
+import io.github.xgl34222220.baize.root.BaiZeProfileRootService
+import io.github.xgl34222220.baize.root.IProfileRootService
+import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
+import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.appearance.ThemeMode
+import io.github.xgl34222220.baize.ui.appearance.UiStyle
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+class CleanupPolicyActivity : ComponentActivity() {
+    private val appearanceViewModel: AppearanceViewModel by viewModels()
+    private var service: IProfileRootService? = null
+    private var bound = false
+    private var state by mutableStateOf(CleanupPolicyUiState())
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            service = IProfileRootService.Stub.asInterface(binder)
+            bound = true
+            state = state.copy(connected = true, message = "Root 策略服务已连接")
+            loadPolicy()
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            service = null
+            bound = false
+            state = state.copy(connected = false, loading = false, message = "Root 策略服务已断开")
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.TRANSPARENT
+        window.navigationBarColor = Color.TRANSPARENT
+        setContent {
+            val appearance = appearanceViewModel.settings.collectAsStateWithLifecycle().value
+            val systemDark = isSystemInDarkTheme()
+            val dark = when (appearance.themeMode) {
+                ThemeMode.SYSTEM -> systemDark
+                ThemeMode.LIGHT -> false
+                ThemeMode.DARK -> true
+            }
+            SideEffect {
+                WindowCompat.getInsetsController(window, window.decorView).apply {
+                    isAppearanceLightStatusBars = !dark
+                    isAppearanceLightNavigationBars = !dark
+                }
+            }
+            BaiZeTheme(appearance) {
+                CompositionLocalProvider(LocalAppearanceSettings provides appearance) {
+                    CleanupPolicyScreen(
+                        miuix = appearance.uiStyle == UiStyle.MIUIX,
+                        state = state,
+                        onBack = ::finish,
+                        onRefresh = ::loadPolicy,
+                        onSelect = ::applyPolicy
+                    )
+                }
+            }
+        }
+        connect()
+    }
+
+    override fun onDestroy() {
+        if (bound) runCatching { RootService.unbind(connection) }
+        super.onDestroy()
+    }
+
+    private fun connect() {
+        state = state.copy(message = "正在连接 Root 策略服务…")
+        runCatching {
+            RootService.bind(
+                Intent(this, BaiZeProfileRootService::class.java).addCategory(RootService.CATEGORY_DAEMON_MODE),
+                connection
+            )
+            bound = true
+        }.onFailure {
+            bound = false
+            state = state.copy(message = "Root 策略服务启动失败：${it.message.orEmpty()}")
+        }
+    }
+
+    private fun loadPolicy() {
+        val root = service ?: return
+        if (state.loading) return
+        state = state.copy(loading = true, message = "正在读取当前清理策略…")
+        lifecycleScope.launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) { JSONObject(root.getSchedulerConfig()) }
+            }
+            result.onSuccess { json ->
+                val policy = CleanupPolicy.fromId(json.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
+                state = state.copy(
+                    connected = true,
+                    loading = false,
+                    activePolicy = policy,
+                    customized = json.optBoolean("cleanup_policy_customized", false),
+                    maxFileMb = json.optInt("max_file_mb", policy.values.getValue("max_file_mb")),
+                    fragmentDays = json.optInt("fragment_days", policy.values.getValue("fragment_days")),
+                    quarantineDays = json.optInt("quarantine_retention_days", policy.values.getValue("quarantine_retention_days")),
+                    message = if (json.optBoolean("cleanup_policy_customized", false)) {
+                        "当前基于${policy.title}档，并包含手动调整"
+                    } else {
+                        "当前使用${policy.title}档"
+                    }
+                )
+            }.onFailure {
+                state = state.copy(loading = false, message = "读取策略失败：${it.message ?: it.javaClass.simpleName}")
+            }
+        }
+    }
+
+    private fun applyPolicy(policy: CleanupPolicy) {
+        val root = service ?: return
+        if (state.loading) return
+        state = state.copy(loading = true, message = "正在应用${policy.title}档…")
+        lifecycleScope.launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) {
+                    JSONObject(root.saveSchedulerConfig(JSONObject().put("cleanup_policy", policy.id).toString()))
+                }
+            }
+            result.onSuccess { json ->
+                if (json.optBoolean("success")) {
+                    state = state.copy(
+                        loading = false,
+                        activePolicy = policy,
+                        customized = false,
+                        message = "${policy.title}档已生效；定时任务周期保持不变"
+                    )
+                    loadPolicy()
+                } else {
+                    state = state.copy(loading = false, message = "应用失败：${json.optString("message", json.optString("error"))}")
+                }
+            }.onFailure {
+                state = state.copy(loading = false, message = "应用失败：${it.message ?: it.javaClass.simpleName}")
+            }
+        }
+    }
+}
+
+private data class CleanupPolicyUiState(
+    val connected: Boolean = false,
+    val loading: Boolean = false,
+    val activePolicy: CleanupPolicy = CleanupPolicy.BALANCED,
+    val customized: Boolean = false,
+    val maxFileMb: Int = 256,
+    val fragmentDays: Int = 7,
+    val quarantineDays: Int = 7,
+    val message: String = "等待连接 Root 策略服务"
+)
+
+@Composable
+private fun CleanupPolicyScreen(
+    miuix: Boolean,
+    state: CleanupPolicyUiState,
+    onBack: () -> Unit,
+    onRefresh: () -> Unit,
+    onSelect: (CleanupPolicy) -> Unit
+) {
+    val horizontal = if (miuix) 18.dp else 20.dp
+    val cardShape = if (miuix) RoundedCornerShape(28.dp) else MaterialTheme.shapes.extraLarge
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentPadding = PaddingValues(bottom = 30.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        item {
+            Row(
+                Modifier.fillMaxWidth().statusBarsPadding().padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onBack) { Icon(Icons.Rounded.ArrowBack, contentDescription = "返回") }
+                Spacer(Modifier.width(6.dp))
+                Column(Modifier.weight(1f)) {
+                    Text("清理策略", fontSize = if (miuix) 30.sp else 27.sp, fontWeight = FontWeight.Black)
+                    Text("三档预设只改变清理范围，不改变定时周期", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+                }
+                IconButton(onClick = onRefresh, enabled = state.connected && !state.loading) {
+                    Icon(Icons.Rounded.Refresh, contentDescription = "刷新")
+                }
+            }
+        }
+        item {
+            Card(
+                modifier = Modifier.padding(horizontal = horizontal).fillMaxWidth(),
+                shape = cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)
+            ) {
+                Column(Modifier.padding(20.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Surface(
+                            modifier = Modifier.size(50.dp),
+                            shape = RoundedCornerShape(17.dp),
+                            color = MaterialTheme.colorScheme.primary.copy(alpha = .12f)
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Icon(Icons.Rounded.Tune, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                            }
+                        }
+                        Spacer(Modifier.width(13.dp))
+                        Column(Modifier.weight(1f)) {
+                            Text("当前：${state.activePolicy.title}档", fontSize = 21.sp, fontWeight = FontWeight.Black)
+                            Text(
+                                if (state.customized) "包含手动参数调整" else state.activePolicy.subtitle,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontSize = 12.sp
+                            )
+                        }
+                        if (!state.customized) {
+                            Icon(Icons.Rounded.CheckCircle, contentDescription = null, tint = BaiZeTokens.colors.success)
+                        }
+                    }
+                    Spacer(Modifier.height(14.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        PolicyMetric("单文件", "${state.maxFileMb} MB", Modifier.weight(1f))
+                        PolicyMetric("碎片保留", "${state.fragmentDays} 天", Modifier.weight(1f))
+                        PolicyMetric("隔离保留", "${state.quarantineDays} 天", Modifier.weight(1f))
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Text(state.message, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                    if (state.loading) {
+                        Spacer(Modifier.height(10.dp))
+                        CircularProgressIndicator(Modifier.size(24.dp))
+                    }
+                }
+            }
+        }
+        item {
+            Column(Modifier.padding(horizontal = horizontal, vertical = 2.dp)) {
+                Text("选择档位", style = MaterialTheme.typography.titleLarge)
+                Text("应用档位会覆盖清理相关参数，但不会修改任何 schedule_* 周期字段", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
+            }
+        }
+        CleanupPolicy.entries.forEach { policy ->
+            item(key = policy.key) {
+                PolicyCard(
+                    policy = policy,
+                    active = state.activePolicy == policy && !state.customized,
+                    enabled = state.connected && !state.loading,
+                    shape = cardShape,
+                    horizontal = horizontal,
+                    onSelect = { onSelect(policy) }
+                )
+            }
+        }
+        item {
+            Card(
+                modifier = Modifier.padding(horizontal = horizontal).fillMaxWidth().navigationBarsPadding(),
+                shape = cardShape,
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerLow)
+            ) {
+                Column(Modifier.padding(18.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(Icons.Rounded.Security, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                        Spacer(Modifier.width(9.dp))
+                        Text("所有档位都无法关闭的保护", fontWeight = FontWeight.Bold)
+                    }
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        "白名单、服务器端快照、挂载点检查、软链接防护、关键路径保护始终生效。高风险不会被普通清理直接删除，关键风险始终只审计。",
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                        lineHeight = 18.sp
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PolicyCard(
+    policy: CleanupPolicy,
+    active: Boolean,
+    enabled: Boolean,
+    shape: androidx.compose.ui.graphics.Shape,
+    horizontal: androidx.compose.ui.unit.Dp,
+    onSelect: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .padding(horizontal = horizontal)
+            .fillMaxWidth()
+            .clip(shape)
+            .clickable(enabled = enabled && !active, onClick = onSelect),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = if (active) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.surfaceContainerLow
+        )
+    ) {
+        Column(Modifier.padding(18.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Surface(
+                    modifier = Modifier.size(43.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    color = if (active) MaterialTheme.colorScheme.secondary.copy(alpha = .16f) else MaterialTheme.colorScheme.primary.copy(alpha = .10f)
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            if (policy == CleanupPolicy.CONSERVATIVE) Icons.Rounded.Security else Icons.Rounded.CleaningServices,
+                            contentDescription = null,
+                            tint = if (active) MaterialTheme.colorScheme.secondary else MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+                Spacer(Modifier.width(12.dp))
+                Column(Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(policy.title, fontSize = 18.sp, fontWeight = FontWeight.Black)
+                        Spacer(Modifier.width(8.dp))
+                        Surface(shape = CircleShape, color = MaterialTheme.colorScheme.primary.copy(alpha = .11f)) {
+                            Text(policy.badge, Modifier.padding(horizontal = 8.dp, vertical = 3.dp), color = MaterialTheme.colorScheme.primary, fontSize = 9.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+                    Text(policy.subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp)
+                }
+                if (active) Icon(Icons.Rounded.CheckCircle, contentDescription = "当前档位", tint = BaiZeTokens.colors.success)
+            }
+            Spacer(Modifier.height(13.dp))
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .55f))
+            Spacer(Modifier.height(9.dp))
+            policy.highlights.forEach { line ->
+                Row(Modifier.padding(vertical = 3.dp), verticalAlignment = Alignment.Top) {
+                    Box(Modifier.padding(top = 6.dp).size(5.dp).background(MaterialTheme.colorScheme.primary, CircleShape))
+                    Spacer(Modifier.width(9.dp))
+                    Text(line, modifier = Modifier.weight(1f), color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 17.sp)
+                }
+            }
+            if (!active) {
+                Spacer(Modifier.height(12.dp))
+                Button(onClick = onSelect, enabled = enabled, modifier = Modifier.fillMaxWidth().height(48.dp), shape = RoundedCornerShape(16.dp)) {
+                    Text("应用${policy.title}档", fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PolicyMetric(label: String, value: String, modifier: Modifier = Modifier) {
+    Surface(modifier = modifier, shape = RoundedCornerShape(14.dp), color = MaterialTheme.colorScheme.surface.copy(alpha = .55f)) {
+        Column(Modifier.padding(horizontal = 10.dp, vertical = 9.dp)) {
+            Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 9.sp)
+            Text(value, fontWeight = FontWeight.Bold, fontSize = 12.sp)
+        }
+    }
+}


### PR DESCRIPTION
## 第五步：清理策略档位

- 新增保守、均衡、积极三档清理策略。
- 策略只覆盖清理范围、保留期、单文件上限、默认勾选和高风险隔离方式，不修改任何定时任务周期。
- 保守档只默认勾选低风险，高风险只审计。
- 均衡档默认勾选低风险与中风险，高风险可逐项手动隔离。
- 积极档启用 OEM 日志并缩短普通垃圾保留期，高风险仍不会直接删除。
- 策略在扫描时固化进不可变快照；切换策略后必须重新扫描才影响该快照。
- 白名单、挂载点、软链接、关键路径、快照和隔离区保护均不可关闭。
- 新增 Material/MIUIx 策略选择页，并从清理中心进入。

## 验证计划

- Android Kotlin 编译、Lint、Macrobenchmark 装配。
- Root 全量回归。
- 新增策略安全契约，锁定无 schedule_* 覆盖、无高风险直接删除、快照风险边界、动态隔离保留期与三档 UI。