### PR TITLE
fix: restore real home one-tap clean

### DIFF
--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -61,6 +61,8 @@ jobs:
           bash v2/tests/test-scheduler-health-diagnostics.sh
       - name: Scan workbench snapshot contract
         run: bash v2/tests/test-scan-workbench-contract.sh
+      - name: Home one-tap actions contract
+        run: bash v2/tests/test-home-one-tap-actions-contract.sh
       - name: Quarantine authorization and restore contract
         run: bash v2/tests/test-quarantine-contract.sh
       - name: Cleaning audit center contract

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
@@ -8,6 +8,7 @@ import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.InstantCacheActivity
 import io.github.xgl34222220.baize.FileOrganizerActivity
+import io.github.xgl34222220.baize.ScanWorkbenchActivity
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.clean.material.CleanScreenMaterial
@@ -58,7 +59,7 @@ fun CleanRoute(
             applyAndSave(scheduler.copy(apkPackagesEnabled = enabled))
         },
         onSave = { dashboardActions.saveScheduler(scheduler) },
-        onScan = {},
+        onScan = { context.startActivity(Intent(context, ScanWorkbenchActivity::class.java)) },
         onApkScan = { context.startActivity(Intent(context, ApkScanActivity::class.java)) },
         onInstantCache = { context.startActivity(Intent(context, InstantCacheActivity::class.java)) },
         onFileOrganizer = { context.startActivity(Intent(context, FileOrganizerActivity::class.java)) },

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
@@ -1,11 +1,8 @@
 package io.github.xgl34222220.baize.ui.home
 
-import android.content.Intent
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
-import io.github.xgl34222220.baize.ScanWorkbenchActivity
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.home.material.HomeScreenMaterial
@@ -19,12 +16,8 @@ fun HomeRoute(
     actions: DashboardActions,
     onOpenClean: () -> Unit
 ) {
-    val context = LocalContext.current
-    val workbenchActions = actions.copy(
-        clean = { context.startActivity(Intent(context, ScanWorkbenchActivity::class.java)) }
-    )
     when (style) {
-        UiStyle.MATERIAL -> HomeScreenMaterial(state, scheduler, workbenchActions, onOpenClean)
-        UiStyle.MIUIX -> HomeScreenMiuix(state, scheduler, workbenchActions, onOpenClean)
+        UiStyle.MATERIAL -> HomeScreenMaterial(state, scheduler, actions, onOpenClean)
+        UiStyle.MIUIX -> HomeScreenMiuix(state, scheduler, actions, onOpenClean)
     }
 }

--- a/v2/tests/test-home-one-tap-actions-contract.sh
+++ b/v2/tests/test-home-one-tap-actions-contract.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+HOME="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt"
+CLEAN="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt"
+DASH="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt"
+CI="$ROOT/.github/workflows/v2.5-concurrent-scheduler-ci.yml"
+
+for file in "$HOME" "$CLEAN" "$DASH" "$CI"; do
+  test -f "$file" || exit 1
+done
+
+grep -Fq 'HomeScreenMaterial(state, scheduler, actions, onOpenClean)' "$HOME"
+grep -Fq 'HomeScreenMiuix(state, scheduler, actions, onOpenClean)' "$HOME"
+! grep -Fq 'actions.copy(' "$HOME"
+! grep -Fq 'ScanWorkbenchActivity' "$HOME"
+
+grep -Fq 'clean = { runSmartClean() }' "$DASH"
+grep -Fq 'organize = { runOneTapOrganize() }' "$DASH"
+grep -Fq 'service.runModuleTask("clean")' "$DASH"
+grep -Fq 'service.runModuleTask("organize")' "$DASH"
+
+grep -Fq 'import io.github.xgl34222220.baize.ScanWorkbenchActivity' "$CLEAN"
+grep -Fq 'onScan = { context.startActivity(Intent(context, ScanWorkbenchActivity::class.java)) }' "$CLEAN"
+grep -Fq 'test-home-one-tap-actions-contract.sh' "$CI"
+
+echo "home one-tap actions contract ok"

--- a/v2/tests/test-scan-workbench-contract.sh
+++ b/v2/tests/test-scan-workbench-contract.sh
@@ -7,6 +7,7 @@ AIDL="$ROOT/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootServi
 SELECTION="$APP/root/CacheSelectionRepository.kt"
 WORKBENCH="$APP/ScanWorkbenchActivity.kt"
 HOME="$APP/ui/home/HomeRoute.kt"
+CLEAN="$APP/ui/clean/CleanRoute.kt"
 MANIFEST="$ROOT/app/src/main/AndroidManifest.xml"
 
 for method in prepareCacheSelection getWhitelistPaths addWhitelistPath; do
@@ -27,7 +28,9 @@ CLEAN_SECTION=$(sed -n '/private fun cleanSelection()/,/private fun quarantineIt
 ! printf '%s\n' "$CLEAN_SECTION" | grep -q 'scanCandidates'
 ! printf '%s\n' "$CLEAN_SECTION" | grep -q 'scanProfile'
 
-grep -q 'ScanWorkbenchActivity::class.java' "$HOME"
+# The detailed workbench remains available from the clean page and must not intercept home one-tap clean.
+grep -q 'ScanWorkbenchActivity::class.java' "$CLEAN"
+! grep -q 'ScanWorkbenchActivity::class.java' "$HOME"
 grep -q 'android:name=".ScanWorkbenchActivity"' "$MANIFEST"
 grep -q '不会直接删除，可单独移入隔离区' "$WORKBENCH"
 grep -q '关键风险项目，只展示不自动清理' "$WORKBENCH"


### PR DESCRIPTION
## 实用主流程修复

- 首页“一键清理”恢复为直接调用 Root 清理任务，不再跳转扫描工作台。
- 首页“一键归类”保持原有直接执行逻辑。
- 详细扫描与结果审核移动到“清理”页入口，仍保留不可变快照清理能力。
- 不改首页布局、不增加确认步骤、不修改定时配置。

## 验证

- 新增首页一键动作永久契约。
- 运行 Root 全量回归与 Android Kotlin/Lint/Macrobenchmark 构建。