### PR TITLE
ci: build temporary downloadable test APK

### DIFF
--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -38,15 +38,23 @@ jobs:
         with:
           gradle-version: '8.13'
 
-      - name: Compile and lint UI
+      - name: Compile, lint, and assemble test APK
         working-directory: v2
         shell: bash
         run: |
           set +e
-          gradle --no-daemon :app:compileDebugKotlin :app:lintDebug :macrobenchmark:assemble > /tmp/baize-android-ui.log 2>&1
+          gradle --no-daemon :app:compileDebugKotlin :app:lintDebug :app:assembleDebug :macrobenchmark:assemble > /tmp/baize-android-ui.log 2>&1
           code=$?
           tail -n 200 /tmp/baize-android-ui.log
           exit "$code"
+
+      - name: Upload test APK
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: baize-test-apk-20260725
+          path: v2/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
 
       - name: Upload Android diagnostics
         if: failure()


### PR DESCRIPTION
临时测试构建分支：基于当前 main，仅为 Android CI 增加 Debug APK 构建和 artifact 上传。不会合并，不修改应用代码、版本号或正式发布配置。