### PR TITLE
feat: add practical cleanup autopilot

### DIFF
--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           bash v2/tests/test-scheduler-health-contract.sh
           bash v2/tests/test-scheduler-health-diagnostics.sh
+      - name: Autopilot scheduling regression
+        run: bash v2/tests/test-autopilot-controller.sh
       - name: Scan workbench snapshot contract
         run: bash v2/tests/test-scan-workbench-contract.sh
       - name: Home one-tap actions contract

--- a/config/default.conf
+++ b/config/default.conf
@@ -1,10 +1,10 @@
 # 只允许 key=value，不要在值中加入空格或命令。
 enabled=1
-screen_off_only=0
+screen_off_only=1
 charging_only=0
 device_idle_only=0
 min_battery=25
-max_battery_temp=0
+max_battery_temp=42
 
 # 根目录扫描工作进程：0=按本机历史基准自适应，1=固定串行，2=固定双工作进程。
 scan_root_workers=0
@@ -17,16 +17,29 @@ scan_parallel_reprobe_runs=6
 # 双工作进程异常后暂停自动尝试的小时数。
 scan_parallel_failure_cooldown_hours=24
 
+# 自动驾驶：只影响后台计划任务，不拦截用户主动发起的一键清理。
+autopilot_enabled=1
+autopilot_check_seconds=60
+autopilot_require_screen_off=1
+autopilot_condition_hold_minutes=5
+autopilot_pressure_percent=90
+autopilot_low_yield_mb=16
+autopilot_high_yield_mb=256
+autopilot_low_yield_streak=3
+autopilot_zero_yield_streak=5
+autopilot_max_interval_factor=8
+autopilot_zero_sleep_hours=72
+
 # 清理任务与文件归类统一由 Root Supervisor 调度。
 # 开启每日定时后，以固定时刻执行已启用任务组，并替代间隔定时。
 schedule_cache_enabled=1
-schedule_cache_hours=1
+schedule_cache_hours=24
 schedule_empty_enabled=1
-schedule_empty_hours=1
+schedule_empty_hours=24
 schedule_rules_enabled=1
-schedule_rules_hours=1
+schedule_rules_hours=24
 schedule_fragment_enabled=1
-schedule_fragment_hours=1
+schedule_fragment_hours=72
 schedule_deep_enabled=0
 schedule_deep_hours=168
 schedule_organize_enabled=0
@@ -68,8 +81,8 @@ notify_zero_result=0
 # 定时任务永远不会执行高风险/关键规则。
 deep_high_risk_enabled=0
 
-app_cache_days=0
-external_cache_days=0
+app_cache_days=2
+external_cache_days=2
 system_logs_days=7
 oem_logs_days=7
 empty_file_days=0
@@ -87,13 +100,13 @@ deep_stage_limit_seconds=180
 # 深度清理：同一次任务连续按文件批次执行；仅用于控制每批文件数量，不延后到下一次定时。
 deep_clean_batch_files=512
 
-schedule_cache_minutes=60
+schedule_cache_minutes=1440
 
-schedule_empty_minutes=60
+schedule_empty_minutes=1440
 
-schedule_rules_minutes=360
+schedule_rules_minutes=1440
 
-schedule_fragment_minutes=720
+schedule_fragment_minutes=4320
 
 schedule_deep_minutes=10080
 

--- a/v2/module/autopilot-controller.sh
+++ b/v2/module/autopilot-controller.sh
@@ -1,0 +1,273 @@
+#!/system/bin/sh
+set -u
+
+MODDIR=${BAIZE_MODULE_DIR:-${0%/*}}
+STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
+CONFIG=${BAIZE_CONFIG_PATH:-$STATE_DIR/config.conf}
+HISTORY_FILE=${BAIZE_HISTORY_FILE:-$STATE_DIR/history.tsv}
+GLOBAL_STATE="$STATE_DIR/autopilot.env"
+LAST_CHECK_FILE="$STATE_DIR/autopilot-last-check.epoch"
+FORCE=${BAIZE_FORCE_AUTOPILOT:-0}
+
+mkdir -p "$STATE_DIR"
+
+config_value() { sed -n "s/^$1=//p" "$CONFIG" 2>/dev/null | tail -n 1; }
+bool_value() { [ "$(config_value "$1")" = 1 ] && echo 1 || echo 0; }
+bool_value_default() {
+  value=$(config_value "$1"); fallback=$2
+  case "$value" in 0|1) echo "$value" ;; *) echo "$fallback" ;; esac
+}
+uint_value() {
+  value=$(config_value "$1"); fallback=$2; minimum=$3; maximum=$4
+  case "$value" in ''|*[!0-9]*) value=$fallback ;; esac
+  [ "$value" -lt "$minimum" ] && value=$minimum
+  [ "$value" -gt "$maximum" ] && value=$maximum
+  echo "$value"
+}
+read_state_value() { sed -n "s/^$2=//p" "$1" 2>/dev/null | tail -n 1; }
+write_atomic() {
+  target=$1; shift
+  tmp="$target.tmp.$$"
+  cat >"$tmp"
+  chmod 0600 "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$target"
+}
+now_epoch() {
+  case "${BAIZE_NOW_EPOCH:-}" in ''|*[!0-9]*) date +%s ;; *) printf '%s\n' "$BAIZE_NOW_EPOCH" ;; esac
+}
+NOW=$(now_epoch)
+CHECK_SECONDS=$(uint_value autopilot_check_seconds 60 15 3600)
+LAST_CHECK=$(sed -n '1p' "$LAST_CHECK_FILE" 2>/dev/null)
+case "$LAST_CHECK" in ''|*[!0-9]*) LAST_CHECK=0 ;; esac
+if [ "$FORCE" != 1 ] && [ $((NOW - LAST_CHECK)) -ge 0 ] && [ $((NOW - LAST_CHECK)) -lt "$CHECK_SECONDS" ]; then
+  exit 0
+fi
+printf '%s\n' "$NOW" >"$LAST_CHECK_FILE"
+chmod 0600 "$LAST_CHECK_FILE" 2>/dev/null || true
+
+if [ "$(bool_value_default autopilot_enabled 1)" != 1 ]; then
+  write_atomic "$GLOBAL_STATE" <<EOF_STATE
+status=disabled
+updated=$NOW
+EOF_STATE
+  exit 0
+fi
+
+storage_used_percent() {
+  case "${BAIZE_STORAGE_USED_PERCENT:-}" in
+    ''|*[!0-9]*)
+      value=$(df -P "$STATE_DIR" 2>/dev/null | awk 'NR==2 {gsub(/%/,"",$5); print $5; exit}')
+      case "$value" in ''|*[!0-9]*) value=0 ;; esac
+      ;;
+    *) value=$BAIZE_STORAGE_USED_PERCENT ;;
+  esac
+  [ "$value" -gt 100 ] && value=100
+  echo "$value"
+}
+interactive_state() {
+  case "${BAIZE_SCREEN_INTERACTIVE:-}" in
+    0|1) echo "$BAIZE_SCREEN_INTERACTIVE" ;;
+    *)
+      if dumpsys power 2>/dev/null | grep -Eq 'Display Power: state=ON|mWakefulness=Awake|mInteractive=true'; then echo 1; else echo 0; fi
+      ;;
+  esac
+}
+battery_temp_tenths() {
+  case "${BAIZE_BATTERY_TEMP_TENTHS:-}" in
+    ''|*[!0-9]*)
+      value=$(dumpsys battery 2>/dev/null | sed -n 's/^[[:space:]]*temperature: //p' | head -n 1)
+      case "$value" in ''|*[!0-9]*) value=0 ;; esac
+      ;;
+    *) value=$BAIZE_BATTERY_TEMP_TENTHS ;;
+  esac
+  echo "$value"
+}
+
+STORAGE_USED=$(storage_used_percent)
+PRESSURE_PERCENT=$(uint_value autopilot_pressure_percent 90 70 99)
+PRESSURE=0
+[ "$STORAGE_USED" -ge "$PRESSURE_PERCENT" ] && PRESSURE=1
+INTERACTIVE=$(interactive_state)
+REQUIRE_SCREEN_OFF=$(bool_value_default autopilot_require_screen_off 1)
+TEMP_TENTHS=$(battery_temp_tenths)
+MAX_TEMP_C=$(config_value max_battery_temp)
+case "$MAX_TEMP_C" in ''|0|*[!0-9]*) MAX_TEMP_C=42 ;; esac
+[ "$MAX_TEMP_C" -lt 30 ] && MAX_TEMP_C=30
+[ "$MAX_TEMP_C" -gt 60 ] && MAX_TEMP_C=60
+HOT=0
+[ "$TEMP_TENTHS" -gt 0 ] && [ "$TEMP_TENTHS" -ge $((MAX_TEMP_C * 10)) ] && HOT=1
+HOLD_SECONDS=$(uint_value autopilot_condition_hold_minutes 5 1 60)
+HOLD_SECONDS=$((HOLD_SECONDS * 60))
+
+LOW_BYTES=$(( $(uint_value autopilot_low_yield_mb 16 1 4096) * 1024 * 1024 ))
+HIGH_BYTES=$(( $(uint_value autopilot_high_yield_mb 256 16 16384) * 1024 * 1024 ))
+MAX_FACTOR=$(uint_value autopilot_max_interval_factor 8 1 16)
+LOW_STREAK_LIMIT=$(uint_value autopilot_low_yield_streak 3 1 20)
+ZERO_STREAK_LIMIT=$(uint_value autopilot_zero_yield_streak 5 2 30)
+ZERO_SLEEP_SECONDS=$(( $(uint_value autopilot_zero_sleep_hours 72 1 720) * 3600 ))
+DAILY=$(bool_value_default daily_schedule_enabled 0)
+
+latest_history_for_group() {
+  group=$1
+  [ -f "$HISTORY_FILE" ] || return 0
+  awk -F '\t' -v group="$group" '
+    function match_group(g,m) {
+      return (g=="cache" && (m=="cache-auto" || m=="cache-clean")) ||
+             (g=="empty" && m=="empty-clean") ||
+             (g=="rules" && m=="rules-clean") ||
+             (g=="fragment" && m=="fragment-clean") ||
+             (g=="deep" && m=="deep-clean")
+    }
+    match_group(group,$2) { line=$0 }
+    END { if (line != "") print line }
+  ' "$HISTORY_FILE"
+}
+base_interval_seconds() {
+  group=$1
+  case "$group" in
+    cache) fallback=1440 ;;
+    empty) fallback=1440 ;;
+    rules) fallback=1440 ;;
+    fragment) fallback=4320 ;;
+    deep) fallback=10080 ;;
+    *) fallback=1440 ;;
+  esac
+  minutes=$(config_value "schedule_${group}_minutes")
+  case "$minutes" in
+    ''|*[!0-9]*)
+      hours=$(config_value "schedule_${group}_hours")
+      case "$hours" in ''|*[!0-9]*) minutes=$fallback ;; *) minutes=$((hours * 60)) ;; esac
+      ;;
+  esac
+  [ "$minutes" -lt 5 ] && minutes=5
+  [ "$minutes" -gt 43200 ] && minutes=43200
+  echo $((minutes * 60))
+}
+state_number() {
+  file=$1; key=$2; fallback=$3
+  value=$(read_state_value "$file" "$key")
+  case "$value" in ''|*[!0-9]*) value=$fallback ;; esac
+  echo "$value"
+}
+
+GLOBAL_STATUS=idle
+GLOBAL_REASON=normal
+[ "$PRESSURE" = 1 ] && { GLOBAL_STATUS=pressure; GLOBAL_REASON=storage_pressure; }
+[ "$REQUIRE_SCREEN_OFF" = 1 ] && [ "$INTERACTIVE" = 1 ] && { GLOBAL_STATUS=waiting; GLOBAL_REASON=screen_active; }
+[ "$HOT" = 1 ] && { GLOBAL_STATUS=waiting; GLOBAL_REASON=temperature_high; }
+
+for group in cache empty rules fragment deep; do
+  [ "$(bool_value "schedule_${group}_enabled")" = 1 ] || continue
+  state="$STATE_DIR/autopilot-$group.env"
+  factor=$(state_number "$state" factor 1)
+  low_streak=$(state_number "$state" low_streak 0)
+  zero_streak=$(state_number "$state" zero_streak 0)
+  suspend_until=$(state_number "$state" suspend_until 0)
+  last_actual_epoch=$(state_number "$state" last_actual_epoch 0)
+  old_signature=$(read_state_value "$state" signature)
+  last_bytes=$(state_number "$state" last_bytes 0)
+
+  latest=$(latest_history_for_group "$group")
+  signature=
+  if [ -n "$latest" ]; then
+    signature=$(printf '%s\n' "$latest" | awk -F '\t' '{print $1"|"$2"|"$3"|"$4"|"$6}')
+    bytes=$(printf '%s\n' "$latest" | awk -F '\t' '{print $3}')
+    case "$bytes" in ''|*[!0-9]*) bytes=0 ;; esac
+    if [ "$signature" != "$old_signature" ]; then
+      last_actual_epoch=$NOW
+      last_bytes=$bytes
+      if [ "$bytes" -eq 0 ]; then
+        zero_streak=$((zero_streak + 1))
+        low_streak=$((low_streak + 1))
+      elif [ "$bytes" -lt "$LOW_BYTES" ]; then
+        zero_streak=0
+        low_streak=$((low_streak + 1))
+      elif [ "$bytes" -ge "$HIGH_BYTES" ]; then
+        zero_streak=0
+        low_streak=0
+        factor=1
+        suspend_until=0
+      else
+        zero_streak=0
+        low_streak=0
+        [ "$factor" -gt 1 ] && factor=$((factor / 2))
+        [ "$factor" -lt 1 ] && factor=1
+        suspend_until=0
+      fi
+      if [ "$zero_streak" -ge "$ZERO_STREAK_LIMIT" ]; then
+        factor=$MAX_FACTOR
+        suspend_until=$((NOW + ZERO_SLEEP_SECONDS))
+      elif [ "$low_streak" -ge "$LOW_STREAK_LIMIT" ]; then
+        factor=$((factor * 2))
+        [ "$factor" -gt "$MAX_FACTOR" ] && factor=$MAX_FACTOR
+        low_streak=0
+      fi
+    fi
+  fi
+
+  [ "$factor" -lt 1 ] && factor=1
+  [ "$factor" -gt "$MAX_FACTOR" ] && factor=$MAX_FACTOR
+  base=$(base_interval_seconds "$group")
+  stamp="$STATE_DIR/last_${group}_run.epoch"
+  stamp_value=$(sed -n '1p' "$stamp" 2>/dev/null)
+  case "$stamp_value" in ''|*[!0-9]*) stamp_value=0 ;; esac
+  [ "$last_actual_epoch" -gt 0 ] || last_actual_epoch=$stamp_value
+
+  effective_factor=$factor
+  effective_suspend=$suspend_until
+  if [ "$PRESSURE" = 1 ]; then
+    effective_factor=1
+    effective_suspend=0
+  fi
+
+  desired_due=0
+  if [ "$last_actual_epoch" -gt 0 ]; then
+    desired_due=$((last_actual_epoch + base * effective_factor))
+  fi
+  [ "$effective_suspend" -gt "$desired_due" ] && desired_due=$effective_suspend
+  if [ "$REQUIRE_SCREEN_OFF" = 1 ] && [ "$INTERACTIVE" = 1 ]; then
+    screen_due=$((NOW + HOLD_SECONDS))
+    [ "$screen_due" -gt "$desired_due" ] && desired_due=$screen_due
+  fi
+  if [ "$HOT" = 1 ]; then
+    hot_due=$((NOW + HOLD_SECONDS * 2))
+    [ "$hot_due" -gt "$desired_due" ] && desired_due=$hot_due
+  fi
+
+  # Fixed daily schedules remain explicit user intent. Autopilot still records yield but does not rewrite their daily cycle.
+  if [ "$DAILY" != 1 ] && [ "$desired_due" -gt 0 ]; then
+    anchor=$((desired_due - base))
+    [ "$anchor" -lt 0 ] && anchor=0
+    printf '%s\n' "$anchor" >"$stamp"
+    chmod 0600 "$stamp" 2>/dev/null || true
+  fi
+
+  write_atomic "$state" <<EOF_STATE
+signature=$signature
+factor=$factor
+low_streak=$low_streak
+zero_streak=$zero_streak
+suspend_until=$suspend_until
+last_actual_epoch=$last_actual_epoch
+last_bytes=$last_bytes
+desired_due=$desired_due
+storage_pressure=$PRESSURE
+screen_hold=$([ "$REQUIRE_SCREEN_OFF" = 1 ] && [ "$INTERACTIVE" = 1 ] && echo 1 || echo 0)
+temperature_hold=$HOT
+updated=$NOW
+EOF_STATE
+done
+
+write_atomic "$GLOBAL_STATE" <<EOF_STATE
+status=$GLOBAL_STATUS
+reason=$GLOBAL_REASON
+storage_used_percent=$STORAGE_USED
+storage_pressure=$PRESSURE
+screen_interactive=$INTERACTIVE
+require_screen_off=$REQUIRE_SCREEN_OFF
+battery_temp_tenths=$TEMP_TENTHS
+max_battery_temp_c=$MAX_TEMP_C
+daily_schedule=$DAILY
+updated=$NOW
+EOF_STATE
+exit 0

--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -38,6 +38,7 @@ chmod 0700 "$STATE_DIR"
 [ -f "$DEEP_SNAPSHOT_ENGINE" ] || abort "! 模块包中缺少 arm64 深度快照引擎"
 [ -f "$MODPATH/scheduler.sh" ] || abort "! 模块包中缺少自动调度器"
 [ -f "$MODPATH/supervisor.sh" ] || abort "! 模块包中缺少调度器守护进程"
+[ -f "$MODPATH/autopilot-controller.sh" ] || abort "! 模块包中缺少自动驾驶控制器"
 [ -f "$MODPATH/task-worker.sh" ] || abort "! 模块包中缺少统一 Root Worker"
 [ -f "$MODPATH/cache-lane-worker.sh" ] || abort "! 模块包中缺少应用缓存并行 Worker"
 [ -f "$MODPATH/organizer-worker.sh" ] || abort "! 模块包中缺少文件归类 Worker"
@@ -100,11 +101,41 @@ if [ -f "$OLD_MOD/module.prop" ] || [ -d "$OLD_UPDATE" ] || [ -d "$OLD_STATE" ];
   fi
 fi
 
+# Upgrade only the untouched legacy default schedule. Explicit user-customized schedules are preserved.
+CONFIG_FILE="$STATE_DIR/config.conf"
+if [ -f "$CONFIG_FILE" ] && [ ! -f "$STATE_DIR/autopilot-defaults-migrated" ]; then
+  value_of() { sed -n "s/^$1=//p" "$CONFIG_FILE" 2>/dev/null | tail -n 1; }
+  if [ "$(value_of screen_off_only)" = 0 ] && \
+     [ "$(value_of schedule_cache_minutes)" = 60 ] && \
+     [ "$(value_of schedule_empty_minutes)" = 60 ] && \
+     [ "$(value_of schedule_rules_minutes)" = 360 ] && \
+     [ "$(value_of schedule_fragment_minutes)" = 720 ] && \
+     [ "$(value_of app_cache_days)" = 0 ] && \
+     [ "$(value_of external_cache_days)" = 0 ]; then
+    sed -i \
+      -e 's/^screen_off_only=0$/screen_off_only=1/' \
+      -e 's/^max_battery_temp=0$/max_battery_temp=42/' \
+      -e 's/^schedule_cache_hours=1$/schedule_cache_hours=24/' \
+      -e 's/^schedule_empty_hours=1$/schedule_empty_hours=24/' \
+      -e 's/^schedule_rules_hours=1$/schedule_rules_hours=24/' \
+      -e 's/^schedule_fragment_hours=1$/schedule_fragment_hours=72/' \
+      -e 's/^schedule_cache_minutes=60$/schedule_cache_minutes=1440/' \
+      -e 's/^schedule_empty_minutes=60$/schedule_empty_minutes=1440/' \
+      -e 's/^schedule_rules_minutes=360$/schedule_rules_minutes=1440/' \
+      -e 's/^schedule_fragment_minutes=720$/schedule_fragment_minutes=4320/' \
+      -e 's/^app_cache_days=0$/app_cache_days=2/' \
+      -e 's/^external_cache_days=0$/external_cache_days=2/' \
+      "$CONFIG_FILE"
+    ui_print "- 已将旧默认计划升级为自动驾驶安全周期"
+  fi
+  touch "$STATE_DIR/autopilot-defaults-migrated"
+fi
+
 chmod 0600 "$STATE_DIR/config.conf" "$STATE_DIR/whitelist.conf" "$STATE_DIR/custom.rules" 2>/dev/null
 chmod 0644 "$APK" "$HASH_FILE" 2>/dev/null
 chmod 0755 "$MODPATH/cleaner.sh" "$MODPATH/native-cleaner.sh" "$MODPATH/cache-snapshot-clean.sh" "$MODPATH/cache-transaction.sh" "$MODPATH/cache-lane-worker.sh" "$MODPATH/one-pass-scan.sh" "$MODPATH/apk-scanner.sh" "$MODPATH/apk-cleaner.sh" "$MODPATH/profile-cleaner.sh" "$MODPATH/deep-scan-manifest.sh" "$MODPATH/deep-manifest-clean.sh" 2>/dev/null
 chmod 0755 "$MODPATH/cleaner.sh.compat" "$MODPATH/scheduler.sh" "$MODPATH/notify.sh" "$NATIVE_ENGINE" "$DEEP_SNAPSHOT_ENGINE" 2>/dev/null
-chmod 0755 "$MODPATH/task-worker.sh" "$MODPATH/organizer-worker.sh" "$MODPATH/worker-runner.sh" "$MODPATH/supervisor.sh" "$MODPATH/app-installer.sh" "$MODPATH/diagnostics-export.sh" "$MODPATH/storage-analyzer.sh" "$MODPATH/duplicate-scanner.sh" "$MODPATH/large-file-scanner.sh" "$MODPATH/quarantine-manager.sh" "$MODPATH/rules-validator.sh" 2>/dev/null
+chmod 0755 "$MODPATH/task-worker.sh" "$MODPATH/organizer-worker.sh" "$MODPATH/worker-runner.sh" "$MODPATH/supervisor.sh" "$MODPATH/autopilot-controller.sh" "$MODPATH/app-installer.sh" "$MODPATH/diagnostics-export.sh" "$MODPATH/storage-analyzer.sh" "$MODPATH/duplicate-scanner.sh" "$MODPATH/large-file-scanner.sh" "$MODPATH/quarantine-manager.sh" "$MODPATH/rules-validator.sh" 2>/dev/null
 
 install_app() {
   pm install -r -d --user 0 "$APK" >/dev/null 2>&1 && return 0

--- a/v2/module/supervisor.sh
+++ b/v2/module/supervisor.sh
@@ -5,6 +5,7 @@ STATE_DIR=${BAIZE_STATE_DIR:-/data/adb/baize-v2}
 STATE="$STATE_DIR/supervisor.env"
 SCHEDULER_STATE="$STATE_DIR/scheduler.env"
 SCHEDULER="$MODDIR/scheduler.sh"
+AUTOPILOT="$MODDIR/autopilot-controller.sh"
 STOP="$STATE_DIR/supervisor.stop"
 HEARTBEAT_SECONDS=${BAIZE_SUPERVISOR_HEARTBEAT_SECONDS:-5}
 QUEUE_WAKE_AFTER_SECONDS=${BAIZE_QUEUE_WAKE_AFTER_SECONDS:-2}
@@ -18,6 +19,12 @@ signal_child() { [ -n "${child:-}" ] && kill -USR1 "$child" 2>/dev/null || true;
 stop_all() { touch "$STOP"; [ -n "${heartbeat_pid:-}" ] && kill "$heartbeat_pid" 2>/dev/null || true; [ -n "${child:-}" ] && kill "$child" 2>/dev/null || true; exit 0; }
 trap stop_all INT TERM
 trap signal_child USR1 HUP
+run_autopilot() {
+  force=${1:-0}
+  [ -f "$AUTOPILOT" ] || return 0
+  BAIZE_MODULE_DIR="$MODDIR" BAIZE_STATE_DIR="$STATE_DIR" BAIZE_FORCE_AUTOPILOT="$force" \
+    sh "$AUTOPILOT" >>"$STATE_DIR/logs/autopilot.log" 2>&1 || true
+}
 write_state() {
   status=$1; code=${2:-0}; reason=${3:-}; now=$(date +%s); tmp="$STATE.tmp.$$"
   { echo "status=$status"; echo "pid=$$"; echo "pid_start_ticks=$SUPERVISOR_START_TICKS"; echo "instance_id=$INSTANCE_ID"; echo "scheduler_pid=${child:-0}"; echo "scheduler_start_ticks=$([ -n "${child:-}" ] && proc_start_ticks "$child" || echo 0)"; echo "restart_count=$restart_count"; echo "last_exit_code=$code"; echo "reason=$reason"; echo "heartbeat_epoch=$now"; echo "updated=$now"; } >"$tmp" && mv -f "$tmp" "$STATE"
@@ -37,12 +44,14 @@ queue_dispatch_stalled() {
 }
 while [ ! -f "$STOP" ]; do
   [ -f "$SCHEDULER" ] || { write_state failed 127 scheduler_missing; sleep 60; continue; }
+  run_autopilot 1
   write_state starting 0 launching_scheduler
   BAIZE_SUPERVISOR_INSTANCE="$INSTANCE_ID" sh "$SCHEDULER" >>"$STATE_DIR/logs/supervisor-scheduler.log" 2>&1 & child=$!
   write_state running 0 scheduler_running
   while kill -0 "$child" 2>/dev/null && [ ! -f "$STOP" ]; do
     sleep "$HEARTBEAT_SECONDS" & heartbeat_pid=$!; wait "$heartbeat_pid" 2>/dev/null || true; heartbeat_pid=
     if kill -0 "$child" 2>/dev/null; then
+      run_autopilot 0
       backoff=1
       if queue_dispatch_stalled; then
         if [ "$RESCUE_AGE" -ge "$QUEUE_RESTART_AFTER_SECONDS" ]; then write_state recovering 0 "scheduler_queue_stalled_${RESCUE_AGE}s"; kill "$child" 2>/dev/null || true

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -17,6 +17,7 @@ OUTPUT="$OUT/BaiZe-v2.5.2-Module.zip"
 bash "$ROOT/tests/test-concurrent-scheduler.sh"
 bash "$ROOT/tests/test-deep-clean-budget.sh"
 bash "$ROOT/tests/test-deep-manifest.sh"
+bash "$ROOT/tests/test-autopilot-controller.sh"
 
 rm -rf "$STAGE"
 mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
@@ -43,7 +44,7 @@ chmod 0755 "$STAGE/storage-index.sh" "$STAGE/task-worker.sh" "$STAGE/cache-lane-
 chmod 0755 "$STAGE/cleaner.sh" "$STAGE/native-cleaner.sh" "$STAGE/cache-snapshot-clean.sh" "$STAGE/cache-transaction.sh" "$STAGE/one-pass-scan.sh" "$STAGE/profile-cleaner.sh" "$STAGE/deep-scan-manifest.sh" "$STAGE/deep-manifest-clean.sh" "$STAGE/apk-scanner.sh" "$STAGE/apk-cleaner.sh"
 chmod 0755 "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine" "$STAGE/bin/arm64-v8a/baize_deep_snapshot"
 chmod 0755 "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh"
-chmod 0755 "$STAGE/quarantine-manager.sh" "$STAGE/large-file-scanner.sh" "$STAGE/duplicate-scanner.sh" "$STAGE/storage-analyzer.sh" "$STAGE/diagnostics-export.sh" "$STAGE/app-installer.sh" "$STAGE/supervisor.sh" "$STAGE/worker-runner.sh" "$STAGE/task-worker.sh" "$STAGE/rules-validator.sh" "$STAGE/organizer-worker.sh" "$STAGE/cache-lane-worker.sh"
+chmod 0755 "$STAGE/quarantine-manager.sh" "$STAGE/large-file-scanner.sh" "$STAGE/duplicate-scanner.sh" "$STAGE/storage-analyzer.sh" "$STAGE/diagnostics-export.sh" "$STAGE/app-installer.sh" "$STAGE/supervisor.sh" "$STAGE/autopilot-controller.sh" "$STAGE/worker-runner.sh" "$STAGE/task-worker.sh" "$STAGE/rules-validator.sh" "$STAGE/organizer-worker.sh" "$STAGE/cache-lane-worker.sh"
 
 cp -f "$APK" "$STAGE/app/baize.apk"
 chmod 0644 "$STAGE/app/baize.apk"
@@ -68,6 +69,9 @@ unzip -l "$OUTPUT" | grep -q 'task-worker.sh'
 unzip -l "$OUTPUT" | grep -q 'cache-lane-worker.sh'
 unzip -p "$OUTPUT" cache-lane-worker.sh | grep -q 'BAIZE_ROOT_STATE_DIR'
 unzip -l "$OUTPUT" | grep -q 'organizer-worker.sh'
+unzip -l "$OUTPUT" | grep -q 'autopilot-controller.sh'
+unzip -p "$OUTPUT" autopilot-controller.sh | grep -q 'autopilot_zero_yield_streak'
+unzip -p "$OUTPUT" supervisor.sh | grep -q 'run_autopilot'
 unzip -p "$OUTPUT" scheduler.sh | grep -q 'resource-lane scheduler'
 unzip -p "$OUTPUT" scheduler.sh | grep -q 'run_parallel_pair'
 unzip -p "$OUTPUT" scheduler.sh | grep -q 'fixed-seven-fields-v1'
@@ -111,6 +115,9 @@ unzip -p "$OUTPUT" one-pass-scan.sh | grep -q 'pruned_subtrees'
 unzip -p "$OUTPUT" one-pass-scan.sh | grep -q 'BAIZE_ROOT_WORKERS'
 unzip -p "$OUTPUT" one-pass-scan.sh | grep -q 'parallel_overlap_milli'
 unzip -p "$OUTPUT" config/default.conf | grep -q '^scan_root_workers=0$'
+unzip -p "$OUTPUT" config/default.conf | grep -q '^autopilot_enabled=1$'
+unzip -p "$OUTPUT" config/default.conf | grep -q '^schedule_cache_minutes=1440$'
+unzip -p "$OUTPUT" config/default.conf | grep -q '^app_cache_days=2$'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-scanner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'apk-cleaner.sh'
 unzip -p "$OUTPUT" cleaner.sh | grep -q 'native-cleaner.sh'

--- a/v2/tests/test-autopilot-controller.sh
+++ b/v2/tests/test-autopilot-controller.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+CONTROLLER="$ROOT/module/autopilot-controller.sh"
+TMP=${TMPDIR:-/tmp}/baize-autopilot-test-$$
+STATE="$TMP/state"
+CONFIG="$STATE/config.conf"
+HISTORY="$STATE/history.tsv"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$STATE"
+
+cat >"$CONFIG" <<'CONF'
+autopilot_enabled=1
+autopilot_check_seconds=60
+autopilot_require_screen_off=1
+autopilot_condition_hold_minutes=5
+autopilot_pressure_percent=90
+autopilot_low_yield_mb=16
+autopilot_high_yield_mb=256
+autopilot_low_yield_streak=3
+autopilot_zero_yield_streak=5
+autopilot_max_interval_factor=8
+autopilot_zero_sleep_hours=72
+max_battery_temp=42
+daily_schedule_enabled=0
+schedule_cache_enabled=1
+schedule_cache_minutes=60
+schedule_empty_enabled=1
+schedule_empty_minutes=60
+schedule_rules_enabled=0
+schedule_fragment_enabled=0
+schedule_deep_enabled=0
+CONF
+: >"$HISTORY"
+
+run_controller() {
+  BAIZE_STATE_DIR="$STATE" \
+  BAIZE_CONFIG_PATH="$CONFIG" \
+  BAIZE_HISTORY_FILE="$HISTORY" \
+  BAIZE_FORCE_AUTOPILOT=1 \
+  BAIZE_NOW_EPOCH="$1" \
+  BAIZE_STORAGE_USED_PERCENT="${2:-50}" \
+  BAIZE_SCREEN_INTERACTIVE="${3:-0}" \
+  BAIZE_BATTERY_TEMP_TENTHS="${4:-350}" \
+  sh "$CONTROLLER"
+}
+value() { sed -n "s/^$2=//p" "$1" | tail -n 1; }
+
+printf '2026-07-25 00:00:00\tcache-auto\t1048576\t1\t0\t0\tlow\tscheduler\t\t\n' >>"$HISTORY"
+run_controller 1000
+printf '2026-07-25 01:00:00\tcache-auto\t1048576\t1\t0\t0\tlow\tscheduler\t\t\n' >>"$HISTORY"
+run_controller 2000
+printf '2026-07-25 02:00:00\tcache-auto\t1048576\t1\t0\t0\tlow\tscheduler\t\t\n' >>"$HISTORY"
+run_controller 3000
+[ "$(value "$STATE/autopilot-cache.env" factor)" = 2 ]
+[ "$(sed -n '1p' "$STATE/last_cache_run.epoch")" = 6600 ]
+
+# Storage pressure cancels the adaptive multiplier and brings the next run forward.
+run_controller 4000 95 0 350
+[ "$(sed -n '1p' "$STATE/last_cache_run.epoch")" = 3000 ]
+[ "$(value "$STATE/autopilot-cache.env" storage_pressure)" = 1 ]
+
+# Active screen defers an otherwise-due scheduled task without affecting manual Root tasks.
+printf '500\n' >"$STATE/last_empty_run.epoch"
+run_controller 5000 50 1 350
+[ "$(sed -n '1p' "$STATE/last_empty_run.epoch")" = 1700 ]
+[ "$(value "$STATE/autopilot-empty.env" screen_hold)" = 1 ]
+
+# High battery temperature extends the next interval task beyond the thermal hold window.
+run_controller 5000 50 0 430
+[ "$(value "$STATE/autopilot-empty.env" temperature_hold)" = 1 ]
+[ "$(sed -n '1p' "$STATE/last_empty_run.epoch")" = 2000 ]
+[ "$(value "$STATE/autopilot.env" reason)" = temperature_high ]
+
+echo "autopilot controller contract ok"


### PR DESCRIPTION
## 改动内容

- 新增 Root 自动驾驶控制器，由 Supervisor 周期执行
- 根据每类任务的真实释放空间学习清理收益
- 连续低收益时自动将间隔扩大至 2/4/8 倍
- 连续零收益时进入最长 72 小时休眠
- 存储使用率达到 90% 时取消收益退避，恢复基础清理频率
- 亮屏或电池温度达到阈值时推迟后台间隔任务
- 手动一键清理不经过自动驾驶限制
- 将新安装默认周期改为缓存/空项/规则 24 小时、碎片 72 小时
- 缓存默认只处理至少 2 天前的文件
- 安装升级时，仅对完全未修改的旧默认计划执行安全迁移，保留用户自定义周期
- 打包阶段验证自动驾驶组件存在、权限正确且默认值已进入模块

## 原因

旧默认配置会每小时执行缓存与空项任务，容易重复扫描、频繁清掉很快重建的缓存。仓库虽然已经有清理效果评分，但此前没有真正参与后台调度。

本 PR 把实际释放空间接入 Root 调度锚点，让白泽在低收益时少运行、存储紧张时及时恢复，并默认避开用户亮屏使用和高温状态。

## 验证

- `sh -n v2/module/autopilot-controller.sh`
- `sh -n v2/module/supervisor.sh`
- `sh -n v2/module/customize.sh`
- `sh -n v2/scripts/package-module.sh`
- `bash v2/tests/test-autopilot-controller.sh`
- 新增 CI 合同测试，覆盖低收益倍增、存储压力恢复、亮屏推迟和高温推迟
