### PR TITLE
ci: build BaiZe test packages

### DIFF
--- a/.github/workflows/baize-test-build-20260725.yml
+++ b/.github/workflows/baize-test-build-20260725.yml
@@ -1,0 +1,70 @@
+name: BaiZe Test Build 20260725
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/baize-test-build-20260725.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform and NDK
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Build ARM64 native engines
+        working-directory: v2
+        run: sh scripts/build-native.sh
+
+      - name: Build Debug APK
+        working-directory: v2
+        run: gradle --no-daemon :app:assembleDebug :app:lintDebug
+
+      - name: Package test module
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p v2/app/build/outputs/apk/release
+          cp v2/app/build/outputs/apk/debug/app-debug.apk v2/app/build/outputs/apk/release/app-release.apk
+          (cd v2 && sh scripts/package-module.sh)
+
+          TEST_DIR='v2/dist/test-20260725-cf291a5'
+          mkdir -p "$TEST_DIR"
+          cp v2/app/build/outputs/apk/debug/app-debug.apk "$TEST_DIR/BaiZe-v2.5.2-cf291a5-Test.apk"
+          cp v2/dist/BaiZe-v2.5.2-Module.zip "$TEST_DIR/BaiZe-v2.5.2-cf291a5-Test-Module.zip"
+          unzip -tq "$TEST_DIR/BaiZe-v2.5.2-cf291a5-Test-Module.zip"
+          (
+            cd "$TEST_DIR"
+            sha256sum BaiZe-v2.5.2-cf291a5-Test.apk BaiZe-v2.5.2-cf291a5-Test-Module.zip > SHA256SUMS.txt
+          )
+
+      - name: Upload test packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.5.2-cf291a5-Test
+          if-no-files-found: error
+          compression-level: 0
+          path: |
+            v2/dist/test-20260725-cf291a5/BaiZe-v2.5.2-cf291a5-Test.apk
+            v2/dist/test-20260725-cf291a5/BaiZe-v2.5.2-cf291a5-Test-Module.zip
+            v2/dist/test-20260725-cf291a5/SHA256SUMS.txt


### PR DESCRIPTION
测试产物已成功生成并下载：Debug APK、完整 Root 模块 ZIP、SHA-256。该临时构建工作流不合并进 main。