### PR TITLE
fix: remove BaiZe Root residue completely

### DIFF
--- a/.github/workflows/v2.5-concurrent-scheduler-ci.yml
+++ b/.github/workflows/v2.5-concurrent-scheduler-ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: bash v2/tests/test-home-one-tap-actions-contract.sh
       - name: Quarantine authorization and restore contract
         run: bash v2/tests/test-quarantine-contract.sh
+      - name: Complete uninstall cleanup regression
+        run: bash v2/tests/test-uninstall-cleanup.sh
       - name: Cleaning audit center contract
         run: bash v2/tests/test-audit-center-contract.sh
       - name: Cleanup policy safety contract

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,3 +1,172 @@
 #!/system/bin/sh
-# 有意保留 /data/adb/safesweep 中的配置和日志，避免误删用户数据。
-echo "白泽已卸载；配置与日志仍保留在 /data/adb/safesweep"
+set -u
+
+APP_ID=${BAIZE_APP_ID:-io.github.xgl34222220.baize}
+ADB_ROOT=${BAIZE_ADB_ROOT:-/data/adb}
+MODULES_DIR=${BAIZE_MODULES_DIR:-$ADB_ROOT/modules}
+MODULES_UPDATE_DIR=${BAIZE_MODULES_UPDATE_DIR:-$ADB_ROOT/modules_update}
+STATE_DIR=${BAIZE_STATE_DIR:-$ADB_ROOT/baize-v2}
+LEGACY_STATE_DIR=${BAIZE_LEGACY_STATE_DIR:-$ADB_ROOT/safesweep}
+MEDIA_ROOT=${BAIZE_MEDIA_ROOT:-/data/media}
+RECOVERY_ROOT=${BAIZE_RECOVERY_ROOT:-$MEDIA_ROOT/0/Download/BaiZe恢复}
+WAIT_SECONDS=${BAIZE_UNINSTALL_WAIT_SECONDS:-1}
+MOD_ID=baize_v2
+LEGACY_MOD_ID=safesweep
+SELF_DIR=${0%/*}
+SELF_PID=$$
+PARENT_PID=${PPID:-0}
+
+case "$WAIT_SECONDS" in ''|*[!0-9]*) WAIT_SECONDS=1 ;; esac
+[ "$WAIT_SECONDS" -gt 5 ] && WAIT_SECONDS=5
+
+safe_owned_path() {
+  case "$1" in
+    "$STATE_DIR"|"$LEGACY_STATE_DIR"|\
+    "$MODULES_UPDATE_DIR/$MOD_ID"|"$MODULES_UPDATE_DIR/$LEGACY_MOD_ID"|\
+    "$MODULES_DIR/$LEGACY_MOD_ID") return 0 ;;
+  esac
+  return 1
+}
+
+remove_owned_path() {
+  target=$1
+  safe_owned_path "$target" || {
+    echo "拒绝删除非白泽目录：$target" >&2
+    return 1
+  }
+  rm -rf -- "$target" 2>/dev/null || true
+}
+
+process_matches() {
+  cmdline=$1
+  case "$cmdline" in
+    *"$MODULES_DIR/$MOD_ID/"*|*"$MODULES_UPDATE_DIR/$MOD_ID/"*|*"$STATE_DIR/"*|\
+    *"$MODULES_DIR/$LEGACY_MOD_ID/"*|*"$MODULES_UPDATE_DIR/$LEGACY_MOD_ID/"*|*"$LEGACY_STATE_DIR/"*) return 0 ;;
+  esac
+  return 1
+}
+
+signal_owned_processes() {
+  signal=$1
+  for proc_dir in /proc/[0-9]*; do
+    [ -d "$proc_dir" ] || continue
+    pid=${proc_dir##*/}
+    [ "$pid" = "$SELF_PID" ] && continue
+    [ "$pid" = "$PARENT_PID" ] && continue
+    [ -r "$proc_dir/cmdline" ] || continue
+    cmdline=$(tr '\000' ' ' <"$proc_dir/cmdline" 2>/dev/null || true)
+    [ -n "$cmdline" ] || continue
+    if process_matches "$cmdline"; then
+      kill "-$signal" "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+unique_recovery_path() {
+  base=$1
+  if [ ! -e "$base" ]; then
+    printf '%s\n' "$base"
+    return 0
+  fi
+  n=1
+  while [ "$n" -le 999 ]; do
+    candidate="$base ($n)"
+    if [ ! -e "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    n=$((n + 1))
+  done
+  return 1
+}
+
+restore_quarantine() {
+  quarantine="$STATE_DIR/quarantine"
+  index="$quarantine/index.tsv"
+  [ -f "$index" ] || return 0
+
+  failed=0
+  tab=$(printf '\t')
+  while IFS="$tab" read -r id epoch size original; do
+    [ -n "${id:-}" ] || continue
+    source="$quarantine/files/$id"
+    [ -f "$source" ] || continue
+
+    case "$original" in
+      "$MEDIA_ROOT"/[0-9]/*|/storage/*|/sdcard/*) ;;
+      *) original= ;;
+    esac
+
+    restored=0
+    if [ -n "$original" ] && [ ! -e "$original" ]; then
+      if mkdir -p "${original%/*}" 2>/dev/null && mv "$source" "$original" 2>/dev/null; then
+        restored=1
+      fi
+    fi
+
+    if [ "$restored" -eq 0 ]; then
+      mkdir -p "$RECOVERY_ROOT" 2>/dev/null || true
+      name=${original##*/}
+      [ -n "$name" ] || name=$id
+      fallback=$(unique_recovery_path "$RECOVERY_ROOT/$name" 2>/dev/null || true)
+      if [ -n "$fallback" ] && mv "$source" "$fallback" 2>/dev/null; then
+        restored=1
+      fi
+    fi
+
+    [ "$restored" -eq 1 ] || failed=1
+  done <"$index"
+
+  return "$failed"
+}
+
+if [ -d "$STATE_DIR" ]; then
+  touch "$STATE_DIR/stop" "$STATE_DIR/supervisor.stop" 2>/dev/null || true
+fi
+
+signal_owned_processes TERM
+[ "$WAIT_SECONDS" -eq 0 ] || sleep "$WAIT_SECONDS"
+signal_owned_processes KILL
+
+QUARANTINE_RESTORED=1
+if ! restore_quarantine; then
+  QUARANTINE_RESTORED=0
+  echo "部分隔离文件无法恢复，已保留隔离目录" >&2
+fi
+
+if command -v pm >/dev/null 2>&1; then
+  pm uninstall "$APP_ID" >/dev/null 2>&1 || true
+  pm uninstall --user 0 "$APP_ID" >/dev/null 2>&1 || true
+fi
+
+if [ "$QUARANTINE_RESTORED" -eq 1 ]; then
+  remove_owned_path "$STATE_DIR"
+else
+  RECOVERY_STATE="$ADB_ROOT/baize-v2-quarantine-recovery"
+  rm -rf -- "$RECOVERY_STATE" 2>/dev/null || true
+  mv "$STATE_DIR/quarantine" "$RECOVERY_STATE" 2>/dev/null || true
+  remove_owned_path "$STATE_DIR"
+fi
+remove_owned_path "$LEGACY_STATE_DIR"
+remove_owned_path "$MODULES_UPDATE_DIR/$MOD_ID"
+remove_owned_path "$MODULES_UPDATE_DIR/$LEGACY_MOD_ID"
+remove_owned_path "$MODULES_DIR/$LEGACY_MOD_ID"
+
+[ "$WAIT_SECONDS" -eq 0 ] || sleep "$WAIT_SECONDS"
+signal_owned_processes KILL
+remove_owned_path "$STATE_DIR"
+remove_owned_path "$LEGACY_STATE_DIR"
+remove_owned_path "$MODULES_UPDATE_DIR/$MOD_ID"
+remove_owned_path "$MODULES_UPDATE_DIR/$LEGACY_MOD_ID"
+
+case "$SELF_DIR" in
+  "$MODULES_DIR/$MOD_ID") touch "$SELF_DIR/remove" 2>/dev/null || true ;;
+esac
+
+sync 2>/dev/null || true
+
+echo "白泽后台进程、App、Root 状态和旧版目录已清理"
+case "$SELF_DIR" in
+  "$MODULES_DIR/$MOD_ID") echo "模块本体目录将在重启后由 Root 管理器移除" ;;
+esac
+[ "$QUARANTINE_RESTORED" -eq 1 ] || echo "未能恢复的隔离文件保存在 $ADB_ROOT/baize-v2-quarantine-recovery"

--- a/v2/module/uninstall.sh
+++ b/v2/module/uninstall.sh
@@ -1,9 +1,181 @@
 #!/system/bin/sh
+set -u
 
-APP_ID="io.github.xgl34222220.baize"
-STATE_DIR="/data/adb/baize-v2"
+APP_ID=${BAIZE_APP_ID:-io.github.xgl34222220.baize}
+ADB_ROOT=${BAIZE_ADB_ROOT:-/data/adb}
+MODULES_DIR=${BAIZE_MODULES_DIR:-$ADB_ROOT/modules}
+MODULES_UPDATE_DIR=${BAIZE_MODULES_UPDATE_DIR:-$ADB_ROOT/modules_update}
+STATE_DIR=${BAIZE_STATE_DIR:-$ADB_ROOT/baize-v2}
+LEGACY_STATE_DIR=${BAIZE_LEGACY_STATE_DIR:-$ADB_ROOT/safesweep}
+MEDIA_ROOT=${BAIZE_MEDIA_ROOT:-/data/media}
+RECOVERY_ROOT=${BAIZE_RECOVERY_ROOT:-$MEDIA_ROOT/0/Download/BaiZe恢复}
+WAIT_SECONDS=${BAIZE_UNINSTALL_WAIT_SECONDS:-1}
+MOD_ID=baize_v2
+LEGACY_MOD_ID=safesweep
+SELF_DIR=${0%/*}
+SELF_PID=$$
+PARENT_PID=${PPID:-0}
 
-pm uninstall "$APP_ID" >/dev/null 2>&1 || true
-pkill -f '/data/adb/modules/baize_v2' >/dev/null 2>&1 || true
-pkill -f '/data/adb/baize-v2' >/dev/null 2>&1 || true
-rm -rf "$STATE_DIR"
+case "$WAIT_SECONDS" in ''|*[!0-9]*) WAIT_SECONDS=1 ;; esac
+[ "$WAIT_SECONDS" -gt 5 ] && WAIT_SECONDS=5
+
+safe_owned_path() {
+  case "$1" in
+    "$STATE_DIR"|"$LEGACY_STATE_DIR"|\
+    "$MODULES_UPDATE_DIR/$MOD_ID"|"$MODULES_UPDATE_DIR/$LEGACY_MOD_ID"|\
+    "$MODULES_DIR/$LEGACY_MOD_ID") return 0 ;;
+  esac
+  return 1
+}
+
+remove_owned_path() {
+  target=$1
+  safe_owned_path "$target" || {
+    echo "拒绝删除非白泽目录：$target" >&2
+    return 1
+  }
+  rm -rf -- "$target" 2>/dev/null || true
+}
+
+process_matches() {
+  cmdline=$1
+  case "$cmdline" in
+    *"$MODULES_DIR/$MOD_ID/"*|*"$MODULES_UPDATE_DIR/$MOD_ID/"*|*"$STATE_DIR/"*|\
+    *"$MODULES_DIR/$LEGACY_MOD_ID/"*|*"$MODULES_UPDATE_DIR/$LEGACY_MOD_ID/"*|*"$LEGACY_STATE_DIR/"*) return 0 ;;
+  esac
+  return 1
+}
+
+signal_owned_processes() {
+  signal=$1
+  for proc_dir in /proc/[0-9]*; do
+    [ -d "$proc_dir" ] || continue
+    pid=${proc_dir##*/}
+    [ "$pid" = "$SELF_PID" ] && continue
+    [ "$pid" = "$PARENT_PID" ] && continue
+    [ -r "$proc_dir/cmdline" ] || continue
+    cmdline=$(tr '\000' ' ' <"$proc_dir/cmdline" 2>/dev/null || true)
+    [ -n "$cmdline" ] || continue
+    if process_matches "$cmdline"; then
+      kill "-$signal" "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+unique_recovery_path() {
+  base=$1
+  if [ ! -e "$base" ]; then
+    printf '%s\n' "$base"
+    return 0
+  fi
+  n=1
+  while [ "$n" -le 999 ]; do
+    candidate="$base ($n)"
+    if [ ! -e "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    n=$((n + 1))
+  done
+  return 1
+}
+
+restore_quarantine() {
+  quarantine="$STATE_DIR/quarantine"
+  index="$quarantine/index.tsv"
+  [ -f "$index" ] || return 0
+
+  failed=0
+  tab=$(printf '\t')
+  while IFS="$tab" read -r id epoch size original; do
+    [ -n "${id:-}" ] || continue
+    source="$quarantine/files/$id"
+    [ -f "$source" ] || continue
+
+    case "$original" in
+      "$MEDIA_ROOT"/[0-9]/*|/storage/*|/sdcard/*) ;;
+      *) original= ;;
+    esac
+
+    restored=0
+    if [ -n "$original" ] && [ ! -e "$original" ]; then
+      if mkdir -p "${original%/*}" 2>/dev/null && mv "$source" "$original" 2>/dev/null; then
+        restored=1
+      fi
+    fi
+
+    if [ "$restored" -eq 0 ]; then
+      mkdir -p "$RECOVERY_ROOT" 2>/dev/null || true
+      name=${original##*/}
+      [ -n "$name" ] || name=$id
+      fallback=$(unique_recovery_path "$RECOVERY_ROOT/$name" 2>/dev/null || true)
+      if [ -n "$fallback" ] && mv "$source" "$fallback" 2>/dev/null; then
+        restored=1
+      fi
+    fi
+
+    [ "$restored" -eq 1 ] || failed=1
+  done <"$index"
+
+  return "$failed"
+}
+
+# Tell every active worker to stop before terminating processes.
+if [ -d "$STATE_DIR" ]; then
+  touch "$STATE_DIR/stop" "$STATE_DIR/supervisor.stop" 2>/dev/null || true
+fi
+
+# Do not use `pkill -f /data/adb/modules/baize_v2`: it also matches and kills
+# this uninstall script before state cleanup can run.
+signal_owned_processes TERM
+[ "$WAIT_SECONDS" -eq 0 ] || sleep "$WAIT_SECONDS"
+signal_owned_processes KILL
+
+# Preserve user files held by the quarantine feature before deleting state.
+QUARANTINE_RESTORED=1
+if ! restore_quarantine; then
+  QUARANTINE_RESTORED=0
+  echo "部分隔离文件无法恢复，已保留隔离目录" >&2
+fi
+
+if command -v pm >/dev/null 2>&1; then
+  pm uninstall "$APP_ID" >/dev/null 2>&1 || true
+  pm uninstall --user 0 "$APP_ID" >/dev/null 2>&1 || true
+fi
+
+# Remove all state and legacy/update staging directories owned by BaiZe.
+if [ "$QUARANTINE_RESTORED" -eq 1 ]; then
+  remove_owned_path "$STATE_DIR"
+else
+  RECOVERY_STATE="$ADB_ROOT/baize-v2-quarantine-recovery"
+  rm -rf -- "$RECOVERY_STATE" 2>/dev/null || true
+  mv "$STATE_DIR/quarantine" "$RECOVERY_STATE" 2>/dev/null || true
+  remove_owned_path "$STATE_DIR"
+fi
+remove_owned_path "$LEGACY_STATE_DIR"
+remove_owned_path "$MODULES_UPDATE_DIR/$MOD_ID"
+remove_owned_path "$MODULES_UPDATE_DIR/$LEGACY_MOD_ID"
+remove_owned_path "$MODULES_DIR/$LEGACY_MOD_ID"
+
+# A worker can recreate the state directory while TERM is being handled.
+# Repeat termination and deletion after a short grace period.
+[ "$WAIT_SECONDS" -eq 0 ] || sleep "$WAIT_SECONDS"
+signal_owned_processes KILL
+remove_owned_path "$STATE_DIR"
+remove_owned_path "$LEGACY_STATE_DIR"
+remove_owned_path "$MODULES_UPDATE_DIR/$MOD_ID"
+remove_owned_path "$MODULES_UPDATE_DIR/$LEGACY_MOD_ID"
+
+# Magisk, KernelSU and APatch remove the active module directory on reboot.
+# Keep the current script alive, but ensure the standard removal marker exists.
+case "$SELF_DIR" in
+  "$MODULES_DIR/$MOD_ID") touch "$SELF_DIR/remove" 2>/dev/null || true ;;
+esac
+
+sync 2>/dev/null || true
+
+echo "白泽后台进程、App、Root 状态和旧版目录已清理"
+case "$SELF_DIR" in
+  "$MODULES_DIR/$MOD_ID") echo "模块本体目录将在重启后由 Root 管理器移除" ;;
+esac
+[ "$QUARANTINE_RESTORED" -eq 1 ] || echo "未能恢复的隔离文件保存在 $ADB_ROOT/baize-v2-quarantine-recovery"

--- a/v2/scripts/package-module.sh
+++ b/v2/scripts/package-module.sh
@@ -18,6 +18,7 @@ bash "$ROOT/tests/test-concurrent-scheduler.sh"
 bash "$ROOT/tests/test-deep-clean-budget.sh"
 bash "$ROOT/tests/test-deep-manifest.sh"
 bash "$ROOT/tests/test-autopilot-controller.sh"
+bash "$ROOT/tests/test-uninstall-cleanup.sh"
 
 rm -rf "$STAGE"
 mkdir -p "$OUT" "$STAGE/app" "$STAGE/bin/arm64-v8a"
@@ -43,7 +44,7 @@ cp -f "$DEEP_NATIVE" "$STAGE/bin/arm64-v8a/baize_deep_snapshot"
 chmod 0755 "$STAGE/storage-index.sh" "$STAGE/task-worker.sh" "$STAGE/cache-lane-worker.sh" "$STAGE/organizer-worker.sh"
 chmod 0755 "$STAGE/cleaner.sh" "$STAGE/native-cleaner.sh" "$STAGE/cache-snapshot-clean.sh" "$STAGE/cache-transaction.sh" "$STAGE/one-pass-scan.sh" "$STAGE/profile-cleaner.sh" "$STAGE/deep-scan-manifest.sh" "$STAGE/deep-manifest-clean.sh" "$STAGE/apk-scanner.sh" "$STAGE/apk-cleaner.sh"
 chmod 0755 "$STAGE/cleaner.sh.compat" "$STAGE/bin/arm64-v8a/baize_engine" "$STAGE/bin/arm64-v8a/baize_deep_snapshot"
-chmod 0755 "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh"
+chmod 0755 "$STAGE/notify.sh" "$STAGE/scheduler.sh" "$STAGE/service.sh" "$STAGE/action.sh" "$STAGE/uninstall.sh"
 chmod 0755 "$STAGE/quarantine-manager.sh" "$STAGE/large-file-scanner.sh" "$STAGE/duplicate-scanner.sh" "$STAGE/storage-analyzer.sh" "$STAGE/diagnostics-export.sh" "$STAGE/app-installer.sh" "$STAGE/supervisor.sh" "$STAGE/autopilot-controller.sh" "$STAGE/worker-runner.sh" "$STAGE/task-worker.sh" "$STAGE/rules-validator.sh" "$STAGE/organizer-worker.sh" "$STAGE/cache-lane-worker.sh"
 
 cp -f "$APK" "$STAGE/app/baize.apk"
@@ -59,6 +60,10 @@ rm -f "$OUTPUT"
 
 unzip -tq "$OUTPUT" >/dev/null
 unzip -l "$OUTPUT" | grep -q 'app/baize.apk'
+unzip -l "$OUTPUT" | grep -q 'uninstall.sh'
+unzip -p "$OUTPUT" uninstall.sh | grep -q 'signal_owned_processes'
+unzip -p "$OUTPUT" uninstall.sh | grep -q 'baize-v2-quarantine-recovery'
+zipinfo -l "$OUTPUT" | grep -Eq '^-rwxr-xr-x.*uninstall\.sh$'
 unzip -l "$OUTPUT" | grep -q 'cleaner.sh'
 unzip -l "$OUTPUT" | grep -q 'native-cleaner.sh'
 unzip -l "$OUTPUT" | grep -q 'cache-snapshot-clean.sh'

--- a/v2/tests/test-uninstall-cleanup.sh
+++ b/v2/tests/test-uninstall-cleanup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "$0")/../.." && pwd)
+T=${TMPDIR:-/tmp}/baize-uninstall-cleanup-test
+rm -rf "$T"
+mkdir -p \
+  "$T/adb/modules/baize_v2" \
+  "$T/adb/modules/safesweep" \
+  "$T/adb/modules_update/baize_v2" \
+  "$T/adb/modules_update/safesweep" \
+  "$T/adb/baize-v2/quarantine/files" \
+  "$T/adb/safesweep" \
+  "$T/media/0/Download" \
+  "$T/bin" \
+  "$T/not-owned"
+
+cp "$ROOT/v2/module/uninstall.sh" "$T/adb/modules/baize_v2/uninstall.sh"
+chmod 0755 "$T/adb/modules/baize_v2/uninstall.sh"
+printf 'legacy\n' >"$T/adb/safesweep/config.conf"
+printf 'new-state\n' >"$T/adb/baize-v2/config.conf"
+printf 'staged\n' >"$T/adb/modules_update/baize_v2/module.prop"
+printf 'staged-old\n' >"$T/adb/modules_update/safesweep/module.prop"
+printf 'old-module\n' >"$T/adb/modules/safesweep/module.prop"
+printf 'keep\n' >"$T/not-owned/file"
+printf 'quarantined-payload\n' >"$T/adb/baize-v2/quarantine/files/q1"
+printf 'q1\t0\t20\t%s\n' "$T/media/0/Download/restored.txt" >"$T/adb/baize-v2/quarantine/index.tsv"
+
+cat >"$T/bin/pm" <<'SH'
+#!/usr/bin/env sh
+printf '%s\n' "$*" >>"$BAIZE_PM_LOG"
+exit 0
+SH
+chmod 0755 "$T/bin/pm"
+
+# Both processes deliberately expose BaiZe-owned paths in cmdline. One recreates
+# the state directory when TERM is received, reproducing the original residue.
+busybox ash -c 'while :; do sleep 1; done' \
+  "$T/adb/modules/baize_v2/worker-runner.sh" &
+worker_pid=$!
+busybox ash -c 'trap '\''mkdir -p "$1"; printf recreated >"$1/recreated"'\'' TERM; while :; do sleep 1; done' \
+  "$T/adb/modules/baize_v2/supervisor.sh" "$T/adb/baize-v2" &
+recreator_pid=$!
+
+cleanup() {
+  kill -KILL "$worker_pid" "$recreator_pid" 2>/dev/null || true
+  rm -rf "$T"
+}
+trap cleanup EXIT
+sleep 1
+
+PATH="$T/bin:$PATH" \
+BAIZE_PM_LOG="$T/pm.log" \
+BAIZE_ADB_ROOT="$T/adb" \
+BAIZE_MEDIA_ROOT="$T/media" \
+BAIZE_RECOVERY_ROOT="$T/media/0/Download/BaiZe恢复" \
+BAIZE_UNINSTALL_WAIT_SECONDS=1 \
+busybox ash "$T/adb/modules/baize_v2/uninstall.sh"
+
+# The uninstall script must survive its own process matching and reach cleanup.
+[ -f "$T/adb/modules/baize_v2/remove" ]
+[ -f "$T/adb/modules/baize_v2/uninstall.sh" ]
+
+# Root manager removes the active module directory on reboot; everything else
+# owned by BaiZe must already be gone before that reboot.
+[ ! -e "$T/adb/baize-v2" ]
+[ ! -e "$T/adb/safesweep" ]
+[ ! -e "$T/adb/modules_update/baize_v2" ]
+[ ! -e "$T/adb/modules_update/safesweep" ]
+[ ! -e "$T/adb/modules/safesweep" ]
+[ -f "$T/not-owned/file" ]
+
+# Quarantined user data must be restored instead of being deleted with state.
+grep -qx 'quarantined-payload' "$T/media/0/Download/restored.txt"
+[ ! -e "$T/adb/baize-v2-quarantine-recovery" ]
+
+# Both normal and user-0 package uninstall paths are attempted.
+grep -qx 'uninstall io.github.xgl34222220.baize' "$T/pm.log"
+grep -qx 'uninstall --user 0 io.github.xgl34222220.baize' "$T/pm.log"
+
+# Workers that previously recreated state must be dead, and the second cleanup
+# pass must have removed anything created by their TERM trap.
+! kill -0 "$worker_pid" 2>/dev/null
+! kill -0 "$recreator_pid" 2>/dev/null
+[ ! -e "$T/adb/baize-v2" ]
+
+# Prevent the original self-termination bug from returning.
+! grep -Eq 'pkill[[:space:]].*-f.*modules/baize_v2' "$ROOT/v2/module/uninstall.sh"
+grep -q 'pid" = "$SELF_PID' "$ROOT/v2/module/uninstall.sh"
+grep -q 'signal_owned_processes TERM' "$ROOT/v2/module/uninstall.sh"
+grep -q 'remove_owned_path "$MODULES_UPDATE_DIR/$MOD_ID"' "$ROOT/v2/module/uninstall.sh"
+
+echo 'complete uninstall cleanup: ok'


### PR DESCRIPTION
修复模块卸载后 `/data/adb` 残留的问题。

根因：旧卸载脚本使用 `pkill -f /data/adb/modules/baize_v2`，会把正在运行的卸载脚本自身杀死，导致后续状态目录删除没有执行。

本次修复：
- 枚举 `/proc` 并跳过卸载脚本自身，不再使用危险的 `pkill -f`。
- 停止调度器、守护进程和所有 Worker 后二次清理，防止进程重建状态目录。
- 删除 `/data/adb/baize-v2`、旧 `/data/adb/safesweep`、新旧 `modules_update` 暂存目录和旧模块目录。
- 卸载 App。
- 卸载前恢复隔离区用户文件；无法恢复时转存到安全恢复目录。
- 保留当前模块目录直到重启，由 Magisk/KernelSU/APatch 按标准 `remove` 标记删除。
- 打包时强制 `uninstall.sh` 可执行并运行动态回归。