### PR TITLE
UI 预览：按统一软件 UI 设计规范重构 WebUI

### DIFF
--- a/.github/workflows/ui-preview-package.yml
+++ b/.github/workflows/ui-preview-package.yml
@@ -1,0 +1,40 @@
+name: Package UI Preview Test
+
+on:
+  push:
+    branches:
+      - ui/unified-design-v1-preview
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout preview branch
+        uses: actions/checkout@v4
+
+      - name: Build flashable module ZIP
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          zip -r "dist/BaiZe-v2.5.5-UI-Preview-Test.zip" . \
+            -x '.git/*' \
+            -x '.github/*' \
+            -x 'dist/*' \
+            -x '*.md' \
+            -x 'docs/*' \
+            -x 'screenshots/*'
+          unzip -l "dist/BaiZe-v2.5.5-UI-Preview-Test.zip" | head -80
+
+      - name: Upload test module
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.5.5-UI-Preview-Test
+          path: dist/BaiZe-v2.5.5-UI-Preview-Test.zip
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7

--- a/.github/workflows/ui-preview-package.yml
+++ b/.github/workflows/ui-preview-package.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - ui/unified-design-v1-preview
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/webroot/style.css
+++ b/webroot/style.css
@@ -1,18 +1,1577 @@
-:root{
-  color-scheme:light dark;--bg:#f2f6fb;--surface:rgba(255,255,255,.90);--surface-strong:#fff;--text:#16202d;--muted:#7a8796;--line:rgba(42,68,99,.085);--blue:#2589f4;--cyan:#31b7d5;--green:#35b781;--violet:#7e73ed;--red:#eb6c68;--amber:#e1a53b;--shadow:0 16px 42px rgba(47,77,113,.085),0 2px 7px rgba(47,77,113,.045);font-family:"MiSans","HarmonyOS Sans SC",system-ui,-apple-system,sans-serif
+:root {
+  color-scheme: light dark;
+  --bg: #ecebfa;
+  --surface: #f8f7fd;
+  --surface-alt: #f2f0fa;
+  --surface-strong: #ffffff;
+  --primary: #245fd3;
+  --primary-strong: #174fbf;
+  --primary-container: #e1ddff;
+  --primary-soft: rgba(36, 95, 211, 0.10);
+  --text: #171923;
+  --muted: #666b7a;
+  --line: rgba(23, 25, 35, 0.08);
+  --success: #0aa45b;
+  --danger: #d83a3a;
+  --warning: #b87300;
+  --violet: #6b5fd7;
+  --cyan: #167fa3;
+  --glass: rgba(248, 247, 253, 0.82);
+  --shadow-1: 0 2px 8px rgba(23, 25, 35, 0.07);
+  --shadow-2: 0 6px 24px rgba(23, 25, 35, 0.11);
+  --radius-chip: 12px;
+  --radius-input: 14px;
+  --radius-group: 18px;
+  --radius-data: 22px;
+  --radius-dock: 32px;
+  --ease-enter: cubic-bezier(0.20, 0.80, 0.20, 1.00);
+  --ease-standard: cubic-bezier(0.20, 0.00, 0.00, 1.00);
+  font-family: "MiSans", "HarmonyOS Sans SC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
-*{box-sizing:border-box;-webkit-tap-highlight-color:transparent}html,body{margin:0;min-height:100%;background:var(--bg);color:var(--text)}body{overflow-x:hidden}button,input,textarea,select{font:inherit;color:inherit}button{border:0;cursor:pointer}svg{width:1em;height:1em;fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}.ambient{position:fixed;z-index:0;border-radius:50%;filter:blur(90px);opacity:.18;pointer-events:none}.ambient-a{width:330px;height:330px;top:-175px;right:-145px;background:#59b7ff}.ambient-b{width:300px;height:300px;left:-185px;bottom:12%;background:#87dfd8}.noise{position:fixed;z-index:0;inset:0;pointer-events:none;opacity:.022;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.8'/%3E%3C/svg%3E")}.shell{position:relative;z-index:1;width:min(100%,680px);margin:0 auto;padding:max(21px,env(safe-area-inset-top)) 16px calc(112px + env(safe-area-inset-bottom))}.page{display:none;animation:page-in .24s cubic-bezier(.2,.8,.2,1) both}.page.active{display:block}@keyframes page-in{from{opacity:0;transform:translateY(7px)}}.surface{position:relative;background:var(--surface);border:1px solid rgba(255,255,255,.82);box-shadow:var(--shadow);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px)}
-.topbar{min-height:55px;display:flex;align-items:center;justify-content:space-between;margin:2px 2px 22px}.topbar.compact{margin-bottom:17px}.brand{display:flex;align-items:center;gap:12px}.brand-mark{width:47px;height:47px;display:grid;place-items:center;border-radius:16px;color:#fff;background:linear-gradient(145deg,#55baff,#217eea);box-shadow:0 10px 24px rgba(33,138,245,.24),inset 0 1px rgba(255,255,255,.35);font-size:20px;font-weight:900}.eyebrow{margin:0 0 4px;color:var(--blue);font-size:8px;font-weight:850;letter-spacing:.17em}h1{margin:0;font-size:27px;line-height:1.05;letter-spacing:-.045em}.icon-button{width:44px;height:44px;display:grid;place-items:center;border-radius:15px;color:var(--blue);background:var(--surface-strong);box-shadow:0 8px 20px rgba(42,73,110,.08);font-size:21px}.icon-button:active{transform:rotate(-18deg) scale(.95)}.pill-button{min-width:70px;height:38px;padding:0 16px;border-radius:13px;color:#fff;background:linear-gradient(135deg,var(--blue),#58b8f6);box-shadow:0 8px 19px rgba(33,138,245,.21);font-size:11px;font-weight:850}.pill-button.ghost{color:var(--blue);background:rgba(33,138,245,.09);box-shadow:none}
-.hero{min-height:195px;display:flex;align-items:center;gap:21px;padding:23px 21px;overflow:hidden;border-radius:29px}.hero-glow{position:absolute;width:220px;height:220px;right:-82px;top:-105px;border-radius:50%;background:radial-gradient(circle,rgba(66,178,255,.23),transparent 68%)}.hero::before{content:"";position:absolute;inset:0;pointer-events:none;background:linear-gradient(125deg,rgba(255,255,255,.26),transparent 44%)}.hero-ring{flex:0 0 119px;height:119px;display:grid;place-items:center;position:relative;border-radius:50%;background:conic-gradient(var(--blue) 0 var(--ring-progress,72%),rgba(33,138,245,.12) var(--ring-progress,72%));box-shadow:0 14px 31px rgba(33,138,245,.16)}.hero-ring::before{content:"";position:absolute;inset:10px;border-radius:inherit;background:var(--surface-strong);box-shadow:inset 0 0 0 1px rgba(33,138,245,.07)}.hero-ring>div{max-width:95px;position:relative;text-align:center}.hero-ring span,.hero-ring small{display:block}.hero-ring span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:19px;font-weight:900;letter-spacing:-.04em}.hero-ring small{margin-top:5px;color:var(--muted);font-size:9px}.hero-copy{min-width:0;position:relative;z-index:1}.device-line{display:flex;align-items:center;color:var(--muted);font-size:10px;font-weight:650}.status-dot{width:8px;height:8px;margin-right:8px;border-radius:50%;background:var(--green);box-shadow:0 0 0 5px rgba(56,185,129,.11)}.hero.running .status-dot{animation:pulse 1.25s infinite}@keyframes pulse{50%{box-shadow:0 0 0 9px rgba(56,185,129,0);transform:scale(.86)}}.hero-copy h2{margin:15px 0 7px;font-size:21px;line-height:1.28;letter-spacing:-.035em}.hero-copy p{margin:0;color:var(--muted);font-size:9px;line-height:1.55}.storage{margin-top:12px;padding:17px 18px;border-radius:22px}.storage-head,.storage-foot{display:flex;align-items:center;justify-content:space-between}.storage-head small,.storage-head strong{display:block}.storage-head small{color:var(--muted);font-size:8px;font-weight:750;letter-spacing:.12em}.storage-head strong{margin-top:5px;font-size:15px}.storage-head>span{color:var(--blue);font-size:18px;font-weight:900}.storage-track{height:8px;margin:14px 0 9px;overflow:hidden;border-radius:10px;background:rgba(109,127,151,.13)}.storage-track i{display:block;width:0;height:100%;border-radius:inherit;background:linear-gradient(90deg,#258df4,#64c9ef);transition:width .55s}.storage-foot{color:var(--muted);font-size:8px}.storage-foot b{color:var(--text);font-weight:750}
-.main-actions{display:grid;grid-template-columns:1.55fr .8fr;gap:10px;margin:13px 0 10px}.main-clean,.scan-only{min-height:77px;display:flex;align-items:center;gap:11px;padding:13px;border-radius:21px;text-align:left}.main-clean{color:#fff;background:linear-gradient(135deg,#1587f7,#55b9f1);box-shadow:0 13px 27px rgba(33,138,245,.23)}.scan-only{background:var(--surface-strong);box-shadow:0 9px 22px rgba(42,73,110,.07)}.main-actions button:active,.row-action:active{transform:translateY(1px) scale(.985)}.main-actions button:disabled,.row-action:disabled,.mini-link:disabled{opacity:.45;filter:grayscale(.25)}.action-icon{width:39px;height:39px;display:grid;place-items:center;flex:0 0 auto;border-radius:13px;background:rgba(255,255,255,.18);font-size:20px}.main-actions strong,.main-actions small{display:block}.main-actions strong{font-size:13px}.main-actions small{margin-top:4px;opacity:.68;font-size:8px;line-height:1.35}.scan-only>svg{flex:0 0 auto;color:var(--blue);font-size:23px}.scan-only span{min-width:0}.arrow{margin-left:auto;opacity:.65;font-size:17px}.stop-strip{width:100%;min-height:47px;display:flex;align-items:center;gap:10px;padding:10px 13px;border:1px solid rgba(239,111,107,.22);border-radius:15px;color:#d75e5a;background:rgba(239,111,107,.075);text-align:left}.stop-strip[hidden]{display:none}.stop-strip svg{font-size:17px}.stop-strip strong,.stop-strip small{display:block}.stop-strip strong{font-size:11px}.stop-strip small{margin-top:3px;color:var(--muted);font-size:8px}
-.section-title{display:flex;align-items:flex-end;justify-content:space-between;margin:25px 3px 10px}.section-title>div small{display:block;margin-bottom:3px;color:var(--blue);font-size:7px;font-weight:850;letter-spacing:.16em}.section-title h3{margin:0;font-size:17px;letter-spacing:-.025em}.section-title>span,.section-title>button{color:var(--muted);font-size:9px}.text-button{padding:5px 3px;color:var(--blue)!important;background:transparent;font-weight:800}.danger-text{color:var(--red)!important}.manual-tools{padding:3px 16px 13px;border-radius:25px}.manual-row{min-height:78px;display:grid;grid-template-columns:39px minmax(0,1fr) auto auto;align-items:center;gap:10px;border-bottom:1px solid var(--line)}.manual-row.deep-row{border-bottom:0}.tool-icon{width:39px;height:39px;display:grid;place-items:center;border-radius:13px;font-size:19px}.tool-icon.green{color:var(--green);background:rgba(56,185,129,.10)}.tool-icon.violet{color:var(--violet);background:rgba(131,116,237,.10)}.tool-icon.red{color:var(--red);background:rgba(239,111,107,.10)}.manual-copy{min-width:0}.manual-copy strong,.manual-copy small{display:block}.manual-copy strong{font-size:13px}.manual-copy small{margin-top:4px;overflow:hidden;color:var(--muted);white-space:nowrap;text-overflow:ellipsis;font-size:8px}.status-badge{padding:5px 7px;border-radius:8px;color:var(--violet);background:rgba(131,116,237,.09);white-space:nowrap;font-size:7px;font-weight:850}.status-badge.risk{color:var(--red);background:rgba(239,111,107,.09)}.mini-link{padding:7px 4px;color:var(--blue);background:transparent;font-size:9px;font-weight:850}.row-action{min-width:61px;height:34px;padding:0 12px;border-radius:11px;color:#fff;font-size:9px;font-weight:850}.row-action.green{background:linear-gradient(135deg,#32b27f,#5ccda4)}.row-action.violet{background:linear-gradient(135deg,#746ae3,#a090f2)}.row-action.red{background:linear-gradient(135deg,#e96764,#f68b79)}.manual-note{margin:4px 2px 0;padding:10px 12px;border-radius:12px;color:#a56e68;background:rgba(239,111,107,.055);font-size:8px;line-height:1.55}.metrics{display:grid;grid-template-columns:repeat(3,1fr);padding:7px;border-radius:23px}.metrics div{min-height:66px;display:flex;flex-direction:column;align-items:center;justify-content:center;border-right:1px solid var(--line);border-bottom:1px solid var(--line)}.metrics div:nth-child(3n){border-right:0}.metrics div:nth-last-child(-n+3){border-bottom:0}.metrics span{font-size:15px;font-weight:900}.metrics small{margin-top:5px;color:var(--muted);font-size:8px}
-.schedule-status{display:flex;align-items:center;gap:12px;padding:14px 16px;border-radius:20px}.schedule-status>span{width:9px;height:9px;border-radius:50%;background:#aeb7c2}.schedule-status strong,.schedule-status small{display:block}.schedule-status strong{font-size:12px}.schedule-status small{margin-top:4px;color:var(--muted);font-size:8px;line-height:1.45}.scheduler-dot.completed{background:var(--green);box-shadow:0 0 0 4px rgba(56,185,129,.13)}.scheduler-dot.running{background:var(--blue);box-shadow:0 0 0 4px rgba(33,138,245,.13)}.scheduler-dot.waiting{background:var(--amber);box-shadow:0 0 0 4px rgba(229,166,55,.13)}.scheduler-dot.failed,.scheduler-dot.interrupted{background:var(--red);box-shadow:0 0 0 4px rgba(239,111,107,.13)}.panel,.compact-panel{padding:3px 16px;border-radius:25px}.feature-row{min-height:70px;display:flex;align-items:center;gap:11px;border-bottom:1px solid var(--line)}.feature-row>span:nth-child(2){min-width:0;flex:1}.feature-row strong,.feature-row small{display:block}.feature-row strong{font-size:13px}.feature-row small{margin-top:4px;color:var(--muted);font-size:8px;line-height:1.45}.feature-icon{width:34px;height:34px;display:grid;place-items:center;flex:0 0 auto;border-radius:11px;font-size:10px;font-weight:900}.feature-icon.blue{color:var(--blue);background:rgba(33,138,245,.09)}.feature-icon.cyan{color:var(--cyan);background:rgba(48,185,213,.10)}.feature-icon.violet{color:var(--violet);background:rgba(131,116,237,.10)}.feature-icon.green{color:var(--green);background:rgba(56,185,129,.10)}.feature-icon.red{color:var(--red);background:rgba(239,111,107,.10)}input[type="checkbox"]{appearance:none;width:44px;height:26px;flex:0 0 auto;padding:3px;border-radius:15px;background:#d8dee6;transition:background .2s}input[type="checkbox"]::after{content:"";display:block;width:20px;height:20px;border-radius:50%;background:#fff;box-shadow:0 2px 7px rgba(0,0,0,.14);transition:transform .2s cubic-bezier(.2,.8,.2,1)}input[type="checkbox"]:checked{background:linear-gradient(135deg,var(--blue),#5abcf7)}input[type="checkbox"]:checked::after{transform:translateX(18px)}input[type="checkbox"].mixed{background:linear-gradient(135deg,#9ba7b5,#bac3cd)}.time-row{min-height:57px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--line);font-size:11px}.time-row>div{display:flex;align-items:center;gap:5px}.time-row input,.interval-grid input,.number-list input{width:55px;height:33px;border:1px solid var(--line);outline:0;border-radius:10px;background:rgba(117,135,158,.065);text-align:center;font-size:11px;font-weight:850}.time-row em,.interval-grid em,.number-list em{color:var(--muted);font-style:normal;font-size:8px}.subheading{display:flex;align-items:flex-end;justify-content:space-between;padding:15px 1px 9px}.subheading span{font-size:10px;font-weight:850}.subheading small{color:var(--muted);font-size:7px}.task-pills{display:grid;grid-template-columns:repeat(3,1fr);gap:7px;padding-bottom:14px}.task-pills label{position:relative}.task-pills input{position:absolute;opacity:0;pointer-events:none}.task-pills span{min-height:35px;display:grid;place-items:center;padding:6px;border:1px solid var(--line);border-radius:11px;color:var(--muted);background:rgba(117,135,158,.035);font-size:8px;font-weight:800;transition:.2s}.task-pills input:checked+span{border-color:rgba(33,138,245,.20);color:var(--blue);background:rgba(33,138,245,.09)}.task-pills .risk-pill input:checked+span{border-color:rgba(239,111,107,.20);color:var(--red);background:rgba(239,111,107,.08)}details{overflow:hidden}.fold{margin:0 -16px;border-top:1px solid var(--line)}.fold summary,.advanced-block>summary,.log-block>summary{list-style:none;cursor:pointer}.fold summary::-webkit-details-marker,.advanced-block>summary::-webkit-details-marker,.log-block>summary::-webkit-details-marker{display:none}.fold summary{min-height:51px;display:grid;grid-template-columns:1fr auto 17px;align-items:center;gap:9px;padding:0 16px}.fold summary span{font-size:10px;font-weight:850}.fold summary small{color:var(--muted);font-size:7px}.fold summary svg,.advanced-block>summary svg,.log-block>summary svg{font-size:15px;transition:transform .2s}.fold[open] summary svg,.advanced-block[open]>summary svg,.log-block[open]>summary svg{transform:rotate(90deg)}.interval-grid{display:grid;grid-template-columns:1fr 1fr;gap:0 15px;padding:0 16px 10px;background:rgba(117,135,158,.025)}.interval-grid label{min-height:51px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--line);font-size:9px}.interval-grid label>div{display:flex;align-items:center;gap:4px}.condition-pills{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;padding:12px 0}.condition-pills label{position:relative}.condition-pills input{position:absolute;opacity:0;pointer-events:none}.condition-pills span{min-height:65px;display:flex;flex-direction:column;align-items:center;justify-content:center;border:1px solid var(--line);border-radius:15px;background:rgba(117,135,158,.035);transition:.2s}.condition-pills b,.condition-pills small{display:block}.condition-pills b{font-size:11px}.condition-pills small{margin-top:5px;color:var(--muted);font-size:7px}.condition-pills input:checked+span{border-color:rgba(33,138,245,.18);color:var(--blue);background:rgba(33,138,245,.08);box-shadow:inset 0 0 0 1px rgba(33,138,245,.025)}.fine-settings{display:grid;grid-template-columns:1fr 1fr;gap:0 14px;padding:0 16px 9px;background:rgba(117,135,158,.025)}.fine-settings label{min-height:51px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--line);font-size:9px}.fine-settings input{width:38px;height:23px}.fine-settings input::after{width:17px;height:17px}.fine-settings input:checked::after{transform:translateX(15px)}.select-panel{min-height:76px;display:flex;align-items:center;gap:13px;padding:13px 16px;border-radius:22px}.select-panel>span{min-width:0;flex:1}.select-panel strong,.select-panel small{display:block}.select-panel strong{font-size:12px}.select-panel small{margin-top:4px;color:var(--muted);font-size:8px}.select-panel select{max-width:137px;height:37px;padding:0 9px;border:1px solid var(--line);outline:0;border-radius:11px;background:rgba(117,135,158,.06);font-size:9px;font-weight:750}.config-store{display:none}
-.advanced-block{margin-top:13px;border-radius:23px}.advanced-block>summary{min-height:69px;display:grid;grid-template-columns:1fr auto 18px;align-items:center;gap:10px;padding:0 17px}.advanced-block>summary span:first-child small,.advanced-block>summary span:first-child strong{display:block}.advanced-block>summary span:first-child small{margin-bottom:4px;color:var(--blue);font-size:7px;font-weight:850;letter-spacing:.14em}.advanced-block>summary span:first-child strong{font-size:12px}.summary-meta{color:var(--muted);font-size:8px}.advanced-content{padding:0 17px 16px;border-top:1px solid var(--line)}.number-list{display:grid;grid-template-columns:1fr 1fr;gap:0 16px}.number-list label{min-height:55px;display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--line);font-size:9px}.number-list label>div{display:flex;align-items:center;gap:4px}.danger-feature{margin-top:10px;border:0;border-radius:15px;padding:0 10px;background:rgba(239,111,107,.055)}.danger-feature strong{color:#d7625e}.editor textarea{width:100%;min-height:125px;margin-top:14px;resize:vertical;border:1px solid var(--line);outline:0;padding:12px;border-radius:14px;background:rgba(117,135,158,.05);font:9px/1.7 ui-monospace,monospace}.editor p{margin:8px 3px 0;color:var(--muted);font-size:8px;line-height:1.5}
-.log-summary{display:flex;align-items:center;justify-content:space-between;padding:17px;border-radius:22px}.log-summary small,.log-summary strong{display:block}.log-summary small{color:var(--muted);font-size:8px}.log-summary strong{margin-top:5px;font-size:12px}.log-summary>span{color:var(--blue);font-size:18px;font-weight:900}.log-block{margin-top:12px;border-radius:22px}.log-block>summary{min-height:61px;display:grid;grid-template-columns:1fr auto 17px;align-items:center;gap:10px;padding:0 16px}.log-block>summary span{font-size:11px;font-weight:850}.log-block>summary small{color:var(--muted);font-size:8px}.log-tools{display:flex;justify-content:flex-end;padding:0 14px 8px}.log-tools button{height:30px;padding:0 11px;border-radius:9px;color:var(--blue);background:rgba(33,138,245,.08);font-size:8px;font-weight:850}.log-view{min-height:390px;margin:0;padding:15px;overflow:auto;border-radius:0 0 21px 21px;color:#cad8e9;background:#151c27;white-space:pre-wrap;word-break:break-all;font:8px/1.75 ui-monospace,monospace}.report-view{min-height:290px}.history-view{min-height:190px}
-.dock{position:fixed;z-index:20;left:50%;bottom:max(14px,env(safe-area-inset-bottom));transform:translateX(-50%);width:min(calc(100% - 32px),430px);height:70px;display:grid;grid-template-columns:repeat(3,1fr);padding:6px;overflow:hidden;border:1px solid rgba(255,255,255,.72);border-radius:25px;background:rgba(255,255,255,.78);box-shadow:0 18px 45px rgba(36,65,99,.16);backdrop-filter:blur(22px) saturate(145%);-webkit-backdrop-filter:blur(22px) saturate(145%)}.dock button{z-index:2;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;background:transparent;color:var(--muted)}.dock button.active{color:var(--blue)}.dock button svg{font-size:19px}.dock button small{font-size:8px;font-weight:800}.dock-indicator{position:absolute;z-index:1;left:6px;top:6px;width:calc((100% - 12px)/3);height:56px;border-radius:19px;background:linear-gradient(145deg,rgba(33,138,245,.13),rgba(74,190,241,.07));box-shadow:inset 0 1px rgba(255,255,255,.45);transition:transform .3s cubic-bezier(.2,.9,.2,1)}.busy{position:fixed;z-index:40;inset:0;display:grid;place-items:center;padding:24px;background:rgba(19,29,42,.22);backdrop-filter:blur(6px)}.busy[hidden]{display:none}.busy-card{width:200px;height:145px;display:flex;flex-direction:column;align-items:center;justify-content:center;border:1px solid rgba(255,255,255,.75);border-radius:26px;background:var(--surface);box-shadow:0 20px 50px rgba(23,42,66,.18)}.busy-card strong{margin-top:13px;font-size:13px}.busy-card small{margin-top:5px;color:var(--muted);font-size:8px}.spinner{width:33px;height:33px;border:3px solid rgba(33,138,245,.14);border-top-color:var(--blue);border-radius:50%;animation:spin .75s linear infinite}@keyframes spin{to{transform:rotate(360deg)}}.snackbar{position:fixed;z-index:50;left:50%;bottom:calc(98px + env(safe-area-inset-bottom));transform:translate(-50%,14px);max-width:calc(100% - 34px);padding:10px 15px;overflow:hidden;border-radius:12px;color:#fff;background:rgba(21,29,40,.93);box-shadow:0 10px 30px rgba(15,25,38,.2);opacity:0;pointer-events:none;transition:.2s;white-space:nowrap;text-overflow:ellipsis;font-size:10px}.snackbar.show{opacity:1;transform:translate(-50%,0)}
-@media(max-width:430px){.manual-row{grid-template-columns:36px minmax(0,1fr) auto auto}.manual-row .status-badge{display:none}.task-pills{grid-template-columns:repeat(2,1fr)}.number-list{grid-template-columns:1fr}.fine-settings{grid-template-columns:1fr}.interval-grid{grid-template-columns:1fr}.select-panel{align-items:flex-start;flex-direction:column}.select-panel select{width:100%;max-width:none}.main-actions{grid-template-columns:1.45fr .8fr}}
-@media(max-width:370px){.shell{padding-left:12px;padding-right:12px}.hero{gap:13px;padding:19px 14px}.hero-ring{flex-basis:104px;height:104px}.hero-copy h2{font-size:18px}.main-clean .action-icon{display:none}.manual-row{grid-template-columns:34px minmax(0,1fr) auto}.mini-link{display:none}.row-action{min-width:57px}.condition-pills{gap:5px}}
-@media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;transition-duration:.01ms!important}}
-@media(prefers-color-scheme:dark){:root{--bg:#0f141b;--surface:rgba(29,36,46,.94);--surface-strong:#202833;--text:#f2f5f8;--muted:#929dab;--line:rgba(255,255,255,.075);--shadow:0 18px 44px rgba(0,0,0,.24)}.surface{border-color:rgba(255,255,255,.07)}input[type="checkbox"]{background:#46515f}.dock{border-color:rgba(255,255,255,.08);background:rgba(27,34,44,.82);box-shadow:0 18px 45px rgba(0,0,0,.35)}select{color-scheme:dark}.manual-note{color:#d29b94}}
-.pill-button.dirty{box-shadow:0 8px 22px rgba(33,138,245,.28);transform:translateY(-1px)}
-.log-tools{gap:7px}.log-view{font-size:9px}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body {
+  min-height: 100%;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  overflow-x: hidden;
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+  color: inherit;
+}
+
+button,
+summary,
+label,
+select {
+  touch-action: manipulation;
+}
+
+button {
+  border: 0;
+  cursor: pointer;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+summary:focus-visible {
+  outline: 3px solid rgba(36, 95, 211, 0.22);
+  outline-offset: 2px;
+}
+
+svg {
+  width: 1em;
+  height: 1em;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.ambient,
+.noise {
+  display: none;
+}
+
+.shell {
+  position: relative;
+  width: min(100%, 720px);
+  margin: 0 auto;
+  padding: max(20px, env(safe-area-inset-top)) 12px calc(96px + env(safe-area-inset-bottom));
+}
+
+.page {
+  display: none;
+  animation: page-in 240ms var(--ease-enter) both;
+}
+
+.page.active {
+  display: block;
+}
+
+@keyframes page-in {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+}
+
+.surface {
+  position: relative;
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow-1);
+}
+
+.topbar {
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 2px 18px;
+}
+
+.topbar.compact {
+  margin-bottom: 14px;
+}
+
+.brand {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand-mark {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border-radius: 16px;
+  color: #fff;
+  background: var(--primary);
+  box-shadow: var(--shadow-1);
+  font-size: 20px;
+  font-weight: 800;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--primary);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(26px, 7vw, 30px);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+  font-weight: 750;
+}
+
+.icon-button {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border-radius: 16px;
+  color: var(--primary);
+  background: var(--surface);
+  box-shadow: var(--shadow-1);
+  font-size: 22px;
+  transition: background 100ms, transform 100ms;
+}
+
+.icon-button:active {
+  background: var(--primary-container);
+  transform: scale(0.98);
+}
+
+.pill-button {
+  min-width: 72px;
+  height: 44px;
+  padding: 0 18px;
+  border-radius: var(--radius-input);
+  color: #fff;
+  background: var(--primary);
+  box-shadow: var(--shadow-1);
+  font-size: 13px;
+  font-weight: 700;
+  transition: background 100ms, transform 100ms;
+}
+
+.pill-button:active {
+  background: var(--primary-strong);
+  transform: scale(0.98);
+}
+
+.pill-button.ghost {
+  color: var(--primary);
+  background: var(--primary-soft);
+  box-shadow: none;
+}
+
+.hero {
+  min-height: 184px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 22px 20px;
+  overflow: hidden;
+  border-radius: var(--radius-data);
+  background: linear-gradient(135deg, var(--primary-container), var(--surface));
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  width: 150px;
+  height: 150px;
+  right: -55px;
+  top: -62px;
+  border-radius: 50%;
+  background: rgba(36, 95, 211, 0.08);
+  pointer-events: none;
+}
+
+.hero-glow {
+  display: none;
+}
+
+.hero-ring {
+  --ring-progress: 72%;
+  position: relative;
+  width: 118px;
+  height: 118px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 118px;
+  border-radius: 50%;
+  background: conic-gradient(var(--primary) 0 var(--ring-progress), rgba(36, 95, 211, 0.12) var(--ring-progress));
+}
+
+.hero-ring::before {
+  content: "";
+  position: absolute;
+  inset: 10px;
+  border-radius: inherit;
+  background: var(--surface-strong);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.hero-ring > div {
+  position: relative;
+  z-index: 1;
+  max-width: 92px;
+  text-align: center;
+}
+
+.hero-ring span,
+.hero-ring small {
+  display: block;
+}
+
+.hero-ring span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 20px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.03em;
+}
+
+.hero-ring small {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 1;
+  min-width: 0;
+}
+
+.device-line {
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 550;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow: 0 0 0 5px rgba(10, 164, 91, 0.12);
+}
+
+.hero.running .status-dot {
+  animation: pulse 1.25s infinite;
+}
+
+@keyframes pulse {
+  50% {
+    box-shadow: 0 0 0 9px rgba(10, 164, 91, 0);
+  }
+}
+
+.hero-copy h2 {
+  margin: 14px 0 7px;
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.025em;
+  font-weight: 750;
+}
+
+.hero-copy p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.storage {
+  margin-top: 8px;
+  padding: 16px;
+  border-radius: var(--radius-group);
+}
+
+.storage-head,
+.storage-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.storage-head small,
+.storage-head strong {
+  display: block;
+}
+
+.storage-head small {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+}
+
+.storage-head strong {
+  margin-top: 3px;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.storage-head > span {
+  color: var(--primary);
+  font-size: 20px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.storage-track {
+  height: 8px;
+  margin: 14px 0 9px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(102, 107, 122, 0.12);
+}
+
+.storage-track i {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--primary);
+  transition: width 420ms var(--ease-standard);
+}
+
+.storage-foot {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.storage-foot b {
+  color: var(--text);
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+.main-actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin: 12px 0 8px;
+}
+
+.main-clean,
+.scan-only {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-group);
+  text-align: left;
+  transition: filter 100ms, transform 100ms;
+}
+
+.main-clean {
+  color: #fff;
+  background: var(--primary);
+  box-shadow: var(--shadow-1);
+}
+
+.scan-only {
+  color: var(--text);
+  background: var(--surface);
+  box-shadow: var(--shadow-1);
+}
+
+.main-actions button:active,
+.row-action:active {
+  filter: brightness(0.96);
+  transform: scale(0.98);
+}
+
+.main-actions button:disabled,
+.row-action:disabled,
+.mini-link:disabled {
+  opacity: 0.42;
+  cursor: default;
+}
+
+.action-icon {
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.16);
+  font-size: 22px;
+}
+
+.main-actions strong,
+.main-actions small {
+  display: block;
+}
+
+.main-actions strong {
+  font-size: 15px;
+  font-weight: 750;
+}
+
+.main-actions small {
+  margin-top: 3px;
+  opacity: 0.78;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.arrow {
+  margin-left: auto;
+  opacity: 0.72;
+  font-size: 19px;
+}
+
+.stop-strip {
+  width: 100%;
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border: 1px solid rgba(216, 58, 58, 0.18);
+  border-radius: var(--radius-input);
+  color: var(--danger);
+  background: rgba(216, 58, 58, 0.08);
+  text-align: left;
+}
+
+.stop-strip[hidden] {
+  display: none;
+}
+
+.stop-strip svg {
+  flex: 0 0 auto;
+  font-size: 19px;
+}
+
+.stop-strip strong,
+.stop-strip small {
+  display: block;
+}
+
+.stop-strip strong {
+  font-size: 13px;
+}
+
+.stop-strip small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.section-title {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 24px 4px 8px;
+}
+
+.section-title > div small {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--primary);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+}
+
+.section-title h3 {
+  margin: 0;
+  font-size: 18px;
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.section-title > span,
+.section-title > button {
+  max-width: 48%;
+  color: var(--muted);
+  font-size: 11px;
+  text-align: right;
+}
+
+.text-button {
+  min-height: 40px;
+  padding: 0 6px;
+  color: var(--primary) !important;
+  background: transparent;
+  font-weight: 700;
+}
+
+.danger-text {
+  color: var(--danger) !important;
+}
+
+.manual-tools,
+.panel,
+.compact-panel {
+  padding: 0 14px;
+  border-radius: var(--radius-group);
+}
+
+.manual-row {
+  min-height: 72px;
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.manual-row.deep-row {
+  border-bottom: 0;
+}
+
+.tool-icon,
+.feature-icon {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  border-radius: 12px;
+  font-weight: 750;
+}
+
+.tool-icon {
+  width: 40px;
+  height: 40px;
+  font-size: 20px;
+}
+
+.feature-icon {
+  width: 36px;
+  height: 36px;
+  font-size: 11px;
+}
+
+.tool-icon.green,
+.feature-icon.green {
+  color: var(--success);
+  background: rgba(10, 164, 91, 0.10);
+}
+
+.tool-icon.violet,
+.feature-icon.violet {
+  color: var(--violet);
+  background: rgba(107, 95, 215, 0.10);
+}
+
+.tool-icon.red,
+.feature-icon.red {
+  color: var(--danger);
+  background: rgba(216, 58, 58, 0.10);
+}
+
+.feature-icon.blue {
+  color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.feature-icon.cyan {
+  color: var(--cyan);
+  background: rgba(22, 127, 163, 0.10);
+}
+
+.manual-copy {
+  min-width: 0;
+}
+
+.manual-copy strong,
+.manual-copy small {
+  display: block;
+}
+
+.manual-copy strong {
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.manual-copy small {
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--muted);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 11px;
+}
+
+.status-badge {
+  padding: 5px 7px;
+  border-radius: 10px;
+  color: var(--violet);
+  background: rgba(107, 95, 215, 0.10);
+  white-space: nowrap;
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.status-badge.risk {
+  color: var(--danger);
+  background: rgba(216, 58, 58, 0.09);
+}
+
+.mini-link {
+  min-width: 42px;
+  min-height: 40px;
+  padding: 0 4px;
+  color: var(--primary);
+  background: transparent;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.row-action {
+  min-width: 62px;
+  height: 36px;
+  padding: 0 12px;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.row-action.green {
+  background: var(--success);
+}
+
+.row-action.violet {
+  background: var(--violet);
+}
+
+.row-action.red {
+  background: var(--danger);
+}
+
+.manual-note {
+  margin: 4px 0 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: #985252;
+  background: rgba(216, 58, 58, 0.07);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 6px;
+  border-radius: var(--radius-group);
+}
+
+.metrics div {
+  min-height: 68px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.metrics div:nth-child(3n) {
+  border-right: 0;
+}
+
+.metrics div:nth-last-child(-n + 3) {
+  border-bottom: 0;
+}
+
+.metrics span {
+  font-size: 17px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.metrics small {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.schedule-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--radius-group);
+}
+
+.schedule-status > span {
+  width: 10px;
+  height: 10px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: rgba(102, 107, 122, 0.45);
+}
+
+.schedule-status strong,
+.schedule-status small {
+  display: block;
+}
+
+.schedule-status strong {
+  font-size: 14px;
+}
+
+.schedule-status small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+#scheduler-dot.completed,
+.scheduler-dot.completed {
+  background: var(--success);
+  box-shadow: 0 0 0 4px rgba(10, 164, 91, 0.12);
+}
+
+#scheduler-dot.running,
+.scheduler-dot.running {
+  background: var(--primary);
+  box-shadow: 0 0 0 4px rgba(36, 95, 211, 0.12);
+}
+
+#scheduler-dot.waiting,
+.scheduler-dot.waiting {
+  background: var(--warning);
+  box-shadow: 0 0 0 4px rgba(184, 115, 0, 0.12);
+}
+
+#scheduler-dot.failed,
+#scheduler-dot.interrupted,
+.scheduler-dot.failed,
+.scheduler-dot.interrupted {
+  background: var(--danger);
+  box-shadow: 0 0 0 4px rgba(216, 58, 58, 0.12);
+}
+
+.feature-row {
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.feature-row:last-child {
+  border-bottom: 0;
+}
+
+.feature-row > span:nth-child(2) {
+  min-width: 0;
+  flex: 1;
+}
+
+.feature-row strong,
+.feature-row small {
+  display: block;
+}
+
+.feature-row strong {
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.feature-row small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+input[type="checkbox"] {
+  appearance: none;
+  width: 50px;
+  height: 30px;
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 3px;
+  border-radius: 999px;
+  background: rgba(102, 107, 122, 0.22);
+  transition: background 180ms var(--ease-standard);
+}
+
+input[type="checkbox"]::after {
+  content: "";
+  display: block;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 2px 6px rgba(23, 25, 35, 0.18);
+  transition: transform 180ms var(--ease-standard);
+}
+
+input[type="checkbox"]:checked {
+  background: var(--primary);
+}
+
+input[type="checkbox"]:checked::after {
+  transform: translateX(20px);
+}
+
+input[type="checkbox"].mixed {
+  background: rgba(102, 107, 122, 0.55);
+}
+
+.time-row {
+  min-height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--line);
+  font-size: 13px;
+}
+
+.time-row > div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.time-row input,
+.interval-grid input,
+.number-list input {
+  width: 60px;
+  height: 40px;
+  border: 1px solid transparent;
+  outline: 0;
+  border-radius: var(--radius-input);
+  background: var(--surface-alt);
+  text-align: center;
+  font-size: 13px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.time-row input:focus,
+.interval-grid input:focus,
+.number-list input:focus {
+  border-color: rgba(36, 95, 211, 0.45);
+  background: var(--primary-container);
+}
+
+.time-row em,
+.interval-grid em,
+.number-list em {
+  color: var(--muted);
+  font-style: normal;
+  font-size: 11px;
+}
+
+.subheading {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 0 8px;
+}
+
+.subheading span {
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.subheading small {
+  color: var(--muted);
+  font-size: 10px;
+  text-align: right;
+}
+
+.task-pills {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding-bottom: 14px;
+}
+
+.task-pills label {
+  position: relative;
+  min-width: 0;
+}
+
+.task-pills input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.task-pills span {
+  min-height: 36px;
+  display: grid;
+  place-items: center;
+  padding: 0 8px;
+  border-radius: 12px;
+  color: var(--muted);
+  background: var(--surface-alt);
+  font-size: 11px;
+  font-weight: 650;
+  text-align: center;
+}
+
+.task-pills input:checked + span {
+  color: var(--primary);
+  background: var(--primary-container);
+}
+
+.task-pills .risk-pill input:checked + span {
+  color: var(--danger);
+  background: rgba(216, 58, 58, 0.09);
+}
+
+.fold {
+  border-top: 1px solid var(--line);
+}
+
+.fold summary,
+.advanced-block > summary,
+.log-block > summary {
+  min-height: 56px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  list-style: none;
+  cursor: pointer;
+}
+
+.fold summary::-webkit-details-marker,
+.advanced-block > summary::-webkit-details-marker,
+.log-block > summary::-webkit-details-marker {
+  display: none;
+}
+
+.fold summary > span,
+.advanced-block > summary > span:first-child,
+.log-block > summary > span {
+  min-width: 0;
+  flex: 1;
+  font-weight: 650;
+}
+
+.fold summary > small,
+.summary-meta,
+.log-block > summary small {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.fold summary svg,
+.advanced-block > summary svg,
+.log-block > summary svg {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 18px;
+  transition: transform 180ms var(--ease-standard);
+}
+
+.fold[open] summary svg,
+.advanced-block[open] > summary svg,
+.log-block[open] > summary svg {
+  transform: rotate(90deg);
+}
+
+.interval-grid,
+.number-list {
+  display: grid;
+  gap: 0;
+  padding-bottom: 12px;
+}
+
+.interval-grid label,
+.number-list label,
+.fine-settings label {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid var(--line);
+  font-size: 12px;
+}
+
+.interval-grid label > div,
+.number-list label > div {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.condition-pills {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.condition-pills label {
+  position: relative;
+}
+
+.condition-pills input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.condition-pills > label > span {
+  min-height: 68px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border-radius: 14px;
+  background: var(--surface-alt);
+  text-align: center;
+}
+
+.condition-pills b,
+.condition-pills small {
+  display: block;
+}
+
+.condition-pills b {
+  font-size: 13px;
+}
+
+.condition-pills small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.condition-pills input:checked + span {
+  color: var(--primary);
+  background: var(--primary-container);
+}
+
+.fine-settings {
+  padding-bottom: 8px;
+}
+
+.fine-settings label input[type="checkbox"] {
+  width: 44px;
+  height: 26px;
+}
+
+.fine-settings label input[type="checkbox"]::after {
+  width: 20px;
+  height: 20px;
+}
+
+.fine-settings label input[type="checkbox"]:checked::after {
+  transform: translateX(18px);
+}
+
+.select-panel {
+  min-height: 68px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-group);
+}
+
+.select-panel > span {
+  min-width: 0;
+  flex: 1;
+}
+
+.select-panel strong,
+.select-panel small {
+  display: block;
+}
+
+.select-panel strong {
+  font-size: 14px;
+}
+
+.select-panel small {
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.select-panel select {
+  max-width: 46%;
+  min-height: 40px;
+  border: 0;
+  outline: 0;
+  border-radius: var(--radius-input);
+  color: var(--primary);
+  background: var(--primary-container);
+  padding: 0 32px 0 12px;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.config-store {
+  display: none;
+}
+
+.advanced-block,
+.log-block {
+  margin-top: 8px;
+  padding: 0 14px;
+  border-radius: var(--radius-group);
+}
+
+.advanced-block > summary > span:first-child small,
+.advanced-block > summary > span:first-child strong {
+  display: block;
+}
+
+.advanced-block > summary > span:first-child small {
+  margin-bottom: 3px;
+  color: var(--primary);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+}
+
+.advanced-block > summary > span:first-child strong {
+  font-size: 14px;
+}
+
+.advanced-content {
+  border-top: 1px solid var(--line);
+  padding-bottom: 12px;
+}
+
+.number-list.two-columns {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0 14px;
+}
+
+.danger-feature {
+  margin-top: 4px;
+  border-top: 1px solid var(--line);
+  border-bottom: 0;
+}
+
+.editor textarea {
+  width: 100%;
+  min-height: 180px;
+  resize: vertical;
+  margin-top: 12px;
+  padding: 14px;
+  border: 1px solid transparent;
+  outline: 0;
+  border-radius: var(--radius-input);
+  background: var(--surface-alt);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.editor textarea:focus {
+  border-color: rgba(36, 95, 211, 0.45);
+  background: var(--primary-container);
+}
+
+.editor p {
+  margin: 8px 2px 0;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.5;
+}
+
+.log-summary {
+  min-height: 78px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-radius: var(--radius-data);
+  background: linear-gradient(135deg, var(--primary-container), var(--surface));
+}
+
+.log-summary small,
+.log-summary strong {
+  display: block;
+}
+
+.log-summary small {
+  color: var(--muted);
+  font-size: 10px;
+}
+
+.log-summary strong {
+  margin-top: 4px;
+  font-size: 16px;
+}
+
+.log-summary > span {
+  color: var(--primary);
+  font-size: 22px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.log-block > summary {
+  border-bottom: 0 solid var(--line);
+}
+
+.log-block[open] > summary {
+  border-bottom-width: 1px;
+}
+
+.log-tools {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 0;
+}
+
+.log-tools button {
+  min-height: 36px;
+  padding: 0 12px;
+  border-radius: 12px;
+  color: var(--primary);
+  background: var(--primary-soft);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.log-view {
+  max-height: 360px;
+  overflow: auto;
+  margin: 0 0 14px;
+  padding: 12px;
+  border-radius: var(--radius-input);
+  color: var(--text);
+  background: var(--surface-alt);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 10px;
+  line-height: 1.6;
+}
+
+.dock {
+  position: fixed;
+  z-index: 40;
+  left: 50%;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  width: min(calc(100% - 28px), 500px);
+  height: 64px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  padding: 7px;
+  transform: translateX(-50%);
+  border: 1px solid rgba(255, 255, 255, 0.86);
+  border-radius: var(--radius-dock);
+  background: var(--glass);
+  box-shadow: var(--shadow-2);
+  backdrop-filter: blur(24px) saturate(1.15);
+  -webkit-backdrop-filter: blur(24px) saturate(1.15);
+}
+
+.dock-indicator {
+  display: none;
+}
+
+.dock button {
+  min-width: 0;
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 10px;
+  border-radius: 24px;
+  color: rgba(23, 25, 35, 0.72);
+  background: transparent;
+  transition: color 180ms var(--ease-standard), background 180ms var(--ease-standard), transform 100ms;
+}
+
+.dock button svg {
+  flex: 0 0 auto;
+  font-size: 22px;
+}
+
+.dock button small {
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.dock button.active {
+  color: var(--primary);
+  background: var(--primary-container);
+}
+
+.dock button:active {
+  transform: scale(0.98);
+}
+
+.busy {
+  position: fixed;
+  z-index: 80;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(17, 19, 26, 0.30);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+}
+
+.busy[hidden] {
+  display: none;
+}
+
+.busy-card {
+  width: min(100%, 320px);
+  min-height: 170px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.74);
+  border-radius: 28px;
+  background: var(--surface);
+  box-shadow: var(--shadow-2);
+  text-align: center;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  margin-bottom: 16px;
+  border: 4px solid rgba(36, 95, 211, 0.14);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 850ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.busy-card strong,
+.busy-card small {
+  display: block;
+}
+
+.busy-card strong {
+  font-size: 16px;
+}
+
+.busy-card small {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.snackbar {
+  position: fixed;
+  z-index: 90;
+  left: 50%;
+  bottom: calc(86px + env(safe-area-inset-bottom));
+  max-width: calc(100% - 32px);
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  padding: 10px 16px;
+  transform: translate(-50%, 16px);
+  border: 1px solid rgba(255, 255, 255, 0.68);
+  border-radius: 16px;
+  color: var(--text);
+  background: var(--surface);
+  box-shadow: var(--shadow-2);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 180ms var(--ease-standard), transform 180ms var(--ease-standard);
+  font-size: 12px;
+  text-align: center;
+}
+
+.snackbar.show,
+.snackbar.visible,
+.snackbar.active {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+@media (max-width: 359px) {
+  .shell {
+    padding-right: 8px;
+    padding-left: 8px;
+  }
+
+  .hero {
+    gap: 14px;
+    padding: 18px 14px;
+  }
+
+  .hero-ring {
+    width: 104px;
+    height: 104px;
+    flex-basis: 104px;
+  }
+
+  .manual-row {
+    grid-template-columns: 38px minmax(0, 1fr) auto;
+  }
+
+  .manual-row .status-badge,
+  .manual-row .mini-link {
+    display: none;
+  }
+
+  .task-pills,
+  .condition-pills {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .number-list.two-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .dock button small {
+    font-size: 10px;
+  }
+}
+
+@media (min-width: 600px) {
+  .shell {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
+
+  .main-actions {
+    grid-template-columns: minmax(0, 1.45fr) minmax(0, 0.75fr);
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #11131a;
+    --surface: #1b1e28;
+    --surface-alt: #252937;
+    --surface-strong: #202430;
+    --primary: #8eafff;
+    --primary-strong: #a9c2ff;
+    --primary-container: #293b68;
+    --primary-soft: rgba(142, 175, 255, 0.13);
+    --text: #f2f4f8;
+    --muted: #b9beca;
+    --line: rgba(255, 255, 255, 0.09);
+    --success: #46cf8d;
+    --danger: #ff8585;
+    --warning: #e8b45d;
+    --violet: #b5a9ff;
+    --cyan: #75cde7;
+    --glass: rgba(27, 30, 40, 0.82);
+    --shadow-1: 0 2px 8px rgba(0, 0, 0, 0.18);
+    --shadow-2: 0 6px 24px rgba(0, 0, 0, 0.30);
+  }
+
+  .surface,
+  .busy-card,
+  .dock,
+  .snackbar {
+    border-color: rgba(255, 255, 255, 0.09);
+  }
+
+  .hero,
+  .log-summary {
+    background: linear-gradient(135deg, var(--primary-container), var(--surface));
+  }
+
+  .dock button {
+    color: rgba(242, 244, 248, 0.74);
+  }
+
+  .manual-note {
+    color: #f0aaaa;
+  }
+
+  .select-panel select {
+    color: var(--primary);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 1ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 1ms !important;
+  }
+}


### PR DESCRIPTION
## 这次改了什么

按《统一软件 UI 设计规范 V1.0》对白泽 WebUI 做第一版视觉重构，仅替换 `webroot/style.css`，不改业务逻辑、元素 ID、事件绑定和清理流程。

- 浅紫灰页面背景与低对比分组卡片
- 18–22px 大圆角层级体系
- #245FD3 主色与语义化成功/危险/警告色
- 首页状态卡、存储卡、主清理按钮重新排版
- 专项工具与累计数据统一为系统设置式分组
- 计划页开关、Chip、输入框、折叠区统一组件皮肤
- 记录页、加载层、Snackbar 统一反馈样式
- 64px 悬浮玻璃底栏，24px 模糊与细描边
- 自动深色模式、小屏/大屏响应式适配
- 支持系统“减少动画”设置

## 设计边界

这次先做可直接运行的视觉预览，不修改 HTML 信息架构和 JavaScript。确认整体方向后，再继续做主题切换、Monet 动态取色、右侧滑入式二级页面等结构升级。