### PR TITLE
feat: 全量重构 UI 并修复安装包扫描与保留时间

### DIFF
--- a/.github/workflows/native-ui-preview-apk.yml
+++ b/.github/workflows/native-ui-preview-apk.yml
@@ -1,0 +1,62 @@
+name: Build Native UI Preview APK
+
+on:
+  push:
+    branches:
+      - ui/native-unified-design-v1-test
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'v2/app/**'
+      - '.github/workflows/native-ui-preview-apk.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: baize-native-ui-preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout preview branch
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform
+        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Compile and assemble debug APK
+        working-directory: v2
+        shell: bash
+        run: |
+          set -euo pipefail
+          gradle --no-daemon :app:compileDebugKotlin :app:assembleDebug
+          test -f app/build/outputs/apk/debug/app-debug.apk
+          cp app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/BaiZe-v2.5.5-Native-UI-Preview.apk
+
+      - name: Upload native UI preview APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-v2.5.5-Native-UI-Preview-APK
+          path: v2/app/build/outputs/apk/debug/BaiZe-v2.5.5-Native-UI-Preview.apk
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/appearance/AppearanceSettings.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/appearance/AppearanceSettings.kt
@@ -55,15 +55,18 @@ data class AccentOption(
     val argb: Int
 )
 
-// 低饱和高级色为主，保留「白泽蓝」「霞光橘」两个较饱和选项给喜欢鲜艳的用户。
+/**
+ * 默认使用规范主色 #245FD3；动态取色不可用或对比不足时回退到该颜色。
+ * 其余低饱和色保留为手动主题选项。
+ */
 val AccentOptions = listOf(
-    AccentOption("default", "雾蓝", 0xFF7C93AB.toInt()),
+    AccentOption("default", "白泽蓝", 0xFF245FD3.toInt()),
+    AccentOption("mist", "雾蓝", 0xFF7C93AB.toInt()),
     AccentOption("sage", "鼠尾草绿", 0xFF8FA98F.toInt()),
     AccentOption("sand", "暖沙", 0xFFC2AE8B.toInt()),
     AccentOption("terracotta", "陶土", 0xFFBE8A72.toInt()),
     AccentOption("mauve", "雾霾紫", 0xFFA494B8.toInt()),
     AccentOption("slate", "岩青", 0xFF7FA3A8.toInt()),
-    AccentOption("azure", "白泽蓝", 0xFF3975F4.toInt()),
     AccentOption("amber", "霞光橘", 0xFFD98E4A.toInt())
 )
 
@@ -76,7 +79,8 @@ data class AppearanceSettings(
     val themeMode: ThemeMode = ThemeMode.SYSTEM,
     val seedArgb: Int = AccentOptions.first().argb,
     val kolorStyle: KolorStyle = KolorStyle.SOFT,
-    val monetEnabled: Boolean = false,
+    /** Android 12+ 默认启用 Monet；旧系统自动使用白泽蓝。 */
+    val monetEnabled: Boolean = true,
     val amoledBlack: Boolean = false,
     val blurEnabled: Boolean = true,
     val glassEnabled: Boolean = true,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanContract.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanContract.kt
@@ -95,7 +95,8 @@ data class CleanUiActions(
     val onFileOrganizer: () -> Unit,
     val onDeepClean: () -> Unit,
     val onCorpses: () -> Unit,
-    val onAudit: () -> Unit
+    val onAudit: () -> Unit,
+    val onApkPackageDaysChanged: (Int) -> Unit = {}
 )
 
 fun SchedulerUiState.toCleanUiState(
@@ -201,6 +202,9 @@ fun SchedulerUiState.withDailyTime(hour: Int, minute: Int): SchedulerUiState =
 
 fun SchedulerUiState.withDailyGrace(minutes: Int): SchedulerUiState =
     copy(dailyGraceMinutes = minutes.coerceIn(15, 720))
+
+fun SchedulerUiState.withApkPackageDays(days: Int): SchedulerUiState =
+    copy(apkPackageDays = days.coerceIn(0, 365))
 
 internal fun formatHours(hours: Int): String = when {
     hours % 24 == 0 -> "${hours / 24} 天"

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
@@ -11,8 +11,9 @@ import io.github.xgl34222220.baize.InstantCacheActivity
 import io.github.xgl34222220.baize.ScanWorkbenchActivity
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
-import io.github.xgl34222220.baize.ui.clean.material.CleanScreenMaterial
 import io.github.xgl34222220.baize.ui.clean.miuix.VideoCleanScreenMiuix
+import io.github.xgl34222220.baize.ui.miuix.ProvideVideoSkin
+import io.github.xgl34222220.baize.ui.miuix.VideoSkin
 
 @Composable
 fun CleanRoute(
@@ -68,14 +69,12 @@ fun CleanRoute(
         onAudit = dashboardActions.audit
     )
 
-    when (style) {
-        UiStyle.MATERIAL -> CleanScreenMaterial(
-            state = state,
-            actions = actions,
-            expandedCategory = expandedCategory,
-            onExpandedCategoryChanged = onExpandedCategoryChanged
-        )
-        UiStyle.MIUIX -> VideoCleanScreenMiuix(
+    val skin = when (style) {
+        UiStyle.MATERIAL -> VideoSkin.MATERIAL3
+        UiStyle.MIUIX -> VideoSkin.MIUIX
+    }
+    ProvideVideoSkin(skin) {
+        VideoCleanScreenMiuix(
             state = state,
             actions = actions,
             expandedCategory = expandedCategory,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
@@ -66,7 +66,10 @@ fun CleanRoute(
         onFileOrganizer = { context.startActivity(Intent(context, FileOrganizerActivity::class.java)) },
         onDeepClean = dashboardActions.deep,
         onCorpses = dashboardActions.corpses,
-        onAudit = dashboardActions.audit
+        onAudit = dashboardActions.audit,
+        onApkPackageDaysChanged = { days ->
+            applyAndSave(scheduler.withApkPackageDays(days))
+        }
     )
 
     val skin = when (style) {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanRoute.kt
@@ -12,7 +12,7 @@ import io.github.xgl34222220.baize.ScanWorkbenchActivity
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.clean.material.CleanScreenMaterial
-import io.github.xgl34222220.baize.ui.clean.miuix.CleanScreenMiuix
+import io.github.xgl34222220.baize.ui.clean.miuix.VideoCleanScreenMiuix
 
 @Composable
 fun CleanRoute(
@@ -75,7 +75,7 @@ fun CleanRoute(
             expandedCategory = expandedCategory,
             onExpandedCategoryChanged = onExpandedCategoryChanged
         )
-        UiStyle.MIUIX -> CleanScreenMiuix(
+        UiStyle.MIUIX -> VideoCleanScreenMiuix(
             state = state,
             actions = actions,
             expandedCategory = expandedCategory,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/VideoCleanScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/VideoCleanScreenMiuix.kt
@@ -1,0 +1,532 @@
+package io.github.xgl34222220.baize.ui.clean.miuix
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AutoAwesome
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.FolderCopy
+import androidx.compose.material.icons.rounded.FolderDelete
+import androidx.compose.material.icons.rounded.InstallMobile
+import androidx.compose.material.icons.rounded.Rule
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.clean.CleanCategoryId
+import io.github.xgl34222220.baize.ui.clean.CleanCategoryUiItem
+import io.github.xgl34222220.baize.ui.clean.CleanScheduleMode
+import io.github.xgl34222220.baize.ui.clean.CleanUiActions
+import io.github.xgl34222220.baize.ui.clean.CleanUiState
+import io.github.xgl34222220.baize.ui.clean.IntValueDialog
+import io.github.xgl34222220.baize.ui.clean.TimeValueDialog
+import io.github.xgl34222220.baize.ui.clean.formatMinutes
+import io.github.xgl34222220.baize.ui.miuix.VideoActionTile
+import io.github.xgl34222220.baize.ui.miuix.VideoCard
+import io.github.xgl34222220.baize.ui.miuix.VideoDivider
+import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
+import io.github.xgl34222220.baize.ui.miuix.VideoLeadingIcon
+import io.github.xgl34222220.baize.ui.miuix.VideoListRow
+import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
+import io.github.xgl34222220.baize.ui.miuix.VideoSwitchRow
+import io.github.xgl34222220.baize.ui.miuix.VideoTabs
+import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+private val videoIntervals = listOf(30, 60, 180, 360, 720, 1_440, 4_320, 10_080, 43_200)
+
+/** 参考视频的“面板”结构：顶部标签切换计划、类别和工具，避免一条无限长设置列表。 */
+@Composable
+fun VideoCleanScreenMiuix(
+    state: CleanUiState,
+    actions: CleanUiActions,
+    expandedCategory: String,
+    onExpandedCategoryChanged: (String) -> Unit
+) {
+    val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+    var showDailyTimeDialog by remember { mutableStateOf(false) }
+    var showDailyGraceDialog by remember { mutableStateOf(false) }
+
+    if (showDailyTimeDialog) {
+        TimeValueDialog(
+            initialHour = state.dailyHour,
+            initialMinute = state.dailyMinute,
+            onDismiss = { showDailyTimeDialog = false },
+            onConfirm = actions.onDailyTimeChanged
+        )
+    }
+    if (showDailyGraceDialog) {
+        IntValueDialog(
+            title = "补做窗口",
+            description = "固定时间到达后，如果条件暂时不满足，会在此时间内继续等待。",
+            initialValue = state.dailyGraceMinutes,
+            range = 15..720,
+            suffix = "分钟",
+            onDismiss = { showDailyGraceDialog = false },
+            onConfirm = actions.onDailyGraceChanged
+        )
+    }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = bottomInset + 102.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        item {
+            VideoTopBar(
+                title = "清理",
+                subtitle = "计划、类别与专项工具",
+                actions = {
+                    VideoIconButton(Icons.Rounded.Search, "扫描", actions.onScan)
+                    VideoIconButton(Icons.Rounded.InstallMobile, "安装包", actions.onApkScan)
+                }
+            )
+        }
+        item {
+            VideoTabs(
+                labels = listOf("计划", "类别", "工具"),
+                selectedIndex = selectedTab,
+                onSelected = { selectedTab = it }
+            )
+        }
+
+        when (selectedTab) {
+            0 -> {
+                item { AutomaticHero(state, actions) }
+                item { VideoSectionTitle("执行方式", state.scheduleSummary) }
+                item {
+                    ScheduleCard(
+                        state = state,
+                        actions = actions,
+                        onEditTime = { showDailyTimeDialog = true },
+                        onEditGrace = { showDailyGraceDialog = true }
+                    )
+                }
+                item { VideoSectionTitle("附加清理", "独立于普通缓存类别") }
+                item {
+                    VideoCard(
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .fillMaxWidth()
+                    ) {
+                        VideoSwitchRow(
+                            icon = Icons.Rounded.InstallMobile,
+                            title = "过期安装包",
+                            subtitle = "保留 ${state.apkPackageDays} 天后自动清理",
+                            checked = state.apkPackagesEnabled,
+                            onCheckedChange = actions.onApkPackagesChanged
+                        )
+                    }
+                }
+                item { ApplyButton(state.saving, actions.onSave) }
+            }
+
+            1 -> {
+                item { VideoSectionTitle("自动清理类别", "每个类别独立开关与周期") }
+                state.categories.forEach { category ->
+                    item(key = category.id.name) {
+                        CategoryCard(
+                            item = category,
+                            expanded = expandedCategory == category.id.name,
+                            dailyMode = state.scheduleMode == CleanScheduleMode.FIXED_DAILY && category.id != CleanCategoryId.ORGANIZE,
+                            onEnabledChanged = { actions.onCategoryEnabledChanged(category.id, it) },
+                            onExpandedChanged = {
+                                onExpandedCategoryChanged(
+                                    if (expandedCategory == category.id.name) "" else category.id.name
+                                )
+                            },
+                            onIntervalChanged = { actions.onCategoryIntervalChanged(category.id, it) }
+                        )
+                    }
+                }
+            }
+
+            else -> {
+                item { VideoSectionTitle("专项工具", "低频功能集中放在单独页面") }
+                item {
+                    ToolGrid(actions)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AutomaticHero(state: CleanUiState, actions: CleanUiActions) {
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth(),
+        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .72f),
+        contentPadding = 16
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(RoundedCornerShape(17.dp))
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = .56f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.CleaningServices,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(27.dp)
+                )
+            }
+            Spacer(Modifier.width(13.dp))
+            Column(Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(7.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (state.automaticCleaningEnabled) BaiZeTokens.colors.success
+                                else MaterialTheme.colorScheme.outline
+                            )
+                    )
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        if (state.automaticCleaningEnabled) "自动清理已开启" else "自动清理已暂停",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(Modifier.height(5.dp))
+                Text(
+                    "${state.enabledCategoryCount} 个类别",
+                    fontSize = 24.sp,
+                    lineHeight = 29.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Text(
+                    if (state.engineReady) state.serviceText else "正在连接 Root 清理服务",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Switch(
+                checked = state.automaticCleaningEnabled,
+                onCheckedChange = actions.onAutomaticCleaningChanged
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScheduleCard(
+    state: CleanUiState,
+    actions: CleanUiActions,
+    onEditTime: () -> Unit,
+    onEditGrace: () -> Unit
+) {
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth(),
+        contentPadding = 14
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            CleanScheduleMode.entries.forEach { mode ->
+                val selected = state.scheduleMode == mode
+                Surface(
+                    modifier = Modifier
+                        .height(36.dp)
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable { actions.onScheduleModeChanged(mode) },
+                    shape = RoundedCornerShape(12.dp),
+                    color = if (selected) MaterialTheme.colorScheme.primaryContainer else BaiZeTokens.colors.surfaceOverlay,
+                    border = BorderStroke(
+                        1.dp,
+                        if (selected) MaterialTheme.colorScheme.primary.copy(alpha = .28f)
+                        else MaterialTheme.colorScheme.outlineVariant.copy(alpha = .22f)
+                    )
+                ) {
+                    Box(
+                        modifier = Modifier.padding(horizontal = 13.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            mode.title,
+                            color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 11.sp,
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
+                        )
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(10.dp))
+        Text(
+            state.scheduleMode.description,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontSize = 10.sp,
+            lineHeight = 14.sp
+        )
+
+        if (state.scheduleMode == CleanScheduleMode.FIXED_DAILY) {
+            Spacer(Modifier.height(12.dp))
+            VideoDivider(start = 0)
+            VideoListRow(
+                icon = Icons.Rounded.CalendarMonth,
+                title = "执行时间",
+                subtitle = "每天固定执行已启用类别",
+                value = state.dailyTimeText,
+                onClick = onEditTime,
+                modifier = Modifier.padding(horizontal = 0.dp)
+            )
+            VideoDivider(start = 0)
+            VideoListRow(
+                icon = Icons.Rounded.AutoAwesome,
+                title = "补做窗口",
+                subtitle = "条件不满足时继续等待",
+                value = formatMinutes(state.dailyGraceMinutes),
+                onClick = onEditGrace,
+                modifier = Modifier.padding(horizontal = 0.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun CategoryCard(
+    item: CleanCategoryUiItem,
+    expanded: Boolean,
+    dailyMode: Boolean,
+    onEnabledChanged: (Boolean) -> Unit,
+    onExpandedChanged: () -> Unit,
+    onIntervalChanged: (Int) -> Unit
+) {
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 15.dp, vertical = 13.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            VideoLeadingIcon(categoryIcon(item.id))
+            Spacer(Modifier.width(12.dp))
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(enabled = item.enabled, onClick = onExpandedChanged)
+            ) {
+                Text(item.title, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+                Spacer(Modifier.height(1.dp))
+                Text(
+                    item.description,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    lineHeight = 14.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                if (item.enabled) {
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        if (dailyMode) "跟随每日固定时间" else "每 ${formatMinutes(item.intervalMinutes)}执行",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+            if (item.enabled && !dailyMode) {
+                Icon(
+                    Icons.Rounded.ChevronRight,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.width(3.dp))
+            }
+            Switch(checked = item.enabled, onCheckedChange = onEnabledChanged)
+        }
+
+        if (expanded && item.enabled && !dailyMode) {
+            VideoDivider(start = 15)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 15.dp, vertical = 11.dp),
+                horizontalArrangement = Arrangement.spacedBy(7.dp)
+            ) {
+                videoIntervals.forEach { minutes ->
+                    val selected = item.intervalMinutes == minutes
+                    Surface(
+                        modifier = Modifier
+                            .height(32.dp)
+                            .clip(RoundedCornerShape(11.dp))
+                            .clickable { onIntervalChanged(minutes) },
+                        shape = RoundedCornerShape(11.dp),
+                        color = if (selected) MaterialTheme.colorScheme.primaryContainer else BaiZeTokens.colors.surfaceOverlay
+                    ) {
+                        Box(
+                            modifier = Modifier.padding(horizontal = 11.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                formatMinutes(minutes),
+                                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                                fontSize = 10.sp,
+                                fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToolGrid(actions: CleanUiActions) {
+    Column(
+        modifier = Modifier.padding(horizontal = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            VideoActionTile(
+                icon = Icons.Rounded.Search,
+                title = "扫描工作台",
+                subtitle = "先扫描，再按快照清理",
+                onClick = actions.onScan,
+                modifier = Modifier.weight(1f),
+                primary = true
+            )
+            VideoActionTile(
+                icon = Icons.Rounded.InstallMobile,
+                title = "安装包扫描",
+                subtitle = "识别重复与过期 APK",
+                onClick = actions.onApkScan,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            VideoActionTile(
+                icon = Icons.Rounded.CleaningServices,
+                title = "即时缓存",
+                subtitle = "快速处理应用缓存",
+                onClick = actions.onInstantCache,
+                modifier = Modifier.weight(1f)
+            )
+            VideoActionTile(
+                icon = Icons.Rounded.FolderCopy,
+                title = "文件归类",
+                subtitle = "整理下载目录与文件",
+                onClick = actions.onFileOrganizer,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            VideoActionTile(
+                icon = Icons.Rounded.AutoAwesome,
+                title = "深度清理",
+                subtitle = "扩大范围并保留保护规则",
+                onClick = actions.onDeepClean,
+                modifier = Modifier.weight(1f)
+            )
+            VideoActionTile(
+                icon = Icons.Rounded.FolderDelete,
+                title = "卸载残留",
+                subtitle = "检查已卸载应用遗留文件",
+                onClick = actions.onCorpses,
+                modifier = Modifier.weight(1f)
+            )
+        }
+        VideoActionTile(
+            icon = Icons.Rounded.Security,
+            title = "规则与安全审计",
+            subtitle = "检查规则命中、保护项和潜在风险",
+            onClick = actions.onAudit,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun ApplyButton(saving: Boolean, onClick: () -> Unit) {
+    Surface(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth()
+            .height(48.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .clickable(enabled = !saving, onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.primary
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                if (saving) "正在应用…" else "保存并应用",
+                color = MaterialTheme.colorScheme.onPrimary,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+private fun categoryIcon(id: CleanCategoryId): ImageVector = when (id) {
+    CleanCategoryId.CACHE -> Icons.Rounded.CleaningServices
+    CleanCategoryId.EMPTY -> Icons.Rounded.FolderDelete
+    CleanCategoryId.RULES -> Icons.Rounded.Rule
+    CleanCategoryId.FRAGMENTS -> Icons.Rounded.FolderDelete
+    CleanCategoryId.DEEP -> Icons.Rounded.AutoAwesome
+    CleanCategoryId.ORGANIZE -> Icons.Rounded.FolderCopy
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/VideoCleanScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/VideoCleanScreenMiuix.kt
@@ -88,6 +88,7 @@ fun VideoCleanScreenMiuix(
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     var showDailyTimeDialog by remember { mutableStateOf(false) }
     var showDailyGraceDialog by remember { mutableStateOf(false) }
+    var showApkRetentionDialog by remember { mutableStateOf(false) }
 
     if (showDailyTimeDialog) {
         TimeValueDialog(
@@ -106,6 +107,17 @@ fun VideoCleanScreenMiuix(
             suffix = "分钟",
             onDismiss = { showDailyGraceDialog = false },
             onConfirm = actions.onDailyGraceChanged
+        )
+    }
+    if (showApkRetentionDialog) {
+        IntValueDialog(
+            title = "安装包保留时间",
+            description = "只影响后台自动清理。手动安装包扫描始终显示全部安装包；设置为 0 天表示扫描到后即可进入自动清理范围。",
+            initialValue = state.apkPackageDays,
+            range = 0..365,
+            suffix = "天",
+            onDismiss = { showApkRetentionDialog = false },
+            onConfirm = actions.onApkPackageDaysChanged
         )
     }
 
@@ -154,9 +166,22 @@ fun VideoCleanScreenMiuix(
                         VideoSwitchRow(
                             icon = Icons.Rounded.InstallMobile,
                             title = "过期安装包",
-                            subtitle = "保留 ${state.apkPackageDays} 天后自动清理",
+                            subtitle = "自动处理超过保留时间的 APK、APKS、XAPK 与 APKM",
                             checked = state.apkPackagesEnabled,
                             onCheckedChange = actions.onApkPackagesChanged
+                        )
+                        VideoDivider()
+                        VideoListRow(
+                            icon = Icons.Rounded.CalendarMonth,
+                            title = "安装包保留时间",
+                            subtitle = if (state.apkPackagesEnabled) {
+                                "超过该时间才进入后台自动清理；手动扫描不受影响"
+                            } else {
+                                "开启过期安装包后可修改"
+                            },
+                            value = apkRetentionText(state.apkPackageDays),
+                            enabled = state.apkPackagesEnabled,
+                            onClick = { showApkRetentionDialog = true }
                         )
                     }
                 }
@@ -521,6 +546,9 @@ private fun ApplyButton(saving: Boolean, onClick: () -> Unit) {
         }
     }
 }
+
+private fun apkRetentionText(days: Int): String =
+    if (days <= 0) "不保留" else "$days 天"
 
 private fun categoryIcon(id: CleanCategoryId): ImageVector = when (id) {
     CleanCategoryId.CACHE -> Icons.Rounded.CleaningServices

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt
@@ -4,8 +4,9 @@ import androidx.compose.runtime.Composable
 import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
-import io.github.xgl34222220.baize.ui.history.material.HistoryScreenMaterial
 import io.github.xgl34222220.baize.ui.history.miuix.VideoHistoryScreenMiuix
+import io.github.xgl34222220.baize.ui.miuix.ProvideVideoSkin
+import io.github.xgl34222220.baize.ui.miuix.VideoSkin
 
 @Composable
 fun HistoryRoute(
@@ -20,8 +21,11 @@ fun HistoryRoute(
         onReviewProtected = dashboardActions.reviewProtected
     )
 
-    when (style) {
-        UiStyle.MATERIAL -> HistoryScreenMaterial(state, actions)
-        UiStyle.MIUIX -> VideoHistoryScreenMiuix(state, actions)
+    val skin = when (style) {
+        UiStyle.MATERIAL -> VideoSkin.MATERIAL3
+        UiStyle.MIUIX -> VideoSkin.MIUIX
+    }
+    ProvideVideoSkin(skin) {
+        VideoHistoryScreenMiuix(state, actions)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/HistoryRoute.kt
@@ -5,7 +5,7 @@ import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.history.material.HistoryScreenMaterial
-import io.github.xgl34222220.baize.ui.history.miuix.HistoryScreenMiuix
+import io.github.xgl34222220.baize.ui.history.miuix.VideoHistoryScreenMiuix
 
 @Composable
 fun HistoryRoute(
@@ -22,6 +22,6 @@ fun HistoryRoute(
 
     when (style) {
         UiStyle.MATERIAL -> HistoryScreenMaterial(state, actions)
-        UiStyle.MIUIX -> HistoryScreenMiuix(state, actions)
+        UiStyle.MIUIX -> VideoHistoryScreenMiuix(state, actions)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/VideoHistoryScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/VideoHistoryScreenMiuix.kt
@@ -1,0 +1,440 @@
+package io.github.xgl34222220.baize.ui.history.miuix
+
+import android.text.format.Formatter
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.DeleteOutline
+import androidx.compose.material.icons.rounded.Folder
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.HistoryUiItem
+import io.github.xgl34222220.baize.ui.common.AppPackageIcon
+import io.github.xgl34222220.baize.ui.history.HistoryUiActions
+import io.github.xgl34222220.baize.ui.history.HistoryUiState
+import io.github.xgl34222220.baize.ui.miuix.VideoCard
+import io.github.xgl34222220.baize.ui.miuix.VideoDivider
+import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
+import io.github.xgl34222220.baize.ui.miuix.VideoListRow
+import io.github.xgl34222220.baize.ui.miuix.VideoMetricTile
+import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
+import io.github.xgl34222220.baize.ui.miuix.VideoTabs
+import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+/** 记录页按参考视频改为顶部标签切换，概览、应用结果和历史记录不再全部堆在一个长页面。 */
+@Composable
+fun VideoHistoryScreenMiuix(
+    state: HistoryUiState,
+    actions: HistoryUiActions
+) {
+    val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    var selectedTab by rememberSaveable { mutableIntStateOf(0) }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = bottomInset + 100.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        item {
+            VideoTopBar(
+                title = "记录",
+                subtitle = "清理结果与累计统计",
+                actions = {
+                    VideoIconButton(Icons.Rounded.Refresh, "刷新", actions.onRefresh)
+                    VideoIconButton(Icons.Rounded.DeleteOutline, "清空记录", actions.onClearHistory)
+                }
+            )
+        }
+        item {
+            VideoTabs(
+                labels = listOf("概览", "应用", "历史"),
+                selectedIndex = selectedTab,
+                onSelected = { selectedTab = it }
+            )
+        }
+
+        when (selectedTab) {
+            0 -> {
+                item { LifetimeHero(state) }
+                item {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        VideoMetricTile(
+                            label = "任务",
+                            value = state.lifetimeRuns.toString(),
+                            caption = "累计执行次数",
+                            modifier = Modifier.weight(1f)
+                        )
+                        VideoMetricTile(
+                            label = "处理文件",
+                            value = state.lifetimeFiles.toString(),
+                            caption = "累计文件数量",
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+                item {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        VideoMetricTile(
+                            label = "空项目",
+                            value = (state.lifetimeEmptyFiles + state.lifetimeEmptyDirs).toString(),
+                            caption = "空文件与目录",
+                            modifier = Modifier.weight(1f)
+                        )
+                        VideoMetricTile(
+                            label = "累计耗时",
+                            value = formatElapsed(state.lifetimeElapsed),
+                            caption = "所有清理任务",
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                }
+                item { VideoSectionTitle("最近结果", "最近一次任务的可读摘要") }
+                item { CurrentResultCard(state) }
+                if (state.protectedItems.isNotEmpty()) {
+                    item {
+                        VideoCard(
+                            modifier = Modifier
+                                .padding(horizontal = 12.dp)
+                                .fillMaxWidth()
+                        ) {
+                            VideoListRow(
+                                icon = Icons.Rounded.Security,
+                                title = "受保护内容",
+                                subtitle = "白名单与安全规则阻止了潜在误删",
+                                value = "${state.protectedItems.size} 项",
+                                onClick = actions.onReviewProtected
+                            )
+                        }
+                    }
+                }
+            }
+
+            1 -> {
+                item { VideoSectionTitle("应用垃圾", "最近一次任务按应用汇总") }
+                if (state.recentApps.isEmpty() && state.recentJunk.isEmpty()) {
+                    item { EmptyCard("暂无应用结果", "完成一次扫描或清理后显示") }
+                } else {
+                    if (state.recentApps.isNotEmpty()) {
+                        item {
+                            VideoCard(
+                                modifier = Modifier
+                                    .padding(horizontal = 12.dp)
+                                    .fillMaxWidth()
+                            ) {
+                                state.recentApps.forEachIndexed { index, app ->
+                                    AppResultRow(
+                                        packageName = app.packageName,
+                                        label = app.label.ifBlank { app.packageName },
+                                        subtitle = app.category.ifBlank { "应用垃圾" },
+                                        bytes = app.bytes,
+                                        files = app.files
+                                    )
+                                    if (index != state.recentApps.lastIndex) VideoDivider()
+                                }
+                            }
+                        }
+                    }
+                    if (state.recentJunk.isNotEmpty()) {
+                        item { VideoSectionTitle("其他垃圾", "不属于单个应用的清理结果") }
+                        item {
+                            VideoCard(
+                                modifier = Modifier
+                                    .padding(horizontal = 12.dp)
+                                    .fillMaxWidth()
+                            ) {
+                                state.recentJunk.forEachIndexed { index, junk ->
+                                    GenericResultRow(
+                                        title = junk.name,
+                                        subtitle = junk.samplePath.ifBlank { "未记录示例路径" },
+                                        bytes = junk.bytes,
+                                        files = junk.files
+                                    )
+                                    if (index != state.recentJunk.lastIndex) VideoDivider()
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            else -> {
+                item { VideoSectionTitle("任务历史", "按时间查看扫描、清理和归类结果") }
+                if (state.records.isEmpty()) {
+                    item { EmptyCard("暂无历史记录", "自动任务执行后会保留结果") }
+                } else {
+                    state.records.take(50).forEachIndexed { index, record ->
+                        item(key = "${record.time}|${record.title}|$index") {
+                            HistoryRecordCard(record)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LifetimeHero(state: HistoryUiState) {
+    val context = LocalContext.current
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth(),
+        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .72f),
+        contentPadding = 16
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        Modifier
+                            .size(7.dp)
+                            .clip(CircleShape)
+                            .background(BaiZeTokens.colors.success)
+                    )
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        "累计清理",
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    Formatter.formatFileSize(context, state.lifetimeReleased),
+                    fontSize = 30.sp,
+                    lineHeight = 35.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    if (state.lastTaskTime.isBlank()) "等待首次任务" else "最近执行 ${state.lastTaskTime}",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = .52f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Rounded.History,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(48.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CurrentResultCard(state: HistoryUiState) {
+    val context = LocalContext.current
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth()
+    ) {
+        VideoListRow(
+            icon = Icons.Rounded.CheckCircle,
+            title = if (state.hasCurrentResult) {
+                state.latestResult.ifBlank { "最近一次任务已完成" }
+            } else {
+                "暂无最近结果"
+            },
+            subtitle = if (state.hasCurrentResult) {
+                "处理 ${state.currentItemCount} 项 · ${state.lastTaskTime}"
+            } else {
+                "完成一次扫描或清理后显示结果"
+            },
+            value = Formatter.formatFileSize(context, state.currentBytes)
+        )
+    }
+}
+
+@Composable
+private fun AppResultRow(
+    packageName: String,
+    label: String,
+    subtitle: String,
+    bytes: Long,
+    files: Long
+) {
+    val context = LocalContext.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 15.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        AppPackageIcon(
+            packageName = packageName,
+            label = label,
+            size = 40.dp,
+            corner = 13.dp
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(label, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        }
+        Column(horizontalAlignment = Alignment.End) {
+            Text(Formatter.formatFileSize(context, bytes), fontSize = 12.sp, fontWeight = FontWeight.Bold)
+            Text("$files 项", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+        }
+    }
+}
+
+@Composable
+private fun GenericResultRow(
+    title: String,
+    subtitle: String,
+    bytes: Long,
+    files: Long
+) {
+    val context = LocalContext.current
+    VideoListRow(
+        icon = Icons.Rounded.Folder,
+        title = title,
+        subtitle = subtitle,
+        value = "${Formatter.formatFileSize(context, bytes)}\n$files 项"
+    )
+}
+
+@Composable
+private fun HistoryRecordCard(record: HistoryUiItem) {
+    val context = LocalContext.current
+    val statusColor = if (record.cleaned) BaiZeTokens.colors.success else MaterialTheme.colorScheme.primary
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth(),
+        contentPadding = 15
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(9.dp)
+                    .clip(CircleShape)
+                    .background(statusColor)
+            )
+            Spacer(Modifier.width(9.dp))
+            Column(Modifier.weight(1f)) {
+                Text(record.title, fontSize = 14.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(
+                    "${record.time} · ${record.trigger}",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Text(
+                Formatter.formatFileSize(context, record.bytes),
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        Spacer(Modifier.height(9.dp))
+        Surface(
+            shape = RoundedCornerShape(13.dp),
+            color = BaiZeTokens.colors.surfaceOverlay
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 9.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(record.result.ifBlank { "任务已完成" }, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp, modifier = Modifier.weight(1f), maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Spacer(Modifier.width(8.dp))
+                Text("${record.files} 项", fontSize = 10.sp, fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyCard(title: String, subtitle: String) {
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth(),
+        contentPadding = 22
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Icon(Icons.Rounded.History, contentDescription = null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(34.dp))
+                Spacer(Modifier.height(8.dp))
+                Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                Spacer(Modifier.height(2.dp))
+                Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+            }
+        }
+    }
+}
+
+private fun formatElapsed(milliseconds: Long): String {
+    if (milliseconds <= 0L) return "0 秒"
+    val seconds = milliseconds / 1_000L
+    return when {
+        seconds >= 3_600L -> "${seconds / 3_600L} 时"
+        seconds >= 60L -> "${seconds / 60L} 分"
+        else -> "$seconds 秒"
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
@@ -6,7 +6,7 @@ import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.home.material.HomeScreenMaterial
-import io.github.xgl34222220.baize.ui.home.miuix.HomeScreenMiuix
+import io.github.xgl34222220.baize.ui.home.miuix.VideoHomeScreenMiuix
 
 @Composable
 fun HomeRoute(
@@ -18,6 +18,6 @@ fun HomeRoute(
 ) {
     when (style) {
         UiStyle.MATERIAL -> HomeScreenMaterial(state, scheduler, actions, onOpenClean)
-        UiStyle.MIUIX -> HomeScreenMiuix(state, scheduler, actions, onOpenClean)
+        UiStyle.MIUIX -> VideoHomeScreenMiuix(state, scheduler, actions, onOpenClean)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
@@ -5,8 +5,9 @@ import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
-import io.github.xgl34222220.baize.ui.home.material.HomeScreenMaterial
 import io.github.xgl34222220.baize.ui.home.miuix.VideoHomeScreenMiuix
+import io.github.xgl34222220.baize.ui.miuix.ProvideVideoSkin
+import io.github.xgl34222220.baize.ui.miuix.VideoSkin
 
 @Composable
 fun HomeRoute(
@@ -16,8 +17,11 @@ fun HomeRoute(
     actions: DashboardActions,
     onOpenClean: () -> Unit
 ) {
-    when (style) {
-        UiStyle.MATERIAL -> HomeScreenMaterial(state, scheduler, actions, onOpenClean)
-        UiStyle.MIUIX -> VideoHomeScreenMiuix(state, scheduler, actions, onOpenClean)
+    val skin = when (style) {
+        UiStyle.MATERIAL -> VideoSkin.MATERIAL3
+        UiStyle.MIUIX -> VideoSkin.MIUIX
+    }
+    ProvideVideoSkin(skin) {
+        VideoHomeScreenMiuix(state, scheduler, actions, onOpenClean)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/VideoHomeScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/VideoHomeScreenMiuix.kt
@@ -1,0 +1,424 @@
+package io.github.xgl34222220.baize.ui.home.miuix
+
+import android.text.format.Formatter
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CalendarMonth
+import androidx.compose.material.icons.rounded.CheckCircle
+import androidx.compose.material.icons.rounded.CleaningServices
+import androidx.compose.material.icons.rounded.DeleteSweep
+import androidx.compose.material.icons.rounded.FolderCopy
+import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.DashboardActions
+import io.github.xgl34222220.baize.DashboardUiState
+import io.github.xgl34222220.baize.SchedulerUiState
+import io.github.xgl34222220.baize.ui.home.homeTaskItems
+import io.github.xgl34222220.baize.ui.home.nextTask
+import io.github.xgl34222220.baize.ui.home.rememberHomeNowEpoch
+import io.github.xgl34222220.baize.ui.home.taskCountdownLabel
+import io.github.xgl34222220.baize.ui.miuix.VideoCard
+import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
+import io.github.xgl34222220.baize.ui.miuix.VideoListRow
+import io.github.xgl34222220.baize.ui.miuix.VideoMetricTile
+import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
+import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+/**
+ * 按参考视频重新搭建的白泽首页：居中标题、主状态仪表卡、卡内三段操作、
+ * 紧凑指标卡和悬浮底栏。不是旧页面换色，而是重新组织首屏信息层级。
+ */
+@Composable
+fun VideoHomeScreenMiuix(
+    state: DashboardUiState,
+    scheduler: SchedulerUiState,
+    actions: DashboardActions,
+    onOpenClean: () -> Unit
+) {
+    val context = LocalContext.current
+    val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val nowEpoch = rememberHomeNowEpoch()
+    val tasks = scheduler.homeTaskItems()
+    val nextTask = tasks.nextTask(nowEpoch)
+    val healthy = state.ready || state.scanCompleted
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = bottomInset + 98.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        item {
+            VideoTopBar(
+                title = "白泽",
+                subtitle = if (state.running) "正在执行清理任务" else "智能清理与文件归类",
+                actions = {
+                    VideoIconButton(
+                        icon = Icons.Rounded.Refresh,
+                        description = "刷新",
+                        onClick = actions.refresh
+                    )
+                }
+            )
+        }
+
+        item {
+            HomeStatusHero(
+                state = state,
+                releasedText = Formatter.formatFileSize(context, state.lastReleased),
+                onPrimary = when {
+                    state.running -> actions.stop
+                    state.scanCompleted -> actions.cleanScan
+                    else -> actions.clean
+                },
+                onScan = actions.scan,
+                onOrganize = actions.organize
+            )
+        }
+
+        if (state.scanCompleted) {
+            item {
+                VideoCard(
+                    modifier = Modifier
+                        .padding(horizontal = 12.dp)
+                        .fillMaxWidth(),
+                    containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .72f)
+                ) {
+                    VideoListRow(
+                        icon = Icons.Rounded.DeleteSweep,
+                        title = "扫描结果已就绪",
+                        subtitle = "${state.scanFiles} 个文件 · ${Formatter.formatFileSize(context, state.scanBytes)}",
+                        value = "立即清理",
+                        onClick = actions.cleanScan
+                    )
+                }
+            }
+        }
+
+        item { VideoSectionTitle("设备与存储", "首屏只保留判断和行动所需的数据") }
+
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth(),
+                contentPadding = 15
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            text = "可用空间",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 10.sp
+                        )
+                        Spacer(Modifier.height(3.dp))
+                        Text(
+                            text = Formatter.formatFileSize(context, state.storageFree),
+                            fontSize = 25.sp,
+                            lineHeight = 30.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Spacer(Modifier.height(5.dp))
+                        Text(
+                            text = "已用 ${Formatter.formatFileSize(context, state.storageUsed)} / ${Formatter.formatFileSize(context, state.storageTotal)}",
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 10.sp,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    Surface(
+                        modifier = Modifier.size(58.dp),
+                        shape = CircleShape,
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = .10f),
+                        border = BorderStroke(5.dp, MaterialTheme.colorScheme.primary.copy(alpha = .18f))
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text(
+                                text = "${(state.storagePercent.coerceIn(0f, 1f) * 100).toInt()}%",
+                                color = MaterialTheme.colorScheme.primary,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                }
+                Spacer(Modifier.height(12.dp))
+                LinearProgressIndicator(
+                    progress = state.storagePercent.coerceIn(0f, 1f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(7.dp)
+                        .clip(CircleShape),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = BaiZeTokens.colors.surfaceOverlay
+                )
+            }
+        }
+
+        item {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                VideoMetricTile(
+                    label = "最近释放",
+                    value = Formatter.formatFileSize(context, state.lastReleased),
+                    caption = if (state.lastTaskTime.isBlank()) "等待首次任务" else state.lastTaskTime,
+                    modifier = Modifier.weight(1f)
+                )
+                VideoMetricTile(
+                    label = "累计任务",
+                    value = "${state.lifetimeRuns}",
+                    caption = "自动与手动任务",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        item {
+            Row(
+                modifier = Modifier.padding(horizontal = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                VideoMetricTile(
+                    label = "累计释放",
+                    value = Formatter.formatFileSize(context, state.lifetimeReleased),
+                    caption = "历史清理总量",
+                    modifier = Modifier.weight(1f)
+                )
+                VideoMetricTile(
+                    label = "处理文件",
+                    value = state.lifetimeFiles.toString(),
+                    caption = "累计文件数量",
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        item { VideoSectionTitle("自动任务", "下一项任务与 Root 服务状态") }
+
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+            ) {
+                VideoListRow(
+                    icon = Icons.Rounded.CalendarMonth,
+                    title = nextTask?.title ?: "自动清理",
+                    subtitle = if (scheduler.enabled) {
+                        taskCountdownLabel(nextTask, nowEpoch, scheduler)
+                    } else {
+                        "自动任务已关闭"
+                    },
+                    value = "清理计划",
+                    onClick = onOpenClean
+                )
+                androidx.compose.material3.HorizontalDivider(
+                    modifier = Modifier.padding(start = 67.dp),
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .34f)
+                )
+                VideoListRow(
+                    icon = Icons.Rounded.Security,
+                    title = when {
+                        state.running -> "Root 任务执行中"
+                        healthy -> "Root 服务运行正常"
+                        state.connected -> "Root 服务已连接"
+                        else -> "正在恢复 Root 服务"
+                    },
+                    subtitle = state.serviceText,
+                    value = when {
+                        state.running -> "执行中"
+                        healthy -> "正常"
+                        else -> "恢复中"
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeStatusHero(
+    state: DashboardUiState,
+    releasedText: String,
+    onPrimary: () -> Unit,
+    onScan: () -> Unit,
+    onOrganize: () -> Unit
+) {
+    val positive = state.ready || state.scanCompleted
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth(),
+        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .72f),
+        contentPadding = 16
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Column(Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .size(7.dp)
+                            .clip(CircleShape)
+                            .background(
+                                when {
+                                    state.running -> BaiZeTokens.colors.warning
+                                    positive -> BaiZeTokens.colors.success
+                                    else -> MaterialTheme.colorScheme.outline
+                                }
+                            )
+                    )
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        text = when {
+                            state.running -> "运行中"
+                            state.scanCompleted -> "扫描完成"
+                            state.ready -> "已就绪"
+                            else -> "连接中"
+                        },
+                        color = MaterialTheme.colorScheme.primary,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    text = if (state.running) state.taskPhase else "最近一次释放",
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(Modifier.height(2.dp))
+                Text(
+                    text = if (state.running) {
+                        "${state.taskProgressFiles} 项"
+                    } else {
+                        releasedText
+                    },
+                    fontSize = 29.sp,
+                    lineHeight = 34.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    text = if (state.running) state.taskProgressPath.ifBlank { state.taskOperation } else state.device,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .size(82.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = .46f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = if (state.running) Icons.Rounded.CleaningServices else Icons.Rounded.CheckCircle,
+                    contentDescription = null,
+                    modifier = Modifier.size(55.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+
+        Spacer(Modifier.height(14.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            HeroAction(
+                icon = if (state.running) Icons.Rounded.Stop else Icons.Rounded.CleaningServices,
+                title = if (state.running) "停止" else if (state.scanCompleted) "清理" else "清理",
+                onClick = onPrimary,
+                modifier = Modifier.weight(1f),
+                primary = true
+            )
+            HeroAction(
+                icon = Icons.Rounded.Search,
+                title = "扫描",
+                onClick = onScan,
+                modifier = Modifier.weight(1f)
+            )
+            HeroAction(
+                icon = Icons.Rounded.FolderCopy,
+                title = "归类",
+                onClick = onOrganize,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun HeroAction(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    primary: Boolean = false
+) {
+    val shape = RoundedCornerShape(14.dp)
+    Surface(
+        modifier = modifier
+            .height(42.dp)
+            .clip(shape)
+            .clickable(onClick = onClick),
+        shape = shape,
+        color = if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface.copy(alpha = .62f),
+        contentColor = if (primary) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(icon, contentDescription = null, modifier = Modifier.size(17.dp))
+            Spacer(Modifier.width(5.dp))
+            Text(title, fontSize = 11.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/MiuixLiquidComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/MiuixLiquidComponents.kt
@@ -1,9 +1,8 @@
 package io.github.xgl34222220.baize.ui.miuix
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -38,9 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
@@ -56,12 +53,16 @@ import dev.chrisbanes.haze.materials.HazeMaterials
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
-/** A stable Miuix navigation item. Labels always stay below icons. */
+/** 底栏项目：图标与标签顺序固定，不因页面切换改变。 */
 data class MiuixLiquidNavItem(
     val title: String,
     val icon: ImageVector
 )
 
+/**
+ * 统一悬浮玻璃底栏。
+ * 玻璃只用于导航层，不把主体卡片做成整页模糊。
+ */
 @OptIn(ExperimentalHazeMaterialsApi::class)
 @Composable
 fun MiuixLiquidDock(
@@ -80,29 +81,32 @@ fun MiuixLiquidDock(
     val amoled = dark && settings.amoledBlack
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val shape = if (floating) {
-        RoundedCornerShape(34.dp)
+        RoundedCornerShape(32.dp)
     } else {
-        RoundedCornerShape(topStart = 34.dp, topEnd = 34.dp)
+        RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp)
     }
 
     val activeHazeState = hazeState.takeIf {
         settings.blurEnabled && settings.glassEnabled && !amoled
     }
     val dockColor = when {
-        amoled -> Color(0xEE000000)
-        activeHazeState != null && dark -> scheme.surface.copy(alpha = .28f)
-        activeHazeState != null -> Color.White.copy(alpha = .22f)
-        dark -> scheme.surface.copy(alpha = .96f)
-        else -> Color.White.copy(alpha = .94f)
+        amoled -> Color(0xF2000000)
+        activeHazeState != null && dark -> BaiZeTokens.colors.surfaceRaised.copy(alpha = .82f)
+        activeHazeState != null -> BaiZeTokens.colors.surfaceRaised.copy(alpha = .84f)
+        else -> BaiZeTokens.colors.surfaceRaised.copy(alpha = .98f)
     }
-    val borderColor = if (dark) Color.White.copy(alpha = .15f) else Color.White.copy(alpha = .82f)
+    val borderColor = if (dark) {
+        Color.White.copy(alpha = .11f)
+    } else {
+        Color.White.copy(alpha = .88f)
+    }
     val hazeModifier = activeHazeState?.let { state ->
         Modifier.hazeEffect(
             state = state,
             style = HazeMaterials.ultraThin()
         ) {
-            blurRadius = 28.dp
-            noiseFactor = .06f
+            blurRadius = 24.dp
+            noiseFactor = .025f
         }
     } ?: Modifier
 
@@ -111,46 +115,24 @@ fun MiuixLiquidDock(
             .then(
                 if (floating) {
                     Modifier
-                        .padding(horizontal = 16.dp)
-                        .padding(bottom = bottomInset + 10.dp)
+                        .padding(horizontal = 14.dp)
+                        .padding(bottom = bottomInset + 12.dp)
                 } else {
                     Modifier
                 }
             )
             .fillMaxWidth()
-            .shadow(if (floating) 18.dp else 7.dp, shape, clip = false)
+            .height(if (floating) 64.dp else 64.dp + bottomInset)
+            .shadow(if (floating) 8.dp else 2.dp, shape, clip = false)
             .clip(shape)
             .then(hazeModifier)
             .background(dockColor)
             .border(1.dp, borderColor, shape)
-            .drawBehind {
-                drawRoundRect(
-                    brush = Brush.verticalGradient(
-                        listOf(
-                            Color.White.copy(alpha = if (dark) .13f else .44f),
-                            Color.Transparent
-                        )
-                    ),
-                    cornerRadius = androidx.compose.ui.geometry.CornerRadius(34.dp.toPx()),
-                    size = size.copy(height = size.height * .58f)
-                )
-                if (!amoled && settings.glassEnabled) {
-                    drawCircle(
-                        brush = Brush.radialGradient(
-                            listOf(scheme.primary.copy(alpha = .14f), Color.Transparent),
-                            center = Offset(size.width * .18f, size.height * .08f),
-                            radius = size.width * .6f
-                        ),
-                        radius = size.width * .6f,
-                        center = Offset(size.width * .18f, size.height * .08f)
-                    )
-                }
-            }
             .padding(
                 start = 6.dp,
-                top = 7.dp,
+                top = 6.dp,
                 end = 6.dp,
-                bottom = if (floating) 7.dp else bottomInset + 7.dp
+                bottom = if (floating) 6.dp else bottomInset + 6.dp
             )
     ) {
         val itemWidth = maxWidth / items.size.toFloat()
@@ -158,50 +140,37 @@ fun MiuixLiquidDock(
         val targetIndex = selectedIndex.coerceIn(items.indices)
         val indicatorX by animateDpAsState(
             targetValue = itemWidth * targetIndex.toFloat(),
-            animationSpec = spring(
-                dampingRatio = .72f,
-                stiffness = Spring.StiffnessMediumLow
-            ),
-            label = "miuixLiquidIndicator"
+            animationSpec = tween(durationMillis = 240),
+            label = "miuixDockIndicator"
         )
 
         Box(
             modifier = Modifier
                 .offset(x = indicatorX + 4.dp)
                 .width(itemWidth - 8.dp)
-                .height(58.dp)
+                .height(48.dp)
                 .clip(RoundedCornerShape(24.dp))
-                .background(
-                    Brush.linearGradient(
-                        listOf(
-                            scheme.primary.copy(alpha = if (dark) .28f else .20f),
-                            scheme.tertiary.copy(alpha = if (dark) .20f else .13f)
-                        )
-                    )
-                )
-                .border(
-                    1.dp,
-                    Color.White.copy(alpha = if (dark) .12f else .62f),
-                    RoundedCornerShape(24.dp)
-                )
+                .background(scheme.primaryContainer.copy(alpha = if (dark) .72f else .88f))
         )
 
         Row(Modifier.fillMaxWidth()) {
             items.forEachIndexed { index, item ->
                 val active = index == targetIndex
                 val iconColor by animateColorAsState(
-                    targetValue = if (active) scheme.primary else scheme.onSurfaceVariant,
+                    targetValue = if (active) scheme.primary else scheme.onSurfaceVariant.copy(alpha = .82f),
+                    animationSpec = tween(180),
                     label = "miuixDockIconColor"
                 )
                 val textColor by animateColorAsState(
                     targetValue = if (active) scheme.primary else scheme.onSurfaceVariant.copy(alpha = .78f),
+                    animationSpec = tween(180),
                     label = "miuixDockTextColor"
                 )
 
                 Column(
                     modifier = Modifier
                         .width(itemWidth)
-                        .height(58.dp)
+                        .height(48.dp)
                         .clip(RoundedCornerShape(24.dp))
                         .clickable { onSelected(index) },
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -210,16 +179,16 @@ fun MiuixLiquidDock(
                     Icon(
                         imageVector = item.icon,
                         contentDescription = item.title,
-                        modifier = Modifier.size(if (compact) 20.dp else if (active) 23.dp else 21.dp),
+                        modifier = Modifier.size(if (compact) 20.dp else 22.dp),
                         tint = iconColor
                     )
-                    Spacer(Modifier.height(3.dp))
+                    Spacer(Modifier.height(2.dp))
                     Text(
                         text = item.title,
                         color = textColor,
                         fontSize = if (compact) 9.sp else 10.sp,
-                        lineHeight = if (compact) 11.sp else 12.sp,
-                        fontWeight = if (active) FontWeight.Bold else FontWeight.Medium
+                        lineHeight = if (compact) 10.sp else 11.sp,
+                        fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium
                     )
                 }
             }
@@ -227,6 +196,7 @@ fun MiuixLiquidDock(
     }
 }
 
+/** 首页视觉中心：运行状态、设备信息与最近释放量集中在一张主状态卡。 */
 @Composable
 fun MiuixOverviewHero(
     device: String,
@@ -240,15 +210,21 @@ fun MiuixOverviewHero(
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.background.luminance() < .5f
     val shape = BaiZeTokens.corners.large
-    val surface = BaiZeTokens.colors.surfaceRaised
 
     Box(
         modifier = modifier
             .fillMaxWidth()
             .clip(shape)
-            .background(surface)
-            .border(1.dp, scheme.onSurface.copy(alpha = if (dark) .08f else .05f), shape)
-            .padding(BaiZeTokens.spacing.xxl)
+            .background(
+                Brush.linearGradient(
+                    listOf(
+                        scheme.primaryContainer.copy(alpha = if (dark) .58f else .82f),
+                        BaiZeTokens.colors.surfaceRaised
+                    )
+                )
+            )
+            .border(1.dp, Color.White.copy(alpha = if (dark) .07f else .62f), shape)
+            .padding(20.dp)
     ) {
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -259,7 +235,7 @@ fun MiuixOverviewHero(
                         .background(if (positive) BaiZeTokens.colors.success else BaiZeTokens.colors.warning)
                 )
                 Spacer(Modifier.width(8.dp))
-                Text(device, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                Text(device, fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
                 Text(
                     "  ·  $android",
                     color = scheme.onSurfaceVariant,
@@ -269,7 +245,7 @@ fun MiuixOverviewHero(
                 )
             }
 
-            Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(20.dp))
             Text(
                 "最近一次释放",
                 color = scheme.onSurfaceVariant,
@@ -282,24 +258,25 @@ fun MiuixOverviewHero(
                 style = BaiZeTokens.type.hero
             )
 
-            Spacer(Modifier.height(20.dp))
+            Spacer(Modifier.height(16.dp))
             Row(
                 Modifier
                     .fillMaxWidth()
                     .clip(BaiZeTokens.corners.medium)
-                    .background(scheme.onSurface.copy(alpha = if (dark) .055f else .04f))
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .background(BaiZeTokens.colors.surfaceOverlay.copy(alpha = if (dark) .78f else .92f))
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
                     if (positive) Icons.Rounded.CheckCircle else Icons.Rounded.Refresh,
                     contentDescription = null,
                     tint = if (positive) BaiZeTokens.colors.success else scheme.primary,
-                    modifier = Modifier.size(24.dp)
+                    modifier = Modifier.size(22.dp)
                 )
-                Spacer(Modifier.width(11.dp))
+                Spacer(Modifier.width(10.dp))
                 Column(Modifier.weight(1f)) {
-                    Text(statusTitle, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+                    Text(statusTitle, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
+                    Spacer(Modifier.height(2.dp))
                     Text(
                         taskPhase,
                         color = scheme.onSurfaceVariant,
@@ -313,6 +290,7 @@ fun MiuixOverviewHero(
     }
 }
 
+/** 统一主操作：页面最多一个高强调主按钮，高度保持 52dp。 */
 @Composable
 fun MiuixLiquidPrimaryButton(
     running: Boolean,
@@ -322,7 +300,7 @@ fun MiuixLiquidPrimaryButton(
     modifier: Modifier = Modifier
 ) {
     val scheme = MaterialTheme.colorScheme
-    val shape = BaiZeTokens.corners.full
+    val shape = BaiZeTokens.corners.medium
     val label = when {
         running -> "停止清理"
         scanReady -> "按扫描结果清理"
@@ -333,32 +311,29 @@ fun MiuixLiquidPrimaryButton(
         scanReady -> Icons.Rounded.DeleteSweep
         else -> Icons.Rounded.AutoAwesome
     }
-
-    // 纯色胶囊：默认 primary，运行中用中性面，禁用为淡灰。
     val containerColor = when {
         !enabled -> scheme.onSurface.copy(alpha = .12f)
-        running -> scheme.surfaceVariant
+        running -> BaiZeTokens.colors.danger
         else -> scheme.primary
     }
     val contentColor = when {
         !enabled -> scheme.onSurface.copy(alpha = .45f)
-        running -> scheme.onSurface
-        else -> scheme.onPrimary
+        else -> Color.White
     }
 
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(64.dp)
+            .height(52.dp)
             .clip(shape)
             .background(containerColor)
             .clickable(enabled = enabled, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(icon, contentDescription = null, tint = contentColor, modifier = Modifier.size(22.dp))
-            Spacer(Modifier.width(10.dp))
-            Text(label, color = contentColor, fontSize = 17.sp, fontWeight = FontWeight.Bold)
+            Icon(icon, contentDescription = null, tint = contentColor, modifier = Modifier.size(21.dp))
+            Spacer(Modifier.width(9.dp))
+            Text(label, color = contentColor, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
@@ -1,0 +1,419 @@
+package io.github.xgl34222220.baize.ui.miuix
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+/**
+ * 参考视频建立的 MIUIX 页面组件：居中标题、紧凑胶囊标签、低对比分组卡、
+ * 小型图标容器与稳定的 4dp 间距节奏。主体卡片保持实色，玻璃只留给底栏。
+ */
+@Composable
+fun VideoTopBar(
+    title: String,
+    subtitle: String? = null,
+    start: @Composable RowScope.() -> Unit = {},
+    actions: @Composable RowScope.() -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .statusBarsPadding()
+            .heightIn(min = 68.dp)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier.align(Alignment.CenterStart),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            content = start
+        )
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .padding(horizontal = 76.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = title,
+                fontSize = 20.sp,
+                lineHeight = 24.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Spacer(Modifier.height(1.dp))
+                Text(
+                    text = subtitle,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    lineHeight = 13.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+        Row(
+            modifier = Modifier.align(Alignment.CenterEnd),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            content = actions
+        )
+    }
+}
+
+@Composable
+fun VideoIconButton(
+    icon: ImageVector,
+    description: String,
+    onClick: () -> Unit,
+    primary: Boolean = false
+) {
+    val shape = RoundedCornerShape(14.dp)
+    Surface(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(shape)
+            .clickable(onClick = onClick),
+        shape = shape,
+        color = if (primary) {
+            MaterialTheme.colorScheme.primaryContainer
+        } else {
+            BaiZeTokens.colors.surfaceRaised
+        },
+        border = BorderStroke(
+            1.dp,
+            Color.White.copy(alpha = if (MaterialTheme.colorScheme.background == Color.Black) .10f else .62f)
+        )
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = icon,
+                contentDescription = description,
+                modifier = Modifier.size(20.dp),
+                tint = if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+            )
+        }
+    }
+}
+
+@Composable
+fun VideoTabs(
+    labels: List<String>,
+    selectedIndex: Int,
+    onSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(7.dp)
+    ) {
+        labels.forEachIndexed { index, label ->
+            val selected = index == selectedIndex
+            Surface(
+                modifier = Modifier
+                    .height(34.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onSelected(index) },
+                shape = RoundedCornerShape(12.dp),
+                color = if (selected) MaterialTheme.colorScheme.primaryContainer else BaiZeTokens.colors.surfaceRaised,
+                border = BorderStroke(
+                    1.dp,
+                    if (selected) MaterialTheme.colorScheme.primary.copy(alpha = .28f)
+                    else MaterialTheme.colorScheme.outlineVariant.copy(alpha = .35f)
+                )
+            ) {
+                Box(
+                    modifier = Modifier.padding(horizontal = 15.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = label,
+                        color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 12.sp,
+                        fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun VideoSectionTitle(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier.padding(horizontal = 16.dp)) {
+        Text(
+            text = title,
+            fontSize = 16.sp,
+            lineHeight = 21.sp,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground
+        )
+        if (!subtitle.isNullOrBlank()) {
+            Spacer(Modifier.height(1.dp))
+            Text(
+                text = subtitle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.sp,
+                lineHeight = 14.sp
+            )
+        }
+    }
+}
+
+@Composable
+fun VideoCard(
+    modifier: Modifier = Modifier,
+    containerColor: Color = BaiZeTokens.colors.surfaceRaised,
+    contentPadding: Int = 0,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(22.dp),
+        color = containerColor,
+        border = BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = .24f)
+        ),
+        shadowElevation = 0.dp
+    ) {
+        Column(
+            modifier = if (contentPadding > 0) Modifier.padding(contentPadding.dp) else Modifier,
+            content = content
+        )
+    }
+}
+
+@Composable
+fun VideoLeadingIcon(
+    icon: ImageVector,
+    primary: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .clip(RoundedCornerShape(13.dp))
+            .background(
+                if (primary) MaterialTheme.colorScheme.primary.copy(alpha = .11f)
+                else MaterialTheme.colorScheme.onSurface.copy(alpha = .055f)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+fun VideoListRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    modifier: Modifier = Modifier,
+    value: String? = null,
+    enabled: Boolean = true,
+    onClick: (() -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(
+                if (onClick != null) Modifier.clickable(enabled = enabled, onClick = onClick)
+                else Modifier
+            )
+            .padding(horizontal = 15.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        VideoLeadingIcon(icon = icon, primary = enabled)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = title,
+                fontSize = 14.sp,
+                lineHeight = 19.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = .45f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(Modifier.height(1.dp))
+            Text(
+                text = subtitle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (enabled) 1f else .5f),
+                fontSize = 10.sp,
+                lineHeight = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        if (!value.isNullOrBlank()) {
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = value,
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 11.sp,
+                lineHeight = 15.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.End,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        if (trailing != null) {
+            Spacer(Modifier.width(8.dp))
+            trailing()
+        }
+    }
+}
+
+@Composable
+fun VideoSwitchRow(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    VideoListRow(
+        icon = icon,
+        title = title,
+        subtitle = subtitle,
+        modifier = modifier,
+        trailing = {
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange
+            )
+        }
+    )
+}
+
+@Composable
+fun VideoDivider(start: Int = 67) {
+    HorizontalDivider(
+        modifier = Modifier.padding(start = start.dp),
+        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .34f)
+    )
+}
+
+@Composable
+fun VideoMetricTile(
+    label: String,
+    value: String,
+    caption: String,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(17.dp),
+        color = BaiZeTokens.colors.surfaceOverlay,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = .18f))
+    ) {
+        Column(Modifier.padding(horizontal = 13.dp, vertical = 11.dp)) {
+            Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+            Spacer(Modifier.height(3.dp))
+            Text(
+                value,
+                fontSize = 17.sp,
+                lineHeight = 21.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                caption,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 9.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+fun VideoActionTile(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    primary: Boolean = false
+) {
+    Surface(
+        modifier = modifier
+            .clip(RoundedCornerShape(19.dp))
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(19.dp),
+        color = if (primary) MaterialTheme.colorScheme.primaryContainer else BaiZeTokens.colors.surfaceRaised,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = .25f))
+    ) {
+        Column(Modifier.padding(14.dp)) {
+            VideoLeadingIcon(icon = icon, primary = true)
+            Spacer(Modifier.height(10.dp))
+            Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(2.dp))
+            Text(
+                subtitle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.sp,
+                lineHeight = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -27,10 +28,13 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -40,9 +44,24 @@ import androidx.compose.ui.unit.sp
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 /**
- * 参考视频建立的 MIUIX 页面组件：居中标题、紧凑胶囊标签、低对比分组卡、
- * 小型图标容器与稳定的 4dp 间距节奏。主体卡片保持实色，玻璃只留给底栏。
+ * 两套外观共用同一信息架构和页面骨架，只替换组件皮肤。
+ * MIUIX 更轻、更圆润、更接近 HyperOS 系统面板；Material 3 使用标准色彩容器与控件层级。
  */
+enum class VideoSkin {
+    MIUIX,
+    MATERIAL3
+}
+
+val LocalVideoSkin = staticCompositionLocalOf { VideoSkin.MIUIX }
+
+@Composable
+fun ProvideVideoSkin(
+    skin: VideoSkin,
+    content: @Composable () -> Unit
+) {
+    CompositionLocalProvider(LocalVideoSkin provides skin, content = content)
+}
+
 @Composable
 fun VideoTopBar(
     title: String,
@@ -50,12 +69,13 @@ fun VideoTopBar(
     start: @Composable RowScope.() -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {}
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .statusBarsPadding()
-            .heightIn(min = 68.dp)
-            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .heightIn(min = if (material) 72.dp else 68.dp)
+            .padding(horizontal = if (material) 16.dp else 12.dp, vertical = 8.dp)
     ) {
         Row(
             modifier = Modifier.align(Alignment.CenterStart),
@@ -71,8 +91,8 @@ fun VideoTopBar(
         ) {
             Text(
                 text = title,
-                fontSize = 20.sp,
-                lineHeight = 24.sp,
+                fontSize = if (material) 22.sp else 20.sp,
+                lineHeight = if (material) 27.sp else 24.sp,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onBackground,
                 maxLines = 1,
@@ -83,8 +103,8 @@ fun VideoTopBar(
                 Text(
                     text = subtitle,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp,
-                    lineHeight = 13.sp,
+                    fontSize = if (material) 11.sp else 10.sp,
+                    lineHeight = if (material) 14.sp else 13.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -106,29 +126,40 @@ fun VideoIconButton(
     onClick: () -> Unit,
     primary: Boolean = false
 ) {
-    val shape = RoundedCornerShape(14.dp)
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
+    val shape = if (material) CircleShape else RoundedCornerShape(14.dp)
+    val dark = MaterialTheme.colorScheme.background.luminance() < .5f
+    val container = when {
+        material && primary -> MaterialTheme.colorScheme.primary
+        material -> MaterialTheme.colorScheme.surfaceContainerHigh
+        primary -> MaterialTheme.colorScheme.primaryContainer
+        else -> BaiZeTokens.colors.surfaceRaised
+    }
+    val content = when {
+        material && primary -> MaterialTheme.colorScheme.onPrimary
+        material -> MaterialTheme.colorScheme.onSurfaceVariant
+        primary -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurface
+    }
     Surface(
         modifier = Modifier
-            .size(40.dp)
+            .size(if (material) 42.dp else 40.dp)
             .clip(shape)
             .clickable(onClick = onClick),
         shape = shape,
-        color = if (primary) {
-            MaterialTheme.colorScheme.primaryContainer
-        } else {
-            BaiZeTokens.colors.surfaceRaised
-        },
-        border = BorderStroke(
+        color = container,
+        contentColor = content,
+        border = if (material) null else BorderStroke(
             1.dp,
-            Color.White.copy(alpha = if (MaterialTheme.colorScheme.background == Color.Black) .10f else .62f)
+            Color.White.copy(alpha = if (dark) .10f else .62f)
         )
     ) {
         Box(contentAlignment = Alignment.Center) {
             Icon(
                 imageVector = icon,
                 contentDescription = description,
-                modifier = Modifier.size(20.dp),
-                tint = if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                modifier = Modifier.size(if (material) 21.dp else 20.dp),
+                tint = content
             )
         }
     }
@@ -141,36 +172,51 @@ fun VideoTabs(
     onSelected: (Int) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
     Row(
         modifier = modifier
             .fillMaxWidth()
             .horizontalScroll(rememberScrollState())
-            .padding(horizontal = 12.dp),
-        horizontalArrangement = Arrangement.spacedBy(7.dp)
+            .padding(horizontal = if (material) 16.dp else 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(if (material) 8.dp else 7.dp)
     ) {
         labels.forEachIndexed { index, label ->
             val selected = index == selectedIndex
+            val shape = RoundedCornerShape(if (material) 18.dp else 12.dp)
+            val container = when {
+                material && selected -> MaterialTheme.colorScheme.primary
+                material -> MaterialTheme.colorScheme.surfaceContainerHigh
+                selected -> MaterialTheme.colorScheme.primaryContainer
+                else -> BaiZeTokens.colors.surfaceRaised
+            }
+            val content = when {
+                material && selected -> MaterialTheme.colorScheme.onPrimary
+                material -> MaterialTheme.colorScheme.onSurfaceVariant
+                selected -> MaterialTheme.colorScheme.primary
+                else -> MaterialTheme.colorScheme.onSurfaceVariant
+            }
             Surface(
                 modifier = Modifier
-                    .height(34.dp)
-                    .clip(RoundedCornerShape(12.dp))
+                    .height(if (material) 38.dp else 34.dp)
+                    .clip(shape)
                     .clickable { onSelected(index) },
-                shape = RoundedCornerShape(12.dp),
-                color = if (selected) MaterialTheme.colorScheme.primaryContainer else BaiZeTokens.colors.surfaceRaised,
-                border = BorderStroke(
+                shape = shape,
+                color = container,
+                contentColor = content,
+                border = if (material) null else BorderStroke(
                     1.dp,
                     if (selected) MaterialTheme.colorScheme.primary.copy(alpha = .28f)
                     else MaterialTheme.colorScheme.outlineVariant.copy(alpha = .35f)
                 )
             ) {
                 Box(
-                    modifier = Modifier.padding(horizontal = 15.dp),
+                    modifier = Modifier.padding(horizontal = if (material) 18.dp else 15.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
                         text = label,
-                        color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontSize = 12.sp,
+                        color = content,
+                        fontSize = if (material) 13.sp else 12.sp,
                         fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium
                     )
                 }
@@ -185,11 +231,12 @@ fun VideoSectionTitle(
     subtitle: String? = null,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.padding(horizontal = 16.dp)) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
+    Column(modifier.padding(horizontal = if (material) 20.dp else 16.dp)) {
         Text(
             text = title,
-            fontSize = 16.sp,
-            lineHeight = 21.sp,
+            fontSize = if (material) 18.sp else 16.sp,
+            lineHeight = if (material) 23.sp else 21.sp,
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.onBackground
         )
@@ -198,8 +245,8 @@ fun VideoSectionTitle(
             Text(
                 text = subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp,
-                lineHeight = 14.sp
+                fontSize = if (material) 11.sp else 10.sp,
+                lineHeight = if (material) 15.sp else 14.sp
             )
         }
     }
@@ -208,19 +255,26 @@ fun VideoSectionTitle(
 @Composable
 fun VideoCard(
     modifier: Modifier = Modifier,
-    containerColor: Color = BaiZeTokens.colors.surfaceRaised,
+    containerColor: Color? = null,
     contentPadding: Int = 0,
     content: @Composable ColumnScope.() -> Unit
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
+    val resolvedColor = containerColor ?: if (material) {
+        MaterialTheme.colorScheme.surfaceContainerLow
+    } else {
+        BaiZeTokens.colors.surfaceRaised
+    }
     Surface(
         modifier = modifier,
-        shape = RoundedCornerShape(22.dp),
-        color = containerColor,
-        border = BorderStroke(
+        shape = RoundedCornerShape(if (material) 20.dp else 22.dp),
+        color = resolvedColor,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        border = if (material) null else BorderStroke(
             1.dp,
             MaterialTheme.colorScheme.outlineVariant.copy(alpha = .24f)
         ),
-        shadowElevation = 0.dp
+        shadowElevation = if (material) 1.dp else 0.dp
     ) {
         Column(
             modifier = if (contentPadding > 0) Modifier.padding(contentPadding.dp) else Modifier,
@@ -235,21 +289,31 @@ fun VideoLeadingIcon(
     primary: Boolean = true,
     modifier: Modifier = Modifier
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
+    val background = when {
+        material && primary -> MaterialTheme.colorScheme.primaryContainer
+        material -> MaterialTheme.colorScheme.surfaceContainerHighest
+        primary -> MaterialTheme.colorScheme.primary.copy(alpha = .11f)
+        else -> MaterialTheme.colorScheme.onSurface.copy(alpha = .055f)
+    }
+    val tint = when {
+        material && primary -> MaterialTheme.colorScheme.onPrimaryContainer
+        material -> MaterialTheme.colorScheme.onSurfaceVariant
+        primary -> MaterialTheme.colorScheme.primary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
     Box(
         modifier = modifier
-            .size(40.dp)
-            .clip(RoundedCornerShape(13.dp))
-            .background(
-                if (primary) MaterialTheme.colorScheme.primary.copy(alpha = .11f)
-                else MaterialTheme.colorScheme.onSurface.copy(alpha = .055f)
-            ),
+            .size(if (material) 42.dp else 40.dp)
+            .clip(RoundedCornerShape(if (material) 14.dp else 13.dp))
+            .background(background),
         contentAlignment = Alignment.Center
     ) {
         Icon(
             imageVector = icon,
             contentDescription = null,
-            modifier = Modifier.size(20.dp),
-            tint = if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+            modifier = Modifier.size(if (material) 21.dp else 20.dp),
+            tint = tint
         )
     }
 }
@@ -265,6 +329,7 @@ fun VideoListRow(
     onClick: (() -> Unit)? = null,
     trailing: (@Composable () -> Unit)? = null
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -272,16 +337,19 @@ fun VideoListRow(
                 if (onClick != null) Modifier.clickable(enabled = enabled, onClick = onClick)
                 else Modifier
             )
-            .padding(horizontal = 15.dp, vertical = 12.dp),
+            .padding(
+                horizontal = if (material) 18.dp else 15.dp,
+                vertical = if (material) 14.dp else 12.dp
+            ),
         verticalAlignment = Alignment.CenterVertically
     ) {
         VideoLeadingIcon(icon = icon, primary = enabled)
-        Spacer(Modifier.width(12.dp))
+        Spacer(Modifier.width(if (material) 14.dp else 12.dp))
         Column(Modifier.weight(1f)) {
             Text(
                 text = title,
-                fontSize = 14.sp,
-                lineHeight = 19.sp,
+                fontSize = if (material) 15.sp else 14.sp,
+                lineHeight = if (material) 20.sp else 19.sp,
                 fontWeight = FontWeight.SemiBold,
                 color = if (enabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = .45f),
                 maxLines = 1,
@@ -291,8 +359,8 @@ fun VideoListRow(
             Text(
                 text = subtitle,
                 color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (enabled) 1f else .5f),
-                fontSize = 10.sp,
-                lineHeight = 14.sp,
+                fontSize = if (material) 11.sp else 10.sp,
+                lineHeight = if (material) 15.sp else 14.sp,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )
@@ -301,9 +369,9 @@ fun VideoListRow(
             Spacer(Modifier.width(8.dp))
             Text(
                 text = value,
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 11.sp,
-                lineHeight = 15.sp,
+                color = if (material) MaterialTheme.colorScheme.onSecondaryContainer else MaterialTheme.colorScheme.primary,
+                fontSize = if (material) 12.sp else 11.sp,
+                lineHeight = if (material) 16.sp else 15.sp,
                 fontWeight = FontWeight.Bold,
                 textAlign = TextAlign.End,
                 maxLines = 2,
@@ -342,9 +410,10 @@ fun VideoSwitchRow(
 
 @Composable
 fun VideoDivider(start: Int = 67) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
     HorizontalDivider(
-        modifier = Modifier.padding(start = start.dp),
-        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .34f)
+        modifier = Modifier.padding(start = if (material) (start + 7).dp else start.dp),
+        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = if (material) .55f else .34f)
     )
 }
 
@@ -355,19 +424,23 @@ fun VideoMetricTile(
     caption: String,
     modifier: Modifier = Modifier
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
     Surface(
         modifier = modifier,
-        shape = RoundedCornerShape(17.dp),
-        color = BaiZeTokens.colors.surfaceOverlay,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = .18f))
+        shape = RoundedCornerShape(if (material) 16.dp else 17.dp),
+        color = if (material) MaterialTheme.colorScheme.surfaceContainer else BaiZeTokens.colors.surfaceOverlay,
+        border = if (material) null else BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = .18f)
+        )
     ) {
-        Column(Modifier.padding(horizontal = 13.dp, vertical = 11.dp)) {
-            Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+        Column(Modifier.padding(horizontal = if (material) 15.dp else 13.dp, vertical = if (material) 13.dp else 11.dp)) {
+            Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = if (material) 11.sp else 10.sp)
             Spacer(Modifier.height(3.dp))
             Text(
                 value,
-                fontSize = 17.sp,
-                lineHeight = 21.sp,
+                fontSize = if (material) 18.sp else 17.sp,
+                lineHeight = if (material) 22.sp else 21.sp,
                 fontWeight = FontWeight.Bold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
@@ -376,7 +449,7 @@ fun VideoMetricTile(
             Text(
                 caption,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 9.sp,
+                fontSize = if (material) 10.sp else 9.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -393,24 +466,41 @@ fun VideoActionTile(
     modifier: Modifier = Modifier,
     primary: Boolean = false
 ) {
+    val material = LocalVideoSkin.current == VideoSkin.MATERIAL3
+    val shape = RoundedCornerShape(if (material) 18.dp else 19.dp)
+    val container = when {
+        material && primary -> MaterialTheme.colorScheme.primaryContainer
+        material -> MaterialTheme.colorScheme.secondaryContainer
+        primary -> MaterialTheme.colorScheme.primaryContainer
+        else -> BaiZeTokens.colors.surfaceRaised
+    }
+    val content = when {
+        material && primary -> MaterialTheme.colorScheme.onPrimaryContainer
+        material -> MaterialTheme.colorScheme.onSecondaryContainer
+        else -> MaterialTheme.colorScheme.onSurface
+    }
     Surface(
         modifier = modifier
-            .clip(RoundedCornerShape(19.dp))
+            .clip(shape)
             .clickable(onClick = onClick),
-        shape = RoundedCornerShape(19.dp),
-        color = if (primary) MaterialTheme.colorScheme.primaryContainer else BaiZeTokens.colors.surfaceRaised,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = .25f))
+        shape = shape,
+        color = container,
+        contentColor = content,
+        border = if (material) null else BorderStroke(
+            1.dp,
+            MaterialTheme.colorScheme.outlineVariant.copy(alpha = .25f)
+        )
     ) {
-        Column(Modifier.padding(14.dp)) {
+        Column(Modifier.padding(if (material) 16.dp else 14.dp)) {
             VideoLeadingIcon(icon = icon, primary = true)
-            Spacer(Modifier.height(10.dp))
-            Text(title, fontSize = 14.sp, fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(if (material) 12.dp else 10.dp))
+            Text(title, color = content, fontSize = if (material) 15.sp else 14.sp, fontWeight = FontWeight.Bold)
             Spacer(Modifier.height(2.dp))
             Text(
                 subtitle,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp,
-                lineHeight = 14.sp,
+                color = content.copy(alpha = .72f),
+                fontSize = if (material) 11.sp else 10.sp,
+                lineHeight = if (material) 15.sp else 14.sp,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis
             )

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
@@ -6,7 +6,8 @@ import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
-import io.github.xgl34222220.baize.ui.settings.material.SettingsScreenMaterial
+import io.github.xgl34222220.baize.ui.miuix.ProvideVideoSkin
+import io.github.xgl34222220.baize.ui.miuix.VideoSkin
 import io.github.xgl34222220.baize.ui.settings.miuix.VideoSettingsScreenMiuix
 
 @Composable
@@ -30,8 +31,11 @@ fun SettingsRoute(
         onOpenCrashDiagnostics = dashboardActions.crash
     )
 
-    when (style) {
-        UiStyle.MATERIAL -> SettingsScreenMaterial(state, actions)
-        UiStyle.MIUIX -> VideoSettingsScreenMiuix(state, actions)
+    val skin = when (style) {
+        UiStyle.MATERIAL -> VideoSkin.MATERIAL3
+        UiStyle.MIUIX -> VideoSkin.MIUIX
+    }
+    ProvideVideoSkin(skin) {
+        VideoSettingsScreenMiuix(state, actions)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
@@ -7,7 +7,7 @@ import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.settings.material.SettingsScreenMaterial
-import io.github.xgl34222220.baize.ui.settings.miuix.SettingsScreenMiuix
+import io.github.xgl34222220.baize.ui.settings.miuix.VideoSettingsScreenMiuix
 
 @Composable
 fun SettingsRoute(
@@ -32,6 +32,6 @@ fun SettingsRoute(
 
     when (style) {
         UiStyle.MATERIAL -> SettingsScreenMaterial(state, actions)
-        UiStyle.MIUIX -> SettingsScreenMiuix(state, actions)
+        UiStyle.MIUIX -> VideoSettingsScreenMiuix(state, actions)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/VideoSettingsScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/VideoSettingsScreenMiuix.kt
@@ -1,0 +1,453 @@
+package io.github.xgl34222220.baize.ui.settings.miuix
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.BatterySaver
+import androidx.compose.material.icons.rounded.BugReport
+import androidx.compose.material.icons.rounded.DarkMode
+import androidx.compose.material.icons.rounded.FolderCopy
+import androidx.compose.material.icons.rounded.Notifications
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Rule
+import androidx.compose.material.icons.rounded.Security
+import androidx.compose.material.icons.rounded.SettingsSuggest
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.SchedulerUiState
+import io.github.xgl34222220.baize.ui.miuix.VideoCard
+import io.github.xgl34222220.baize.ui.miuix.VideoDivider
+import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
+import io.github.xgl34222220.baize.ui.miuix.VideoLeadingIcon
+import io.github.xgl34222220.baize.ui.miuix.VideoListRow
+import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
+import io.github.xgl34222220.baize.ui.miuix.VideoSwitchRow
+import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
+import io.github.xgl34222220.baize.ui.settings.SettingsUiActions
+import io.github.xgl34222220.baize.ui.settings.SettingsUiState
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+import kotlin.math.roundToInt
+
+/** 设置页采用视频中的系统设置语言：居中标题、分组卡片、紧凑行高与右侧状态值。 */
+@Composable
+fun VideoSettingsScreenMiuix(
+    state: SettingsUiState,
+    actions: SettingsUiActions
+) {
+    val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val scheduler = state.scheduler
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = bottomInset + 100.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        item {
+            VideoTopBar(
+                title = "设置",
+                subtitle = "界面、自动任务与安全保护",
+                actions = {
+                    VideoIconButton(
+                        icon = Icons.Rounded.Refresh,
+                        description = "重新连接服务",
+                        onClick = actions.onReconnect
+                    )
+                }
+            )
+        }
+
+        item { AppearanceHero(state, actions.onOpenAppearance) }
+
+        item { VideoSectionTitle("自动执行", "任务只在合适的设备状态下运行") }
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+            ) {
+                VideoSwitchRow(
+                    icon = Icons.Rounded.SettingsSuggest,
+                    title = "仅在息屏时执行",
+                    subtitle = "使用手机时不占用存储性能",
+                    checked = scheduler.screenOffOnly,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(screenOffOnly = it))
+                    }
+                )
+                VideoDivider()
+                VideoSwitchRow(
+                    icon = Icons.Rounded.BatterySaver,
+                    title = "仅在充电时执行",
+                    subtitle = "连接电源后再开始自动任务",
+                    checked = scheduler.chargingOnly,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(chargingOnly = it))
+                    }
+                )
+                VideoDivider()
+                VideoSwitchRow(
+                    icon = Icons.Rounded.SettingsSuggest,
+                    title = "仅在系统空闲时执行",
+                    subtitle = "等待 Android 进入空闲状态",
+                    checked = scheduler.idleOnly,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(idleOnly = it))
+                    }
+                )
+            }
+        }
+
+        item { VideoSectionTitle("文件归类", "文件整理使用独立运行条件") }
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+            ) {
+                VideoSwitchRow(
+                    icon = Icons.Rounded.FolderCopy,
+                    title = "归类时等待息屏",
+                    subtitle = "文件移动不会打断前台操作",
+                    checked = scheduler.organizeScreenOffOnly,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(organizeScreenOffOnly = it))
+                    }
+                )
+                VideoDivider()
+                VideoSwitchRow(
+                    icon = Icons.Rounded.BatterySaver,
+                    title = "归类时等待充电",
+                    subtitle = "连接电源后再整理下载文件",
+                    checked = scheduler.organizeChargingOnly,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(organizeChargingOnly = it))
+                    }
+                )
+                VideoDivider()
+                VideoSwitchRow(
+                    icon = Icons.Rounded.SettingsSuggest,
+                    title = "归类时等待系统空闲",
+                    subtitle = "降低文件移动对前台应用的影响",
+                    checked = scheduler.organizeIdleOnly,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(organizeIdleOnly = it))
+                    }
+                )
+            }
+        }
+
+        item { VideoSectionTitle("清理保护", "电量、文件大小和白名单") }
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+            ) {
+                SliderSettingRow(
+                    icon = Icons.Rounded.BatterySaver,
+                    title = "最低电量 ${scheduler.minBattery}%",
+                    subtitle = "低于此电量时自动等待",
+                    value = scheduler.minBattery.toFloat(),
+                    valueRange = 0f..100f,
+                    steps = 19,
+                    onValueChange = {
+                        actions.onUpdateScheduler(scheduler.copy(minBattery = it.roundToInt()))
+                    }
+                )
+                VideoDivider()
+                SliderSettingRow(
+                    icon = Icons.Rounded.Security,
+                    title = "单文件上限 ${scheduler.maxFileMb} MB",
+                    subtitle = "超过上限的文件不会自动清理",
+                    value = scheduler.maxFileMb.toFloat(),
+                    valueRange = 16f..2048f,
+                    steps = 30,
+                    onValueChange = {
+                        actions.onUpdateScheduler(scheduler.copy(maxFileMb = it.roundToInt()))
+                    }
+                )
+                VideoDivider()
+                VideoListRow(
+                    icon = Icons.Rounded.Security,
+                    title = "应用白名单",
+                    subtitle = "受保护应用不会被自动清理",
+                    value = "${state.whitelistCount} 个",
+                    onClick = actions.onOpenWhitelist
+                )
+            }
+        }
+
+        item { VideoSectionTitle("通知", "任务完成后的系统提醒") }
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+            ) {
+                VideoSwitchRow(
+                    icon = Icons.Rounded.Notifications,
+                    title = "任务完成通知",
+                    subtitle = "自动任务结束后显示结果",
+                    checked = scheduler.notifyOnComplete,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(notifyOnComplete = it))
+                    }
+                )
+                VideoDivider()
+                VideoSwitchRow(
+                    icon = Icons.Rounded.Notifications,
+                    title = "零结果也通知",
+                    subtitle = "没有可清理内容时也发送通知",
+                    checked = scheduler.notifyZero,
+                    onCheckedChange = {
+                        actions.onUpdateScheduler(scheduler.copy(notifyZero = it))
+                    }
+                )
+            }
+        }
+
+        item { VideoSectionTitle("服务与诊断", "Root 服务状态和高级入口") }
+        item {
+            VideoCard(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+            ) {
+                ServiceStatusRow(state)
+                VideoDivider()
+                VideoListRow(
+                    icon = Icons.Rounded.Rule,
+                    title = "规则与清理明细",
+                    subtitle = "查看规则命中、扫描结果和保护状态",
+                    value = "打开",
+                    onClick = actions.onOpenAudit
+                )
+                VideoDivider()
+                VideoListRow(
+                    icon = Icons.Rounded.Refresh,
+                    title = "重新连接 Root 服务",
+                    subtitle = "服务异常或授权变化时使用",
+                    value = "重连",
+                    onClick = actions.onReconnect
+                )
+                VideoDivider()
+                VideoListRow(
+                    icon = Icons.Rounded.BugReport,
+                    title = "崩溃与诊断信息",
+                    subtitle = "查看最近异常和调试信息",
+                    value = "查看",
+                    onClick = actions.onOpenCrashDiagnostics
+                )
+            }
+        }
+
+        item {
+            Surface(
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .clickable(
+                        enabled = !scheduler.saving,
+                        onClick = { actions.onSaveScheduler(scheduler) }
+                    ),
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.primary
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    Text(
+                        if (scheduler.saving) "正在保存…" else "保存设置",
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppearanceHero(
+    state: SettingsUiState,
+    onClick: () -> Unit
+) {
+    VideoCard(
+        modifier = Modifier
+            .padding(horizontal = 12.dp)
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(22.dp))
+            .clickable(onClick = onClick),
+        containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = .72f),
+        contentPadding = 16
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(52.dp)
+                    .clip(RoundedCornerShape(17.dp))
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = .54f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    Icons.Rounded.DarkMode,
+                    contentDescription = null,
+                    modifier = Modifier.size(27.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            Spacer(Modifier.size(13.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    "界面与主题",
+                    fontSize = 18.sp,
+                    lineHeight = 23.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(Modifier.height(3.dp))
+                Text(
+                    state.appearanceSummary,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 10.sp,
+                    lineHeight = 14.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            Text(
+                "设置",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+@Composable
+private fun SliderSettingRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    title: String,
+    subtitle: String,
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    onValueChange: (Float) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 15.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        VideoLeadingIcon(icon)
+        Spacer(Modifier.size(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(title, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+            Text(
+                subtitle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.sp,
+                lineHeight = 14.sp
+            )
+            Slider(
+                value = value,
+                onValueChange = onValueChange,
+                valueRange = valueRange,
+                steps = steps
+            )
+        }
+    }
+}
+
+@Composable
+private fun ServiceStatusRow(state: SettingsUiState) {
+    val healthy = state.connected && state.ready && !state.running
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 15.dp, vertical = 13.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(13.dp))
+                .background(MaterialTheme.colorScheme.primary.copy(alpha = .11f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .clip(CircleShape)
+                    .background(
+                        when {
+                            state.running -> BaiZeTokens.colors.warning
+                            healthy -> BaiZeTokens.colors.success
+                            else -> MaterialTheme.colorScheme.outline
+                        }
+                    )
+            )
+        }
+        Spacer(Modifier.size(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                when {
+                    state.running -> "Root 任务执行中"
+                    healthy -> "Root 服务运行正常"
+                    state.connected -> "Root 服务已连接"
+                    else -> "Root 服务正在恢复"
+                },
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                state.serviceText,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.sp,
+                lineHeight = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+        Text(
+            when {
+                state.running -> "执行中"
+                healthy -> "正常"
+                else -> "恢复中"
+            },
+            color = MaterialTheme.colorScheme.primary,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
@@ -22,48 +22,48 @@ import io.github.xgl34222220.baize.ui.appearance.KolorStyle
 import io.github.xgl34222220.baize.ui.appearance.ThemeMode
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 
-// Material 3 使用更清晰的层级和较克制的圆角。
+/** Material 3：标准化控件皮肤，与 MIUIX 共用同一圆角等级。 */
 private val MaterialShapes = Shapes(
-    extraSmall = RoundedCornerShape(4.dp),
-    small = RoundedCornerShape(10.dp),
-    medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(24.dp),
+    extraSmall = RoundedCornerShape(10.dp),
+    small = RoundedCornerShape(12.dp),
+    medium = RoundedCornerShape(14.dp),
+    large = RoundedCornerShape(18.dp),
     extraLarge = RoundedCornerShape(28.dp)
 )
 
-// MIUIx / HyperOS 使用更紧凑的系统分组圆角，不与 Material 共用形状。
+/** MIUIX / HyperOS：分组卡片更圆润，悬浮层使用 28–32dp 圆角。 */
 private val MiuixShapes = Shapes(
-    extraSmall = RoundedCornerShape(6.dp),
+    extraSmall = RoundedCornerShape(10.dp),
     small = RoundedCornerShape(12.dp),
-    medium = RoundedCornerShape(16.dp),
+    medium = RoundedCornerShape(18.dp),
     large = RoundedCornerShape(22.dp),
-    extraLarge = RoundedCornerShape(24.dp)
+    extraLarge = RoundedCornerShape(32.dp)
 )
 
 private val MaterialTypography = Typography(
-    displaySmall = TextStyle(fontSize = 40.sp, lineHeight = 46.sp, fontWeight = FontWeight.Bold),
-    headlineLarge = TextStyle(fontSize = 32.sp, lineHeight = 38.sp, fontWeight = FontWeight.Bold),
+    displaySmall = TextStyle(fontSize = 32.sp, lineHeight = 38.sp, fontWeight = FontWeight.Bold),
+    headlineLarge = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
     headlineMedium = TextStyle(fontSize = 24.sp, lineHeight = 30.sp, fontWeight = FontWeight.Bold),
-    titleLarge = TextStyle(fontSize = 20.sp, lineHeight = 26.sp, fontWeight = FontWeight.Bold),
+    titleLarge = TextStyle(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold),
     titleMedium = TextStyle(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold),
-    bodyLarge = TextStyle(fontSize = 16.sp, lineHeight = 23.sp),
-    bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 20.sp),
-    bodySmall = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
-    labelLarge = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Bold),
-    labelMedium = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Bold)
-)
-
-private val MiuixTypography = Typography(
-    displaySmall = TextStyle(fontSize = 38.sp, lineHeight = 44.sp, fontWeight = FontWeight.Bold),
-    headlineLarge = TextStyle(fontSize = 32.sp, lineHeight = 38.sp, fontWeight = FontWeight.Bold),
-    headlineMedium = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
-    titleLarge = TextStyle(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.Bold),
-    titleMedium = TextStyle(fontSize = 15.sp, lineHeight = 21.sp, fontWeight = FontWeight.SemiBold),
     bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 22.sp),
     bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 20.sp),
     bodySmall = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
     labelLarge = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.SemiBold),
-    labelMedium = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.SemiBold)
+    labelMedium = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Medium)
+)
+
+private val MiuixTypography = Typography(
+    displaySmall = TextStyle(fontSize = 32.sp, lineHeight = 38.sp, fontWeight = FontWeight.Bold),
+    headlineLarge = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
+    headlineMedium = TextStyle(fontSize = 24.sp, lineHeight = 30.sp, fontWeight = FontWeight.Bold),
+    titleLarge = TextStyle(fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold),
+    titleMedium = TextStyle(fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold),
+    bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 22.sp),
+    bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 20.sp),
+    bodySmall = TextStyle(fontSize = 12.sp, lineHeight = 17.sp),
+    labelLarge = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.SemiBold),
+    labelMedium = TextStyle(fontSize = 11.sp, fontWeight = FontWeight.Medium)
 )
 
 @Composable
@@ -93,7 +93,7 @@ private fun BaiZeMaterialTheme(settings: AppearanceSettings, dark: Boolean, cont
     DynamicMaterialTheme(
         seedColor = resolveSeedColor(settings),
         useDarkTheme = dark,
-        withAmoled = settings.amoledBlack,
+        withAmoled = dark && settings.amoledBlack,
         style = settings.kolorStyle.toPaletteStyle(),
         shapes = MaterialShapes,
         typography = MaterialTypography,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTokens.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTokens.kt
@@ -13,83 +13,73 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
 /**
- * 方向 A 设计 token：两套皮肤（Material / Miuix）共享的语义色、圆角、间距与字阶。
- * 由 [BaiZeTheme] 按明暗/AMOLED 注入，页面与组件一律经 [BaiZeTokens] 读取，
- * 不再散落硬编码色值与随机的 dp/sp。
+ * 白泽统一原生 UI 设计 token。
+ *
+ * 基准：MIUIX / HyperOS 气质 + Material 3 动态色 + Monet + 轻量玻璃。
+ * 两套皮肤共享语义色、圆角、间距和字阶，页面不再自行定义随机值。
  */
-
-// ---------- 语义色 ----------
 
 @Immutable
 data class BaiZeColors(
-    /** 成功 / 就绪（低饱和绿） */
     val success: Color,
-    /** 警告 / 未就绪（低饱和琥珀） */
     val warning: Color,
-    /** 错误 / 危险操作 */
     val danger: Color,
-    /** 中性信息提示 */
     val info: Color,
-    /** 页面背景 */
     val surfaceBase: Color,
-    /** 卡片 / 列表项 */
     val surfaceRaised: Color,
-    /** 浮层 / 弹层 / 强调卡片 */
     val surfaceOverlay: Color
 )
 
+/** 浅色：浅紫灰底、低对比分组卡片。 */
 val LightBaiZeColors = BaiZeColors(
-    success = Color(0xFF3D9B76),
-    warning = Color(0xFFB08A3C),
-    danger = Color(0xFFC0554F),
-    info = Color(0xFF5B84A6),
-    surfaceBase = Color(0xFFF4F4F6),
-    surfaceRaised = Color(0xFFFFFFFF),
-    surfaceOverlay = Color(0xFFFCFCFD)
+    success = Color(0xFF0AA45B),
+    warning = Color(0xFFB87300),
+    danger = Color(0xFFD83A3A),
+    info = Color(0xFF245FD3),
+    surfaceBase = Color(0xFFECEBFA),
+    surfaceRaised = Color(0xFFF8F7FD),
+    surfaceOverlay = Color(0xFFF2F0FA)
 )
 
+/** 普通深色：避免纯黑压迫感，维持柔和层级。 */
 val DarkBaiZeColors = BaiZeColors(
-    success = Color(0xFF6FBA97),
-    warning = Color(0xFFCBA465),
-    danger = Color(0xFFCF7E74),
-    info = Color(0xFF8AA9C4),
-    surfaceBase = Color(0xFF101114),
-    surfaceRaised = Color(0xFF1C1D21),
-    surfaceOverlay = Color(0xFF24252A)
+    success = Color(0xFF46CF8D),
+    warning = Color(0xFFE8B45D),
+    danger = Color(0xFFFF8585),
+    info = Color(0xFF8EAFFF),
+    surfaceBase = Color(0xFF11131A),
+    surfaceRaised = Color(0xFF1B1E28),
+    surfaceOverlay = Color(0xFF252937)
 )
 
-/** AMOLED 纯黑模式：背景纯黑，卡片仅用极浅阶差。 */
+/** AMOLED：页面纯黑，主体与次级容器保留极轻阶差。 */
 val AmoledBaiZeColors = DarkBaiZeColors.copy(
     surfaceBase = Color(0xFF000000),
-    surfaceRaised = Color(0xFF101012),
-    surfaceOverlay = Color(0xFF1A1B1F)
+    surfaceRaised = Color(0xFF0C0C0D),
+    surfaceOverlay = Color(0xFF171719)
 )
-
-// ---------- 圆角 ----------
 
 @Immutable
 data class BaiZeCorners(
-    /** 小控件：图标托底、标签、chip */
+    /** Chip、小按钮、图标托底。 */
     val small: Shape,
-    /** 常规卡片、列表项 */
+    /** 输入框、设置分组卡片。 */
     val medium: Shape,
-    /** 页面级大卡片、对话框 */
+    /** 数据卡、仪表盘主卡片。 */
     val large: Shape,
-    /** Hero / 主按钮 / Dock */
+    /** 悬浮底栏、底部弹层与高层级浮层。 */
     val extraLarge: Shape,
-    /** 胶囊、圆形指示点 */
+    /** 胶囊和圆形状态。 */
     val full: Shape
 )
 
 val DefaultBaiZeCorners = BaiZeCorners(
     small = RoundedCornerShape(12.dp),
-    medium = RoundedCornerShape(20.dp),
-    large = RoundedCornerShape(28.dp),
-    extraLarge = RoundedCornerShape(36.dp),
+    medium = RoundedCornerShape(18.dp),
+    large = RoundedCornerShape(22.dp),
+    extraLarge = RoundedCornerShape(32.dp),
     full = RoundedCornerShape(percent = 50)
 )
-
-// ---------- 间距（4 倍数） ----------
 
 @Immutable
 data class BaiZeSpacing(
@@ -100,39 +90,30 @@ data class BaiZeSpacing(
     val xl: Dp = 20.dp,
     val xxl: Dp = 24.dp,
     val huge: Dp = 32.dp,
-    /** 全应用统一的页面水平边距 */
-    val pageHorizontal: Dp = 20.dp
+    /** 360dp 手机基准的统一页面左右边距。 */
+    val pageHorizontal: Dp = 12.dp
 )
 
 val DefaultBaiZeSpacing = BaiZeSpacing()
 
-// ---------- 字阶 ----------
-
 @Immutable
 data class BaiZeTypeScale(
-    /** 11sp：说明文字、辅助信息（应用内最小字号） */
     val caption: TextStyle,
-    /** 13sp：正文 */
     val body: TextStyle,
-    /** 15sp：强调正文 */
     val bodyLarge: TextStyle,
-    /** 17sp：卡片标题 */
     val title: TextStyle,
-    /** 22sp：区块标题（中文 Bold，不用 Black） */
     val headline: TextStyle,
-    /** 28sp：页头主标题 */
     val display: TextStyle,
-    /** 40sp 等宽数字：Hero 大数字 */
     val hero: TextStyle
 )
 
 val DefaultBaiZeTypeScale = BaiZeTypeScale(
-    caption = TextStyle(fontSize = 11.sp, lineHeight = 15.sp),
-    body = TextStyle(fontSize = 13.sp, lineHeight = 18.sp),
+    caption = TextStyle(fontSize = 11.sp, lineHeight = 16.sp),
+    body = TextStyle(fontSize = 14.sp, lineHeight = 20.sp),
     bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 21.sp),
     title = TextStyle(fontSize = 17.sp, lineHeight = 23.sp, fontWeight = FontWeight.SemiBold),
-    headline = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
-    display = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
+    headline = TextStyle(fontSize = 24.sp, lineHeight = 30.sp, fontWeight = FontWeight.Bold),
+    display = TextStyle(fontSize = 30.sp, lineHeight = 36.sp, fontWeight = FontWeight.Bold),
     hero = TextStyle(
         fontSize = 40.sp,
         lineHeight = 46.sp,
@@ -141,14 +122,11 @@ val DefaultBaiZeTypeScale = BaiZeTypeScale(
     )
 )
 
-// ---------- CompositionLocal 注入 ----------
-
 val LocalBaiZeColors = staticCompositionLocalOf { LightBaiZeColors }
 val LocalBaiZeCorners = staticCompositionLocalOf { DefaultBaiZeCorners }
 val LocalBaiZeSpacing = staticCompositionLocalOf { DefaultBaiZeSpacing }
 val LocalBaiZeTypeScale = staticCompositionLocalOf { DefaultBaiZeTypeScale }
 
-/** 统一的 token 读取入口：`BaiZeTokens.colors.success` 等。 */
 object BaiZeTokens {
     val colors: BaiZeColors
         @Composable get() = LocalBaiZeColors.current

--- a/v2/module/apk-snapshot-scan.sh
+++ b/v2/module/apk-snapshot-scan.sh
@@ -138,27 +138,42 @@ human_bytes() { awk -v b="$1" 'BEGIN { if (b>=1073741824) printf "%.2f GB",b/107
 should_stop() { [ -f "$STOP_FILE" ]; }
 
 CONFIG_DAYS=$(get_uint apk_package_days 30 0 365)
-# 手动安装包扫描必须展示当前能找到的全部安装包；保留期只用于自动任务。
-if [ "$TRIGGER" = "manual" ]; then DAYS=0; else DAYS=$CONFIG_DAYS; fi
+# App 内点击、命令行手动扫描都必须展示当前可找到的全部安装包；保留期只用于自动任务。
+case "$TRIGGER" in
+  manual|app|ui) DAYS=0 ;;
+  *) DAYS=$CONFIG_DAYS ;;
+esac
 MAX_MB=$(get_uint apk_package_max_mb 4096 16 16384)
 MAX_FILE_BYTES=$((MAX_MB * 1024 * 1024))
 INDEX_FILE="$STATE_DIR/index/storage-files.nul"
+APK_INDEX="$STATE_DIR/index/apk-files.nul"
 COVERAGE_FILE="$STATE_DIR/index/coverage.tsv"
-set_phase "正在建立全应用共享存储索引" 0 0 "$MEDIA_ROOT"
-if ! BAIZE_STATE_DIR="$STATE_DIR" BAIZE_MEDIA_ROOT="$MEDIA_ROOT" /system/bin/sh "$MODDIR/storage-index.sh" refresh "$TRIGGER"; then
-  echo "共享存储索引失败" >&2
+
+# 旧实现每次点击都强制 refresh 全部共享存储，并再次遍历全量文件索引筛 APK。
+# 现在使用增量 ensure，并直接消费 storage-index.sh 已生成的专用 APK NUL 索引。
+set_phase "正在更新安装包快速索引" 0 0 "$MEDIA_ROOT"
+if ! BAIZE_STATE_DIR="$STATE_DIR" BAIZE_MEDIA_ROOT="$MEDIA_ROOT" /system/bin/sh "$MODDIR/storage-index.sh" ensure "$TRIGGER"; then
+  echo "安装包索引更新失败" >&2
   exit 5
 fi
-[ -s "$INDEX_FILE" ] || { echo "共享存储索引为空" >&2; exit 5; }
+[ -f "$INDEX_FILE" ] || { echo "共享存储索引缺失" >&2; exit 5; }
+[ -f "$APK_INDEX" ] || { echo "安装包快速索引缺失" >&2; exit 5; }
 
-root_total=$(awk -F '\t' 'NR>1 && ($1=="scanned" || $1=="partial"){n++} END{print n+0}' "$COVERAGE_FILE" 2>/dev/null)
+root_total=$(awk -F '\t' 'NR>1{n++} END{print n+0}' "$COVERAGE_FILE" 2>/dev/null)
 root_current=$root_total
+apk_total=$(tr -cd '\000' <"$APK_INDEX" 2>/dev/null | wc -c | tr -d ' ')
+case "$apk_total" in ''|*[!0-9]*) apk_total=0 ;; esac
 protected=0
 errors=0
 cutoff=$((START_EPOCH - DAYS * 86400))
-set_phase "正在从共享索引筛选安装包" 0 "$root_total" "$INDEX_FILE"
+current=0
+set_phase "正在校验安装包文件" 0 "$apk_total" "$APK_INDEX"
 while IFS= read -r -d '' candidate; do
   should_stop && handle_signal
+  current=$((current + 1))
+  if [ $((current % 16)) -eq 0 ] || [ "$current" -eq "$apk_total" ]; then
+    set_phase "正在校验安装包文件" "$current" "$apk_total" "$candidate"
+  fi
   [ -f "$candidate" ] || continue
   ext=$(printf '%s' "${candidate##*.}" | tr '[:upper:]' '[:lower:]')
   case "$ext" in apk|apks|xapk|apkm) ;; *) continue ;; esac
@@ -174,7 +189,7 @@ while IFS= read -r -d '' candidate; do
     continue
   fi
   printf '%s\0' "$candidate" >>"$TARGETS_TMP"
-done <"$INDEX_FILE"
+done <"$APK_INDEX"
 
 files=0
 bytes=0
@@ -247,7 +262,7 @@ cp -f "$REPORT_FILE" "$REPORT_DIR/latest.tsv"
   echo "----------------------------------------"
   echo "$result"
   echo "扫描快照: $snapshot_id"
-  echo "扫描根目录: $root_total | 手动扫描全部年龄: $([ "$DAYS" -eq 0 ] && echo 是 || echo 否)"
+  echo "扫描根目录: $root_total | 快速索引候选: $apk_total | 交互扫描全部年龄: $([ "$DAYS" -eq 0 ] && echo 是 || echo 否)"
   echo "白名单或异常保护: $protected | 失败: $errors | 耗时: ${elapsed}s"
   echo "扫描覆盖来源: $root_total（详情见 $COVERAGE_FILE）"
 } >>"$LOG_FILE"
@@ -258,7 +273,7 @@ printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
 tail -n 100 "$HISTORY_FILE" >"$HISTORY_FILE.tmp.$$" 2>/dev/null && mv -f "$HISTORY_FILE.tmp.$$" "$HISTORY_FILE"
 
 echo "$result"
-echo "扫描快照: $snapshot_id | 安装包: $files 个 | 扫描根: $root_total | 受保护: $protected | 耗时: ${elapsed}s"
+echo "扫描快照: $snapshot_id | 安装包: $files 个 | 索引候选: $apk_total | 扫描根: $root_total | 受保护: $protected | 耗时: ${elapsed}s"
 cleanup_lock
 trap - EXIT INT TERM
 exit 0

--- a/v2/tests/test-home-one-tap-actions-contract.sh
+++ b/v2/tests/test-home-one-tap-actions-contract.sh
@@ -11,16 +11,20 @@ for file in "$HOME" "$CLEAN" "$DASH" "$CI"; do
   test -f "$file" || exit 1
 done
 
-grep -Fq 'HomeScreenMaterial(state, scheduler, actions, onOpenClean)' "$HOME"
-grep -Fq 'HomeScreenMiuix(state, scheduler, actions, onOpenClean)' "$HOME"
+# MIUIX 与 Material 3 现在共用同一套视频风格首页骨架，只通过 VideoSkin 切换组件皮肤。
+grep -Fq 'UiStyle.MATERIAL -> VideoSkin.MATERIAL3' "$HOME"
+grep -Fq 'UiStyle.MIUIX -> VideoSkin.MIUIX' "$HOME"
+grep -Fq 'VideoHomeScreenMiuix(state, scheduler, actions, onOpenClean)' "$HOME"
 ! grep -Fq 'actions.copy(' "$HOME"
 ! grep -Fq 'ScanWorkbenchActivity' "$HOME"
 
+# 首页一键清理与一键归类仍直接执行 Root 任务，不能退化成打开扫描工作台。
 grep -Fq 'clean = { runSmartClean() }' "$DASH"
 grep -Fq 'organize = { runOneTapOrganize() }' "$DASH"
 grep -Fq 'service.runModuleTask("clean")' "$DASH"
 grep -Fq 'service.runModuleTask("organize")' "$DASH"
 
+# 详细扫描继续只放在清理页专项入口。
 grep -Fq 'import io.github.xgl34222220.baize.ScanWorkbenchActivity' "$CLEAN"
 grep -Fq 'onScan = { context.startActivity(Intent(context, ScanWorkbenchActivity::class.java)) }' "$CLEAN"
 grep -Fq 'test-home-one-tap-actions-contract.sh' "$CI"


### PR DESCRIPTION
## 白泽原生 App 全量升级

本 PR 参考用户提供的视频界面，对 `v2/app` 的首页、清理、记录和设置四个一级页面进行全量 Compose UI 重构，并同步修复实机测试中发现的安装包扫描问题。

## UI 重构

- MIUIX 与 Material 3 共用同一套全新信息架构和页面骨架，切换外观不再退回旧页面。
- 首页：居中标题、主状态卡、清理 / 扫描 / 归类操作、存储进度、指标卡和 Root 状态。
- 清理：计划 / 类别 / 工具标签页、自动清理状态、执行模式、独立类别周期和专项工具。
- 记录：概览 / 应用 / 历史标签页，重新组织累计数据、最近结果和任务记录。
- 设置：系统设置式分组卡片，重新组织主题、执行条件、保护、通知、服务和诊断。
- 主体卡片改为实色单层圆角容器，修复部分设备出现“圆角卡片内套白色方块”的渲染问题。
- 保留 Monet、深色、AMOLED 和悬浮玻璃底栏。

## 安装包扫描与清理

- App 手动扫描不再误套后台 30 天保留期，手动扫描始终显示全部 APK / APKS / XAPK / APKM。
- 扫描改为复用增量共享索引和专用安装包索引，避免每次强制全盘重建后再遍历全部文件。
- 后台安装包保留时间从固定 30 天改为可配置 0–365 天。
- 清理页新增“安装包保留时间”入口，修改后立即保存到 Root `apk_package_days` 配置。
- 保留时间只影响后台自动清理，不影响手动扫描结果。

## 安全边界

- 首页一键清理与一键归类继续直接执行原 Root 任务。
- 详细扫描仍使用不可变快照，清理前继续进行授权与状态复核。
- 不取消白名单、关键路径、挂载点、软链接、单文件上限和高风险保护。

## 验证

- Root Stability CI 覆盖 Shell / BusyBox、调度、快照、深度清理、索引、归类与首页一键动作契约。
- Android UI CI 覆盖 Kotlin 编译、Lint 和 Macrobenchmark。
- 正式发布前使用现有正式签名 Secrets 构建 Release APK 与完整模块 ZIP。