### PR TITLE
修复设置页开关自动回退

### DIFF
--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
@@ -1,6 +1,11 @@
 package io.github.xgl34222220.baize.ui.settings
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import io.github.xgl34222220.baize.DashboardActions
 import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.SchedulerUiState
@@ -19,10 +24,44 @@ fun SettingsRoute(
     dashboardActions: DashboardActions,
     onOpenDetails: () -> Unit
 ) {
-    val state = dashboard.toSettingsUiState(scheduler, appearance)
+    var draft by remember { mutableStateOf(scheduler.copy(saving = false)) }
+    var dirty by remember { mutableStateOf(false) }
+    var saveRequested by remember { mutableStateOf(false) }
+
+    LaunchedEffect(scheduler) {
+        when {
+            !dirty -> {
+                draft = scheduler.copy(saving = false)
+            }
+
+            saveRequested && !scheduler.saving && scheduler.hasSameEditableConfig(draft) -> {
+                draft = scheduler.copy(saving = false)
+                dirty = false
+                saveRequested = false
+            }
+
+            else -> {
+                draft = draft.withRuntimeFrom(scheduler).copy(saving = false)
+            }
+        }
+    }
+
+    val visibleScheduler = draft.withRuntimeFrom(scheduler)
+    val state = dashboard.toSettingsUiState(visibleScheduler, appearance)
     val actions = SettingsUiActions(
-        onUpdateScheduler = dashboardActions.updateScheduler,
-        onSaveScheduler = dashboardActions.saveScheduler,
+        onUpdateScheduler = { updated ->
+            draft = updated.copy(saving = false)
+            dirty = true
+            saveRequested = false
+            dashboardActions.updateScheduler(updated.copy(saving = false))
+        },
+        onSaveScheduler = { requested ->
+            val cleanDraft = requested.copy(saving = false)
+            draft = cleanDraft
+            dirty = true
+            saveRequested = true
+            dashboardActions.saveScheduler(cleanDraft)
+        },
         onSchedulerCommand = dashboardActions.schedulerCommand,
         onOpenAppearance = dashboardActions.theme,
         onOpenWhitelist = dashboardActions.whitelist,
@@ -39,3 +78,30 @@ fun SettingsRoute(
         VideoSettingsScreenMiuix(state, actions)
     }
 }
+
+private fun SchedulerUiState.hasSameEditableConfig(other: SchedulerUiState): Boolean =
+    toJson().toString() == other.toJson().toString()
+
+/**
+ * 前台轮询只负责刷新调度器运行状态；尚未保存的设置草稿必须继续留在界面中。
+ */
+private fun SchedulerUiState.withRuntimeFrom(remote: SchedulerUiState): SchedulerUiState = copy(
+    runtimeState = remote.runtimeState,
+    runtimeReason = remote.runtimeReason,
+    queueCount = remote.queueCount,
+    queueGroups = remote.queueGroups,
+    nextTask = remote.nextTask,
+    blockedGroups = remote.blockedGroups,
+    nextCheckEpoch = remote.nextCheckEpoch,
+    runtimeGroup = remote.runtimeGroup,
+    cacheNextEpoch = remote.cacheNextEpoch,
+    emptyNextEpoch = remote.emptyNextEpoch,
+    rulesNextEpoch = remote.rulesNextEpoch,
+    fragmentNextEpoch = remote.fragmentNextEpoch,
+    deepNextEpoch = remote.deepNextEpoch,
+    organizeNextEpoch = remote.organizeNextEpoch,
+    supervisorStatus = remote.supervisorStatus,
+    supervisorHeartbeatAge = remote.supervisorHeartbeatAge,
+    runtimeStale = remote.runtimeStale,
+    saving = remote.saving
+)


### PR DESCRIPTION
## 问题

白泽 v2.5.6 正式版设置页会每 0.75～3 秒轮询 Root 调度配置，并把服务端旧配置直接覆盖到 Compose 状态。用户尚未点击“保存设置”时，刚切换的开关因此会自动回退。

## 修复

- 设置页新增本地配置草稿，用户改动不再被前台轮询覆盖。
- Root 轮询仍实时合并运行状态、队列、下次执行时间和守护进程状态。
- 保存成功且服务端配置与草稿一致后，才结束草稿状态并同步服务端结果。
- 保存失败或轮询返回旧值时保留用户改动，允许再次保存。

## 影响范围

覆盖录屏中的“仅在息屏/充电/系统空闲时执行”“归类时等待息屏/充电/系统空闲”等开关，也同时保护电量、文件上限、通知等未保存设置。