### PR TITLE
修复 App 反复重连，收拢重复恢复与轮询逻辑

### DIFF
--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -43,7 +43,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          gradle --no-daemon :app:compileDebugKotlin :app:lintDebug :macrobenchmark:assemble > /tmp/baize-android-ui.log 2>&1
+          gradle --no-daemon :app:testDebugUnitTest :app:compileDebugKotlin :app:lintDebug :macrobenchmark:assemble > /tmp/baize-android-ui.log 2>&1
           code=$?
           tail -n 200 /tmp/baize-android-ui.log
           exit "$code"

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/FileOrganizerWorker.kt
@@ -17,7 +17,9 @@ import com.topjohnwu.superuser.ipc.RootService
 import io.github.xgl34222220.baize.root.BaiZeProfileRootService
 import io.github.xgl34222220.baize.root.IProfileRootService
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
@@ -46,7 +48,8 @@ data class FileOrganizerScheduleSettings(
  */
 class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
     override suspend fun doWork(): Result {
-        val session = runCatching { bindRootServiceWithRetry() }.getOrElse {
+        val session = runCatching { withTimeout(ROOT_BIND_TIMEOUT_MS) { bindRootService() } }.getOrElse {
+            currentCoroutineContext().ensureActive()
             writeResult(applicationContext, "Root 调度器连接失败：${it.message ?: it.javaClass.simpleName}")
             return Result.retry()
         }
@@ -63,6 +66,7 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
                 return Result.success()
             }
             val response = runCatching { JSONObject(session.service.runModuleTask("scheduler-wake")) }.getOrElse {
+                currentCoroutineContext().ensureActive()
                 writeResult(applicationContext, "Root 调度器唤醒失败：${it.message ?: it.javaClass.simpleName}")
                 return Result.retry()
             }
@@ -82,17 +86,6 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
         } finally {
             session.close()
         }
-    }
-
-    private suspend fun bindRootServiceWithRetry(): RootSession {
-        var lastError: Throwable? = null
-        repeat(ROOT_BIND_ATTEMPTS) { attempt ->
-            val result = runCatching { withTimeout(ROOT_BIND_TIMEOUT_MS) { bindRootService() } }
-            result.getOrNull()?.let { return it }
-            lastError = result.exceptionOrNull()
-            if (attempt + 1 < ROOT_BIND_ATTEMPTS) delay(ROOT_BIND_RETRY_DELAY_MS * (attempt + 1L))
-        }
-        throw lastError ?: IllegalStateException("Root 服务连接失败")
     }
 
     private suspend fun bindRootService(): RootSession = withContext(Dispatchers.Main.immediate) {
@@ -128,12 +121,15 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
                         .addCategory(RootService.CATEGORY_DAEMON_MODE),
                     connection
                 )
-            }.onFailure { if (continuation.isActive) continuation.resumeWithException(it) }
+            }.onFailure {
+                unbindOnMainThread()
+                if (continuation.isActive) continuation.resumeWithException(it)
+            }
         }
     }
 
     private data class RootSession(val service: IProfileRootService, val connection: ServiceConnection) {
-        suspend fun close() = withContext(Dispatchers.Main.immediate) { runCatching { RootService.unbind(connection) } }
+        suspend fun close() = withContext(NonCancellable + Dispatchers.Main.immediate) { runCatching { RootService.unbind(connection) } }
     }
 
     companion object {
@@ -150,8 +146,6 @@ class FileOrganizerWorker(appContext: Context, params: WorkerParameters) : Corou
         private const val KEY_LAST_RESULT = "last_result"
         private const val UNIQUE_WORK = "baize_root_scheduler_watchdog"
         private const val ROOT_BIND_TIMEOUT_MS = 20_000L
-        private const val ROOT_BIND_ATTEMPTS = 3
-        private const val ROOT_BIND_RETRY_DELAY_MS = 800L
         private const val WATCHDOG_INTERVAL_MINUTES = 15L
         private const val WATCHDOG_FLEX_MINUTES = 5L
         val ALLOWED_INTERVALS = listOf(30, 60, 360, 720, 1_440, 4_320, 10_080)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
@@ -204,7 +204,8 @@ class MiuixDashboardActivity : ComponentActivity() {
                 appearance = appearance
             )
         }
-        connectPrimaryService()
+        // Both engines may own a task from the previous App process.
+        connectServices()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -336,9 +337,8 @@ class MiuixDashboardActivity : ComponentActivity() {
     }
 
     private suspend fun probeRemoteTask(): RemoteTaskProbe = withContext(Dispatchers.IO) {
-        val expectProfile = true
         val expectCache = cacheRequested
-        var profileResponded = !expectProfile
+        var profileResponded = false
         var cacheResponded = !expectCache
         var runningState: JSONObject? = null
 
@@ -358,7 +358,7 @@ class MiuixDashboardActivity : ComponentActivity() {
         }
 
         RemoteTaskProbe(
-            complete = (expectProfile || expectCache) && profileResponded && cacheResponded,
+            complete = profileResponded && cacheResponded,
             runningState = runningState
         )
     }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
@@ -66,8 +66,10 @@ class MiuixDashboardActivity : ComponentActivity() {
     private var pollJob: Job? = null
     private var recoveryProbeJob: Job? = null
     private var schedulerMonitorJob: Job? = null
-    private var queueStallStartedRealtime = 0L
-    private var lastQueueWakeRealtime = 0L
+    private val connectionRecovery = RootRecoveryPolicy()
+    private var serviceRecoveryJob: Job? = null
+    private var cacheRequested = false
+    private var releasingConnections = false
     private var taskCallbackRegistered = false
     private val taskProgressCallback = object : ITaskProgressCallback.Stub() {
         override fun onTaskProgress(stateJson: String?) {
@@ -86,39 +88,73 @@ class MiuixDashboardActivity : ComponentActivity() {
 
     private val profileConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            if (isDestroyed || releasingConnections) return
             rootService = IProfileRootService.Stub.asInterface(binder)
             profileBound = true
             taskCallbackRegistered = runCatching { rootService?.registerTaskProgressCallback(taskProgressCallback); true }.getOrDefault(false)
+            if (rootService != null && (!cacheRequested || cacheService != null)) {
+                connectionRecovery.connected(SystemClock.elapsedRealtime())
+                serviceRecoveryJob?.cancel()
+                serviceRecoveryJob = null
+            }
             updateConnectionState()
             recoverRemoteTaskOrRefresh(runPendingActions = true)
         }
 
+        override fun onNullBinding(name: ComponentName?) {
+            runCatching { RootService.unbind(this) }
+            onServiceDisconnected(name)
+        }
+
+        override fun onBindingDied(name: ComponentName?) {
+            runCatching { RootService.unbind(this) }
+            onServiceDisconnected(name)
+        }
+
         override fun onServiceDisconnected(name: ComponentName?) {
+            if (releasingConnections || isDestroyed) return
             rootService = null
             profileBound = false
             taskCallbackRegistered = false
             pollJob?.cancel()
             updateConnectionState()
             scheduleServiceRecovery(
-                requireCache = pendingScanAfterConnect != null || pendingSnapshotClean || safeSnapshotId.isNotBlank()
+                requireCache = cacheRequested
             )
         }
     }
 
     private val cacheConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            if (isDestroyed || releasingConnections) return
             cacheService = IBaiZeRootService.Stub.asInterface(binder)
             cacheBound = true
+            if (rootService != null && (!cacheRequested || cacheService != null)) {
+                connectionRecovery.connected(SystemClock.elapsedRealtime())
+                serviceRecoveryJob?.cancel()
+                serviceRecoveryJob = null
+            }
             updateConnectionState()
             recoverRemoteTaskOrRefresh(runPendingActions = true)
         }
 
+        override fun onNullBinding(name: ComponentName?) {
+            runCatching { RootService.unbind(this) }
+            onServiceDisconnected(name)
+        }
+
+        override fun onBindingDied(name: ComponentName?) {
+            runCatching { RootService.unbind(this) }
+            onServiceDisconnected(name)
+        }
+
         override fun onServiceDisconnected(name: ComponentName?) {
+            if (releasingConnections || isDestroyed) return
             cacheService = null
             cacheBound = false
             pollJob?.cancel()
             updateConnectionState()
-            if (pendingScanAfterConnect != null || pendingSnapshotClean || cacheSnapshotId.isNotBlank()) {
+            if (cacheRequested) {
                 scheduleServiceRecovery(requireCache = true)
             }
         }
@@ -168,7 +204,7 @@ class MiuixDashboardActivity : ComponentActivity() {
                 appearance = appearance
             )
         }
-        connectServices()
+        connectPrimaryService()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -192,7 +228,7 @@ class MiuixDashboardActivity : ComponentActivity() {
         if (rootService != null || cacheService != null) {
             recoverRemoteTaskOrRefresh()
         } else {
-            connectServices()
+            connectRequestedServices()
         }
         startForegroundModuleMonitor()
     }
@@ -213,32 +249,17 @@ class MiuixDashboardActivity : ComponentActivity() {
                     delay(750L)
                     continue
                 }
-                val snapshots = withContext(Dispatchers.IO) {
-                    val schedulerJson = runCatching { JSONObject(service.getSchedulerConfig()) }.getOrNull()
-                    val taskJson = runCatching { JSONObject(service.getTaskState()) }.getOrNull()
-                    schedulerJson to taskJson
+                // The active task poll owns progress. The foreground monitor only fills gaps.
+                val schedulerJson = withContext(Dispatchers.IO) {
+                    runCatching { JSONObject(service.getSchedulerConfig()) }.getOrNull()
                 }
-                snapshots.first?.let { schedulerJson ->
-                    val schedulerSnapshot = SchedulerUiState.fromJson(schedulerJson)
-                    schedulerState.value = schedulerSnapshot
-                    val reason = schedulerSnapshot.runtimeReason
-                    val blocked = reason.contains("息屏") || reason.contains("充电") || reason.contains("电量") ||
-                        reason.contains("空闲") || reason.contains("当前任务") || reason.contains("自动重试") || reason.contains("自动恢复")
-                    val pending = schedulerSnapshot.queueCount > 0 && schedulerSnapshot.runtimeState != "running" && !blocked
-                    val nowRealtime = SystemClock.elapsedRealtime()
-                    if (pending) {
-                        if (queueStallStartedRealtime == 0L) queueStallStartedRealtime = nowRealtime
-                        if (nowRealtime - queueStallStartedRealtime >= 2_000L && nowRealtime - lastQueueWakeRealtime >= 2_500L) {
-                            lastQueueWakeRealtime = nowRealtime
-                            withContext(Dispatchers.IO) { runCatching { service.runModuleTask("scheduler-wake") } }
-                        }
-                    } else queueStallStartedRealtime = 0L
-                }
-                val task = snapshots.second
+                schedulerJson?.let { schedulerState.value = SchedulerUiState.fromJson(it) }
+                val probe = if (pollJob?.isActive == true) null else probeRemoteTask()
+                val task = probe?.runningState
                 if (task?.optBoolean("running") == true) {
                     idleConfirmations = 0
                     renderTaskState(task)
-                } else if (dashboardState.value.running) {
+                } else if (probe?.complete == true && pollJob?.isActive != true && dashboardState.value.running) {
                     idleConfirmations += 1
                     if (idleConfirmations >= 2) {
                         idleConfirmations = 0
@@ -252,10 +273,7 @@ class MiuixDashboardActivity : ComponentActivity() {
                 } else {
                     idleConfirmations = 0
                 }
-                val fast = dashboardState.value.running ||
-                    schedulerState.value.runtimeState == "running" ||
-                    schedulerState.value.queueCount > 0
-                delay(if (fast) 750L else 3_000L)
+                delay(3_000L)
             }
         }
     }
@@ -294,14 +312,15 @@ class MiuixDashboardActivity : ComponentActivity() {
                     dashboardState.value = dashboardState.value.copy(
                         connected = rootService != null,
                         ready = false,
-                        serviceText = "正在连接后台任务状态…",
+                        serviceText = if (connectionRecovery.exhausted) "Root 连接恢复失败，请手动重连"
+                            else "暂时无法读取后台任务状态，稍后重试",
                         taskPhase = if (dashboardState.value.running) {
                             "后台任务仍在执行，正在恢复 Root 连接…"
                         } else {
                             dashboardState.value.taskPhase
                         }
                     )
-                    connectServices()
+                    connectRequestedServices()
                 }
                 dashboardState.value.running -> {
                     // A just-started Binder task may need a brief moment before running.env appears.
@@ -317,8 +336,8 @@ class MiuixDashboardActivity : ComponentActivity() {
     }
 
     private suspend fun probeRemoteTask(): RemoteTaskProbe = withContext(Dispatchers.IO) {
-        val expectProfile = rootService != null || profileBound
-        val expectCache = cacheService != null || cacheBound
+        val expectProfile = true
+        val expectCache = cacheRequested
         var profileResponded = !expectProfile
         var cacheResponded = !expectCache
         var runningState: JSONObject? = null
@@ -361,14 +380,14 @@ class MiuixDashboardActivity : ComponentActivity() {
                 if (!probe.complete) {
                     idleConfirmations = 0
                     dashboardState.value = dashboardState.value.copy(
-                        running = true,
                         connected = rootService != null,
                         ready = false,
-                        serviceText = "后台任务连接中断，正在自动恢复…",
+                        serviceText = if (connectionRecovery.exhausted) "Root 连接恢复失败，请手动重连"
+                            else "暂时无法读取后台任务进度…",
                         taskPhase = "后台任务仍由 Root 执行，正在重新连接进度…"
                     )
-                    connectServices()
-                    delay(700)
+                    connectRequestedServices()
+                    delay(1_500)
                     continue
                 }
 
@@ -392,6 +411,7 @@ class MiuixDashboardActivity : ComponentActivity() {
     }
 
     private fun connectPrimaryService() {
+        if (releasingConnections || isDestroyed || connectionRecovery.exhausted || serviceRecoveryJob?.isActive == true) return
         if (rootService != null || profileBound) return
         dashboardState.value = dashboardState.value.copy(
             connected = false,
@@ -412,51 +432,59 @@ class MiuixDashboardActivity : ComponentActivity() {
                 ready = false,
                 serviceText = "Root 清理服务启动失败：${it.message.orEmpty()}"
             )
+            scheduleServiceRecovery(requireCache = cacheRequested)
         }
     }
 
     private fun connectServices() {
-        dashboardState.value = dashboardState.value.copy(serviceText = "正在连接双 Root 快照引擎…")
-        if (!profileBound) {
-            runCatching {
-                RootService.bind(
-                    Intent(this, BaiZeProfileRootService::class.java)
-                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
-                    profileConnection
-                )
-                profileBound = true
-            }.onFailure {
-                dashboardState.value = dashboardState.value.copy(serviceText = "分类引擎启动失败：${it.message.orEmpty()}")
-            }
-        }
-        if (!cacheBound) {
-            runCatching {
-                RootService.bind(
-                    Intent(this, BaiZeRootService::class.java)
-                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
-                    cacheConnection
-                )
-                cacheBound = true
-            }.onFailure {
-                dashboardState.value = dashboardState.value.copy(serviceText = "缓存引擎启动失败：${it.message.orEmpty()}")
-            }
+        cacheRequested = true
+        connectRequestedServices()
+    }
+
+    private fun connectRequestedServices() {
+        connectPrimaryService()
+        if (!cacheRequested || cacheBound || releasingConnections || isDestroyed ||
+            connectionRecovery.exhausted || serviceRecoveryJob?.isActive == true) return
+        runCatching {
+            RootService.bind(
+                Intent(this, BaiZeRootService::class.java)
+                    .addCategory(RootService.CATEGORY_DAEMON_MODE),
+                cacheConnection
+            )
+            cacheBound = true
+        }.onFailure {
+            cacheBound = false
+            dashboardState.value = dashboardState.value.copy(serviceText = "缓存引擎启动失败：${it.message.orEmpty()}")
+            scheduleServiceRecovery(requireCache = true)
         }
     }
 
-    private fun reconnectService() {
+    private fun releaseConnections() {
+        releasingConnections = true
+        serviceRecoveryJob?.cancel()
+        serviceRecoveryJob = null
+        recoveryProbeJob?.cancel()
+        pollJob?.cancel()
+        if (taskCallbackRegistered) runCatching { rootService?.unregisterTaskProgressCallback(taskProgressCallback) }
+        taskCallbackRegistered = false
         if (profileBound) runCatching { RootService.unbind(profileConnection) }
         if (cacheBound) runCatching { RootService.unbind(cacheConnection) }
         rootService = null
         cacheService = null
         profileBound = false
         cacheBound = false
+        releasingConnections = false
+    }
+
+    private fun reconnectService() {
+        releaseConnections()
+        connectionRecovery.reset()
         dashboardState.value = dashboardState.value.copy(
             connected = false,
             ready = false,
-            running = false,
             serviceText = "正在重新连接 Root 清理服务…"
         )
-        connectPrimaryService()
+        connectRequestedServices()
         toast("正在重新连接 Root 清理服务")
     }
 
@@ -467,7 +495,9 @@ class MiuixDashboardActivity : ComponentActivity() {
             connected = primaryConnected,
             ready = if (primaryConnected) dashboardState.value.ready else false,
             serviceText = when {
+                primaryConnected && dashboardState.value.ready -> dashboardState.value.serviceText
                 primaryConnected -> "Root 清理服务已连接，正在校验模块组件…"
+                connectionRecovery.exhausted -> "Root 连接恢复失败，请手动重连"
                 scanReady -> "扫描快照已就绪，清理时会自动恢复 Root 服务"
                 profileBound -> "正在连接 Root 清理服务…"
                 else -> "Root 清理服务已断开，正在自动恢复…"
@@ -515,11 +545,28 @@ class MiuixDashboardActivity : ComponentActivity() {
     }
 
     private fun scheduleServiceRecovery(requireCache: Boolean) {
-        lifecycleScope.launch {
-            delay(350)
-            if (isFinishing || isDestroyed) return@launch
-            if (requireCache) connectServices() else connectPrimaryService()
+        cacheRequested = cacheRequested || requireCache
+        if (releasingConnections || isFinishing || isDestroyed) return
+        connectionRecovery.disconnected(SystemClock.elapsedRealtime())
+        if (serviceRecoveryJob?.isActive == true) return
+        val retryDelay = connectionRecovery.nextDelay() ?: run {
+            dashboardState.value = dashboardState.value.copy(serviceText = "Root 连接恢复失败，请手动重连")
+            return
         }
+        serviceRecoveryJob = lifecycleScope.launch {
+            delay(retryDelay)
+            serviceRecoveryJob = null
+            connectRequestedServices()
+        }
+    }
+
+    private fun handleTaskRequestFailure(service: IProfileRootService, label: String, error: Throwable?) {
+        dashboardState.value = dashboardState.value.copy(taskPhase = "$label：${error?.message ?: "Root 服务异常"}")
+        // Invalid JSON / a rejected request is not evidence that the Binder died.
+        if (rootService === service && !service.asBinder().isBinderAlive) {
+            profileConnection.onServiceDisconnected(null)
+        }
+        recoverRemoteTaskOrRefresh()
     }
 
     private fun readServiceStatus() {
@@ -528,6 +575,7 @@ class MiuixDashboardActivity : ComponentActivity() {
             val json = withContext(Dispatchers.IO) {
                 runCatching { JSONObject(service.ping()) }.getOrNull()
             } ?: return@launch
+            if (rootService !== service) return@launch
             val root = json.optBoolean("root")
             val module = json.optBoolean("module")
             val cleaner = json.optBoolean("cleaner")
@@ -659,16 +707,7 @@ class MiuixDashboardActivity : ComponentActivity() {
             }
             pollJob?.cancel()
             if (response.isFailure) {
-                rootService = null
-                profileBound = false
-                dashboardState.value = dashboardState.value.copy(
-                    connected = false,
-                    ready = false,
-                    running = false,
-                    serviceText = "Root 服务已断开，正在重新连接…",
-                    taskPhase = "文件归类启动失败：${response.exceptionOrNull()?.message ?: "Root 服务异常"}"
-                )
-                connectPrimaryService()
+                handleTaskRequestFailure(service, "文件归类启动失败", response.exceptionOrNull())
                 return@launch
             }
             val json = response.getOrThrow()
@@ -736,16 +775,7 @@ class MiuixDashboardActivity : ComponentActivity() {
             }
             pollJob?.cancel()
             if (response.isFailure) {
-                rootService = null
-                profileBound = false
-                dashboardState.value = dashboardState.value.copy(
-                    connected = false,
-                    ready = false,
-                    running = false,
-                    serviceText = "Root 服务已断开，正在重新连接…",
-                    taskPhase = "安装包扫描失败：${response.exceptionOrNull()?.message ?: "Root 服务异常"}"
-                )
-                connectPrimaryService()
+                handleTaskRequestFailure(service, "安装包扫描失败", response.exceptionOrNull())
                 return@launch
             }
             val json = response.getOrThrow()
@@ -829,19 +859,9 @@ class MiuixDashboardActivity : ComponentActivity() {
             }
             pollJob?.cancel()
             if (response.isFailure) {
-                rootService = null
-                profileBound = false
-                dashboardState.value = dashboardState.value.copy(
-                    connected = false,
-                    ready = false,
-                    running = false,
-                    serviceText = "Root 清理服务已断开，正在重新连接…",
-                    taskPhase = "清理启动失败：${response.exceptionOrNull()?.message ?: "Root 服务异常"}"
-                )
-                connectPrimaryService()
+                handleTaskRequestFailure(service, "清理启动失败", response.exceptionOrNull())
                 return@launch
             }
-
             val json = response.getOrThrow()
             if (json.optString("error") == "busy" || json.optInt("exitCode") == 3) {
                 val message = json.optString("message", "当前已有扫描或清理任务正在运行")
@@ -1765,13 +1785,8 @@ class MiuixDashboardActivity : ComponentActivity() {
     private fun toast(message: String) = Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
 
     override fun onDestroy() {
-        if (taskCallbackRegistered) runCatching { rootService?.unregisterTaskProgressCallback(taskProgressCallback) }
-
-        pollJob?.cancel()
-        recoveryProbeJob?.cancel()
+        releaseConnections()
         schedulerMonitorJob?.cancel()
-        if (profileBound) runCatching { RootService.unbind(profileConnection) }
-        if (cacheBound) runCatching { RootService.unbind(cacheConnection) }
         super.onDestroy()
     }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/MiuixDashboardActivity.kt
@@ -411,8 +411,12 @@ class MiuixDashboardActivity : ComponentActivity() {
     }
 
     private fun connectPrimaryService() {
-        if (releasingConnections || isDestroyed || connectionRecovery.exhausted || serviceRecoveryJob?.isActive == true) return
-        if (rootService != null || profileBound) return
+        if (releasingConnections || isDestroyed) return
+        if (connectionRecovery.exhausted) {
+            dashboardState.value = dashboardState.value.copy(serviceText = "Root 连接恢复失败，请手动重连")
+            return
+        }
+        if (serviceRecoveryJob?.isActive == true || rootService != null || profileBound) return
         dashboardState.value = dashboardState.value.copy(
             connected = false,
             ready = false,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/RootRecoveryPolicy.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/RootRecoveryPolicy.kt
@@ -1,0 +1,35 @@
+package io.github.xgl34222220.baize
+
+/** Retry a short outage, but stop a crashing service from creating a reconnect loop. */
+internal class RootRecoveryPolicy {
+    private var attempts = 0
+    private var connectedSince: Long? = null
+    var exhausted = false
+        private set
+
+    fun connected(now: Long) {
+        if (connectedSince == null) connectedSince = now
+    }
+
+    fun disconnected(now: Long) {
+        if (connectedSince?.let { now - it >= 30_000L } == true) reset()
+        connectedSince = null
+    }
+
+    fun nextDelay(): Long? {
+        val delay = when (attempts) {
+            0 -> 1_000L
+            1 -> 3_000L
+            2 -> 10_000L
+            else -> null
+        }
+        if (delay == null) exhausted = true else attempts++
+        return delay
+    }
+
+    fun reset() {
+        attempts = 0
+        connectedSince = null
+        exhausted = false
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/TaskCoordinator.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/TaskCoordinator.kt
@@ -129,6 +129,7 @@ internal class TaskCoordinator(
         publish(force)
     }
 
+    @Synchronized
     private fun publish(force: Boolean = false) {
         val now = SystemClock.elapsedRealtime()
         if (!force && now - lastCallbackAt < 220L) return

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/RootRecoveryPolicyTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/RootRecoveryPolicyTest.kt
@@ -1,0 +1,49 @@
+package io.github.xgl34222220.baize
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class RootRecoveryPolicyTest {
+    @Test fun repeatedShortConnectionsEventuallyStop() {
+        val policy = RootRecoveryPolicy()
+        listOf(1_000L, 3_000L, 10_000L).forEachIndexed { index, delay ->
+            policy.connected(index * 2_000L)
+            policy.disconnected(index * 2_000L + 100L)
+            assertEquals(delay, policy.nextDelay())
+            // The last scheduled attempt must still be allowed to bind.
+            assertFalse(policy.exhausted)
+        }
+        policy.connected(20_000)
+        policy.disconnected(20_100)
+        assertNull(policy.nextDelay())
+        assertTrue(policy.exhausted)
+    }
+
+    @Test fun stableConnectionRestoresRetryBudget() {
+        val policy = RootRecoveryPolicy()
+        repeat(3) { policy.nextDelay() }
+        policy.connected(0)
+        policy.connected(20_000) // Another engine must not restart the stability clock.
+        policy.disconnected(30_000)
+        assertEquals(1_000L, policy.nextDelay())
+        assertFalse(policy.exhausted)
+    }
+
+    @Test fun duplicateDisconnectDoesNotRestoreBudget() {
+        val policy = RootRecoveryPolicy()
+        policy.connected(0)
+        policy.disconnected(100)
+        assertEquals(1_000L, policy.nextDelay())
+        policy.disconnected(40_000)
+        assertEquals(3_000L, policy.nextDelay())
+    }
+
+    @Test fun manualRetryRestoresExhaustedBudget() {
+        val policy = RootRecoveryPolicy()
+        repeat(4) { policy.nextDelay() }
+        assertTrue(policy.exhausted)
+        policy.reset()
+        assertFalse(policy.exhausted)
+        assertEquals(1_000L, policy.nextDelay())
+    }
+}


### PR DESCRIPTION
用户反馈 v2.7.0 App 反复断开、连接。代码存在三处将请求或 JSON 解析异常直接当作断连并重新绑定，以及没有次数限制的断线恢复。本次基于 v2.7.0 修复这些可确认的问题；设备上是否另有 Root 进程崩溃，仍需真机复测。

改动：
- 仅 Binder 确认死亡时按断连处理，保留请求异常信息并重新读取后台任务状态。
- 合并同时到来的恢复请求，按 1/3/10 秒重试，短暂连接不重置预算；连接稳定 30 秒后恢复重试预算，连续失败后显示手动重连。后续点击操作也不会将耗尽状态误显示为正在连接。
- 统一连接入口，只重新绑定缺失服务；首次启动仍连接双引擎，保留 App 被关闭后的后台任务恢复。手动重连注销旧回调并保留后台任务状态。
- 任务状态读失败不再当作任务结束；任务轮询活跃时前台监测不重复获取进度。
- 删除首页依据中文状态文案反复唤醒调度器的逻辑，删除 WorkManager 内部三连重试，保留 Root supervisor 和 WorkManager 自身重试。Worker 取消时仍释放绑定。
- 序列化进度回调广播，避免并发 beginBroadcast 导致异常。
- 增加重连策略单元测试，将 Android CI 纳入单元测试。

验证：
- git diff --check、scheduler-health-contract、home-one-tap-actions-contract 通过。
- 主体修复提交 3e5f8ca 的 Android CI 通过，日志确认 testDebugUnitTest、compileDebugKotlin、lintDebug、macrobenchmark assemble 成功：https://github.com/xgl34222220-ops/BaiZe/actions/runs/34079048035
- 同提交 APK 构建通过：https://github.com/xgl34222220-ops/BaiZe/actions/runs/34079048034
- 最终提交 d83fede 补充重试耗尽后的提示处理，CI 重新验证中。
- 本地缺少 Android 构建缓存和 BusyBox；organizer-auto-budget 未在本地运行。没有真机复测。

删除规则、白名单、快照校验及 UI 样式保持原有行为。暂不合并或发布正式版。