### PR TITLE
v2.8.2: 修复媒体 Provider 异常导致 Root 进程退出

### DIFF
--- a/RELEASE_NOTES_v2.8.2.md
+++ b/RELEASE_NOTES_v2.8.2.md
@@ -1,0 +1,16 @@
+# 白泽 v2.8.2
+
+修复 Android 16 上 Root 服务连上后立即断开的问题。
+
+2.8.1 的真机 Root 堆栈显示，MediaScannerConnection 在 android.bg 线程获取 media provider 时抛出 SecurityException：独立 Root 进程没有 ActivityManager 登记的 IApplicationThread。这不是 Root 授权失败，也不是旧的主题崩溃。
+
+- Root 媒体刷新改用隔离的系统 content call scan_file 命令，经 external provider 入口调用；不再在 Root 进程使用 App 媒体扫描接口。
+- 媒体刷新始终在后台串行执行，提供命令超时；失败保留 pending/inflight 队列，收到明确成功回复后才确认完成。
+- 校验命令的实际回复，避免 content 命令报错但返回退出码 0 时误删队列；路径使用独立参数，支持空格、中文和多用户存储路径。
+- 保留 Root 崩溃诊断及之前的清理功能。
+
+依据：AOSP MediaProvider.getResultForScanFile 与 content 命令的 getContentProviderExternal / CallCommand 实现。
+https://github.com/aosp-mirror/platform_packages_providers_mediaprovider/blob/main/src/com/android/providers/media/MediaProvider.java
+https://github.com/aosp-mirror/platform_frameworks_base/blob/main/cmds/content/src/com/android/commands/content/Content.java
+
+请同时更新模块和 App。修正针对已收到的真机异常，最终稳定性仍需设备验证。

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=baize_v2
 name=白泽 v2
-version=v2.8.1
-versionCode=28001
+version=v2.8.2
+versionCode=28002
 author=惜故里丶
 description=用于清理应用缓存、安装包、卸载残留和深度垃圾，并整理应用下载、接收、附件与导出文件。
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/BaiZe/main/update.json

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "io.github.xgl34222220.baize"
         minSdk = 26
         targetSdk = 36
-        versionCode = 28001
-        versionName = "2.8.1"
+        versionCode = 28002
+        versionName = "2.8.2"
     }
 
     sourceSets.getByName("main") {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootMediaScanCommand.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootMediaScanCommand.kt
@@ -1,0 +1,42 @@
+package io.github.xgl34222220.baize.root
+
+import android.util.Log
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/** The platform content tool acquires an external provider, without an IApplicationThread. */
+internal object RootMediaScanCommand {
+    private const val COMMAND_TIMEOUT_SECONDS = 15L
+
+    internal fun arguments(path: String): List<String> {
+        val user = Regex("^/(?:storage/emulated|data/media)/(\\d+)(?:/|$)")
+            .find(path)?.groupValues?.get(1) ?: "0"
+        return listOf("/system/bin/content", "call", "--user", user,
+            "--uri", "content://media", "--method", "scan_file", "--arg", path)
+    }
+
+    // content catches provider exceptions and can still exit 0. Require its actual reply too.
+    internal fun succeeded(code: Int, output: String): Boolean = code == 0 &&
+        output.lineSequence().any { it.startsWith("Result: Bundle[") && it.contains("android.intent.extra.STREAM=") } &&
+        !output.contains("Error while accessing provider:")
+
+    fun scan(path: String, stateDir: File): Boolean {
+        val output = File.createTempFile("media-command-", ".log", stateDir)
+        var process: Process? = null
+        return try {
+            process = ProcessBuilder(arguments(path)).redirectErrorStream(true).redirectOutput(output).start()
+            if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                Log.w("BaiZeMedia", "Media refresh command timed out; queue retained")
+                false
+            } else {
+                val response = output.inputStream().bufferedReader().use { it.readText().take(16_000) }
+                succeeded(process.exitValue(), response).also {
+                    if (!it) Log.w("BaiZeMedia", "Media refresh command failed: ${response.take(2_000)}")
+                }
+            }
+        } finally {
+            process?.let { if (it.isAlive) it.destroyForcibly() }
+            output.delete()
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootMediaScanQueue.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootMediaScanQueue.kt
@@ -1,7 +1,6 @@
 package io.github.xgl34222220.baize.root
 
 import android.content.Context
-import android.media.MediaScannerConnection
 import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
@@ -9,15 +8,13 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Root-side durable media-scan queue used by both organizer implementations.
  *
  * The queue lives under /data/adb, so only the RootService touches it.  Shell organizer tasks
  * append to the same pending file (or a spool file when the tiny filesystem lock is busy).
- * A flush atomically claims pending -> inflight, submits MediaScannerConnection batches and only
+ * A flush atomically claims pending -> inflight, submits isolated content commands and only
  * deletes inflight after all callbacks arrive.  A crash/failure therefore causes a retry rather
  * than a lost media refresh.  Duplicate scans are acceptable; lost queue entries are not.
  */
@@ -27,10 +24,8 @@ internal object RootMediaScanQueue {
     const val LOCK_NAME = "organizer-media-scan.lock"
     const val SPOOL_PREFIX = "organizer-media-scan.spool."
 
-    private const val BATCH_SIZE = 1000
     private const val STALE_LOCK_MS = 30_000L
     private const val STALE_TASK_QUEUE_MS = 60_000L
-    private const val CALLBACK_TIMEOUT_MS = 120_000L
     private const val RETRY_BACKOFF_MS = 30_000L
 
     private val startupExecutor = Executors.newSingleThreadExecutor()
@@ -76,9 +71,11 @@ internal object RootMediaScanQueue {
 
     private data class Claim(val inflight: File, val paths: List<String>, val token: Long)
 
-    fun flush(context: Context, stateDir: File = File(RootPaths.STATE_DIR)): Int {
-        // Root package contexts have no Application; the supplied service context remains valid.
-        val appContext = context.applicationContext ?: context
+    fun flush(
+        context: Context,
+        stateDir: File = File(RootPaths.STATE_DIR),
+        scanPath: (String, File) -> Boolean = RootMediaScanCommand::scan
+    ): Int {
         val claim = synchronized(monitor) {
             if (activeToken != 0L) return@synchronized null
             if (SystemClock.elapsedRealtime() < retryAfterRealtime) return@synchronized null
@@ -106,49 +103,24 @@ internal object RootMediaScanQueue {
             Claim(inflight, paths, token)
         } ?: return 0
 
-        submit(appContext, stateDir, claim.inflight, claim.paths, claim.token)
+        submit(context, stateDir, claim.inflight, claim.paths, claim.token, scanPath)
         return claim.paths.size
     }
 
-    private fun submit(context: Context, stateDir: File, inflight: File, paths: List<String>, token: Long) {
-        val submitted = AtomicInteger(0)
-        val completed = AtomicInteger(0)
-        val submissionDone = AtomicBoolean(false)
-        val submissionFailed = AtomicBoolean(false)
-
-        fun maybeFinish() {
-            if (!submissionDone.get()) return
-            if (completed.get() < submitted.get()) return
-            finishSubmission(context, stateDir, inflight, token, !submissionFailed.get())
-        }
-
-        for (batch in paths.chunked(BATCH_SIZE)) {
-            submitted.addAndGet(batch.size)
-            try {
-                MediaScannerConnection.scanFile(
-                    context,
-                    batch.toTypedArray(),
-                    null
-                ) { _, _ ->
-                    completed.incrementAndGet()
-                    maybeFinish()
-                }
-            } catch (_: Throwable) {
-                submitted.addAndGet(-batch.size)
-                submissionFailed.set(true)
-                break
+    private fun submit(
+        context: Context, stateDir: File, inflight: File, paths: List<String>, token: Long,
+        scanPath: (String, File) -> Boolean
+    ) {
+        // Do not acquire a ContentProvider from the unregistered Root app_process.
+        // Android's scanFile() posts to android.bg, outside a caller's try/catch.
+        startupExecutor.execute {
+            val success = try {
+                paths.all { scanPath(it, stateDir) }
+            } catch (error: Exception) {
+                android.util.Log.w("BaiZeMedia", "Media refresh retained for retry", error)
+                false
             }
-        }
-
-        submissionDone.set(true)
-        if (submitted.get() == 0) {
-            finishSubmission(context, stateDir, inflight, token, false)
-        } else {
-            maybeFinish()
-            handler.postDelayed(
-                { finishSubmission(context, stateDir, inflight, token, false) },
-                CALLBACK_TIMEOUT_MS
-            )
+            finishSubmission(context, stateDir, inflight, token, success)
         }
     }
 
@@ -179,7 +151,7 @@ internal object RootMediaScanQueue {
 
         if (success && acknowledged) {
             // New shell/app entries may have arrived in pending while this batch was in flight.
-            handler.post { flush(context, stateDir) }
+            startupExecutor.execute { flush(context, stateDir) }
         }
     }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootMediaScanQueue.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootMediaScanQueue.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.Executors
  * The queue lives under /data/adb, so only the RootService touches it.  Shell organizer tasks
  * append to the same pending file (or a spool file when the tiny filesystem lock is busy).
  * A flush atomically claims pending -> inflight, submits isolated content commands and only
- * deletes inflight after all callbacks arrive.  A crash/failure therefore causes a retry rather
+ * deletes inflight after every command succeeds.  A crash/failure therefore causes a retry rather
  * than a lost media refresh.  Duplicate scans are acceptable; lost queue entries are not.
  */
 internal object RootMediaScanQueue {

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/root/RootMediaScanCommandTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/root/RootMediaScanCommandTest.kt
@@ -1,0 +1,24 @@
+package io.github.xgl34222220.baize.root
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class RootMediaScanCommandTest {
+    @Test fun providerErrorsAreNotSuccessEvenWithExitZero() {
+        assertFalse(RootMediaScanCommand.succeeded(0, "Error while accessing provider:media\njava.lang.SecurityException"))
+        assertFalse(RootMediaScanCommand.succeeded(0, "Result: null"))
+        assertFalse(RootMediaScanCommand.succeeded(1, "Result: Bundle[{android.intent.extra.STREAM=null}]"))
+        assertTrue(RootMediaScanCommand.succeeded(0, "Result: Bundle[{android.intent.extra.STREAM=null}]"))
+        assertTrue(RootMediaScanCommand.succeeded(0, "Result: Bundle[{android.intent.extra.STREAM=content://media/external/images/media/1}]"))
+    }
+
+    @Test fun pathsAreSingleArgumentsAndSelectCorrectStorageUser() {
+        val path = "/storage/emulated/10/照片/a ' ; touch bad.jpg"
+        val args = RootMediaScanCommand.arguments(path)
+        assertEquals("10", args[args.indexOf("--user") + 1])
+        assertEquals(path, args.last())
+        assertEquals("/system/bin/content", args.first())
+        val privatePath = RootMediaScanCommand.arguments("/data/media/12/DCIM/a.jpg")
+        assertEquals("12", privatePath[privatePath.indexOf("--user") + 1])
+    }
+}

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/root/RootMediaScanQueueContextTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/root/RootMediaScanQueueContextTest.kt
@@ -62,7 +62,10 @@ class RootMediaScanQueueContextTest {
 
     private fun awaitCondition(condition: () -> Boolean) {
         val end = System.nanoTime() + TimeUnit.SECONDS.toNanos(3)
-        while (!condition() && System.nanoTime() < end) Thread.sleep(10)
-        assertTrue(condition())
+        while (System.nanoTime() < end) {
+            if (condition()) return
+            Thread.sleep(10)
+        }
+        fail("Condition did not complete within 3 seconds")
     }
 }

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/root/RootMediaScanQueueContextTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/root/RootMediaScanQueueContextTest.kt
@@ -3,7 +3,7 @@ package io.github.xgl34222220.baize.root
 import android.app.Application
 import android.content.Context
 import android.content.ContextWrapper
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -11,20 +11,58 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import java.io.File
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [28], application = Application::class)
 class RootMediaScanQueueContextTest {
     @get:Rule val folder = TemporaryFolder()
 
-    @Test fun pendingMediaDoesNotCrashWhenRootContextHasNoApplication() {
+    @Test fun mediaQueueDoesNotTouchRootApplicationOrContentResolver() {
         val context = object : ContextWrapper(RuntimeEnvironment.getApplication()) {
-            override fun getApplicationContext(): Context? = null
+            override fun getApplicationContext(): Context = error("Root has no Application")
+            override fun getContentResolver(): android.content.ContentResolver = error("Unregistered Root process")
         }
         val state = folder.newFolder("state")
-        val media = folder.newFile("photo.jpg")
-        assertEquals(1, RootMediaScanQueue.enqueue(state, listOf(media.path)))
-        // Previously submit() received null and threw before its scan failure handler.
-        assertEquals(1, RootMediaScanQueue.flush(context, state))
+        val path = folder.newFile("我的 photo.jpg").path
+        val called = CountDownLatch(1)
+        RootMediaScanQueue.enqueue(state, listOf(path))
+        assertEquals(1, RootMediaScanQueue.flush(context, state) { actual, _ ->
+            assertEquals(path, actual)
+            called.countDown()
+            true
+        })
+        assertTrue(called.await(3, TimeUnit.SECONDS))
+        awaitCondition { !File(state, RootMediaScanQueue.INFLIGHT_NAME).exists() }
+    }
+
+    @Test fun providerFailureRetainsInflightAndCanRetryAfterBackoff() {
+        val context = RuntimeEnvironment.getApplication()
+        val state = folder.newFolder("retry")
+        val path = folder.newFile("a.jpg").path
+        val failed = CountDownLatch(1)
+        RootMediaScanQueue.enqueue(state, listOf(path))
+        RootMediaScanQueue.flush(context, state) { _, _ -> failed.countDown(); false }
+        assertTrue(failed.await(3, TimeUnit.SECONDS))
+        assertTrue(File(state, RootMediaScanQueue.INFLIGHT_NAME).exists())
+        val retried = CountDownLatch(1)
+        awaitCondition {
+            ShadowSystemClock.advanceBy(Duration.ofSeconds(31))
+            RootMediaScanQueue.flush(context, state) { actual, _ ->
+                assertEquals(path, actual); retried.countDown(); true
+            } == 1
+        }
+        assertTrue(retried.await(3, TimeUnit.SECONDS))
+        awaitCondition { !File(state, RootMediaScanQueue.INFLIGHT_NAME).exists() }
+    }
+
+    private fun awaitCondition(condition: () -> Boolean) {
+        val end = System.nanoTime() + TimeUnit.SECONDS.toNanos(3)
+        while (!condition() && System.nanoTime() < end) Thread.sleep(10)
+        assertTrue(condition())
     }
 }

--- a/v2/module/customize.sh
+++ b/v2/module/customize.sh
@@ -27,7 +27,7 @@ for base in "$MODPATH" "/data/adb/modules/baize_v2" "/data/adb/modules_update/ba
   rm -rf "$base/webroot" "$base/webui" "$base/www" "$base/ksu-webui" 2>/dev/null || true
 done
 
-ui_print "- 正在安装白泽 v2.8.1"
+ui_print "- 正在安装白泽 v2.8.2"
 ui_print "- 白泽是 Android Root 垃圾清理与文件归类模块"
 ui_print "- 用于扫描清理缓存、安装包、卸载残留和深度垃圾"
 ui_print "- 可整理应用下载、接收、附件与导出文件"

--- a/v2/module/module.prop
+++ b/v2/module/module.prop
@@ -1,7 +1,7 @@
 id=baize_v2
 name=白泽 v2
-version=v2.8.1
-versionCode=28001
+version=v2.8.2
+versionCode=28002
 author=惜故里丶
 description=用于清理应用缓存、安装包、卸载残留和深度垃圾，并整理应用下载、接收、附件与导出文件。
 updateJson=https://raw.githubusercontent.com/xgl34222220-ops/BaiZe/main/update.json

--- a/v2/module/task-worker.sh
+++ b/v2/module/task-worker.sh
@@ -65,7 +65,7 @@ tmp="$RUNNING_FILE.tmp.$$"
   echo "progress_total=0"
   echo "current_path="
   echo "task_id=$TASK_ID"
-  echo "worker=detached-root-worker-v2.8.1"
+  echo "worker=detached-root-worker-v2.8.2"
 } >"$tmp" && mv -f "$tmp" "$RUNNING_FILE"
 write_worker_marker 0
 if [ "$WAIT_MODE" = wait ]; then

--- a/v2/tests/test-organizer-media-scan.sh
+++ b/v2/tests/test-organizer-media-scan.sh
@@ -19,15 +19,16 @@ code_only "$KT" | grep -q '"/system/bin/am"' && say "Kotlin 又恢复了 Process
 code_only "$KT" | grep -q 'MEDIA_SCANNER_SCAN_FILE' && say "Kotlin 又使用废弃广播"
 grep -q 'RootMediaScanQueue.enqueue' "$KT" || say "FileOrganizerEngine 未持久化到 root 队列"
 
-grep -q 'MediaScannerConnection.scanFile' "$QUEUE" || say "Root 队列未使用 MediaScannerConnection"
+grep -q 'MediaScannerConnection' "$QUEUE" && say "Root 队列不得调用 App 媒体扫描接口"
+grep -q 'RootMediaScanCommand::scan' "$QUEUE" || say "Root 队列未使用隔离媒体命令"
 grep -q 'PENDING_NAME = "organizer-media-scan.nul"' "$QUEUE" || say "pending 文件名不一致"
 grep -q 'INFLIGHT_NAME = "organizer-media-scan.inflight.nul"' "$QUEUE" || say "缺少 inflight 事务文件"
 grep -q 'pending.renameTo(inflight)' "$QUEUE" || say "未原子 claim pending -> inflight"
 grep -q 'recoverInflightLocked' "$QUEUE" || say "进程失败后不能恢复 inflight"
 grep -q 'recoverSpoolsLocked' "$QUEUE" || say "不能恢复 shell/Kotlin spool"
-grep -q 'CALLBACK_TIMEOUT_MS' "$QUEUE" || say "缺少 callback 超时保护"
+grep -q 'COMMAND_TIMEOUT_SECONDS' "${QUEUE%/*}/RootMediaScanCommand.kt" || say "缺少外部命令超时"
 # 删除 inflight 只能发生在 finish/空文件路径，不能在 scanFile 之前先删 pending。
-scan_line=$(grep -n 'MediaScannerConnection.scanFile' "$QUEUE" | head -n1 | cut -d: -f1)
+scan_line=$(grep -n 'paths.all' "$QUEUE" | head -n1 | cut -d: -f1)
 delete_line=$(grep -n 'acknowledged = !inflight.exists() || inflight.delete()' "$QUEUE" | head -n1 | cut -d: -f1)
 case "$scan_line" in ''|*[!0-9]*) say "无法定位 scanFile" ;; esac
 case "$delete_line" in ''|*[!0-9]*) say "无法定位 inflight ack" ;; esac


### PR DESCRIPTION
2.8.1 真机堆栈已确认 MediaScannerConnection 在 android.bg 获取 media provider 抛出 SecurityException，独立 Root 进程没有 ActivityManager 登记的 IApplicationThread。此前 Context 修正未处理这个异步异常入口。

改用系统 content call scan_file 的 external provider 入口，并放在独立子进程执行。串行后台刷新，命令超时清理子进程，失败保留 inflight，校验退出码与真实 Bundle 回复后才确认队列。删除 Root 中 MediaScannerConnection 及 callback 状态机，保留待处理恢复和多用户路径。

新增 Root Context 不访问应用 provider、失败重试保留队列、命令零退出码错误与路径参数测试。版本 2.8.2 / 28002，CI 验证中；设备稳定性仍需真机确认。