### PR TITLE
修复 v2.9.3 扫描结果跨 Root 通信失败

### DIFF
--- a/.github/workflows/root-ipc-hotfix.yml
+++ b/.github/workflows/root-ipc-hotfix.yml
@@ -1,0 +1,136 @@
+name: BaiZe Root IPC Hotfix Test APK
+
+on:
+  push:
+    branches: [codex/fix-root-json-response]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: baize-root-ipc-hotfix-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BAIZE_CERT_SHA256: 9efa848001ccdc168ea96753d332b1713e2668ba6a2fa22d5bfd98de65db1f0f
+
+jobs:
+  build-test-apk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Identify test build
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHORT_SHA=$(git rev-parse --short=8 HEAD)
+          echo "BAIZE_TEST_LABEL=v2.9.3-ipc-test+$SHORT_SHA" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Install Android platform
+        shell: bash
+        run: |
+          set +o pipefail
+          yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Prepare formal signing certificate
+        shell: bash
+        env:
+          KEYSTORE_BASE64_RAW: ${{ secrets.BAIZE_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD_RAW: ${{ secrets.BAIZE_KEYSTORE_PASSWORD }}
+          KEY_ALIAS_RAW: ${{ secrets.BAIZE_KEY_ALIAS }}
+          KEY_PASSWORD_RAW: ${{ secrets.BAIZE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          normalize_secret() {
+            secret_name=$1
+            raw_value=$2
+            value=$(printf '%s' "$raw_value" | tr -d '\r\n')
+            value=$(printf '%s' "$value" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+            case "$value" in "$secret_name="*) value=${value#*=} ;; esac
+            case "$value" in
+              \"*\") value=${value#\"}; value=${value%\"} ;;
+              \'*\') value=${value#\'}; value=${value%\'} ;;
+            esac
+            printf '%s' "$value"
+          }
+          KEYSTORE_BASE64=$(normalize_secret BAIZE_KEYSTORE_BASE64 "$KEYSTORE_BASE64_RAW" | tr -d '[:space:]')
+          KEYSTORE_PASSWORD=$(normalize_secret BAIZE_KEYSTORE_PASSWORD "$KEYSTORE_PASSWORD_RAW")
+          KEY_ALIAS=$(normalize_secret BAIZE_KEY_ALIAS "$KEY_ALIAS_RAW")
+          KEY_PASSWORD=$(normalize_secret BAIZE_KEY_PASSWORD "$KEY_PASSWORD_RAW")
+          test -n "$KEYSTORE_BASE64"
+          test -n "$KEYSTORE_PASSWORD"
+          test -n "$KEY_ALIAS"
+          test -n "$KEY_PASSWORD"
+          KEYSTORE="$RUNNER_TEMP/baize-ipc-test.jks"
+          umask 077
+          printf '%s' "$KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE"
+          keytool -list -keystore "$KEYSTORE" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null
+          ACTUAL_CERT=$(keytool -exportcert -keystore "$KEYSTORE" -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" -rfc | openssl x509 -noout -fingerprint -sha256 | cut -d= -f2 | tr -d ':' | tr '[:upper:]' '[:lower:]')
+          test "$ACTUAL_CERT" = "$BAIZE_CERT_SHA256"
+          {
+            echo "BAIZE_KEYSTORE_PATH=$KEYSTORE"
+            echo "BAIZE_KEYSTORE_PASSWORD=$KEYSTORE_PASSWORD"
+            echo "BAIZE_KEY_ALIAS=$KEY_ALIAS"
+            echo "BAIZE_KEY_PASSWORD=$KEY_PASSWORD"
+          } >> "$GITHUB_ENV"
+
+      - name: Test and build signed App
+        working-directory: v2
+        run: gradle --no-daemon :app:testReleaseUnitTest :app:assembleRelease :app:lintRelease
+
+      - name: Verify and name test APK
+        shell: bash
+        run: |
+          set -euo pipefail
+          APK=v2/app/build/outputs/apk/release/app-release.apk
+          OUT=v2/dist/ipc-hotfix
+          mkdir -p "$OUT"
+          CERT="$OUT/BaiZe-$BAIZE_TEST_LABEL-signing-certificate.txt"
+          "$ANDROID_HOME/build-tools/36.0.0/apksigner" verify --verbose --print-certs "$APK" > "$CERT"
+          APK_CERT=$(awk -F': ' '/certificate SHA-256 digest/ {print tolower($NF); exit}' "$CERT" | tr -d ':[:space:]')
+          test "$APK_CERT" = "$BAIZE_CERT_SHA256"
+          cp "$APK" "$OUT/BaiZe-$BAIZE_TEST_LABEL.apk"
+          cd "$OUT"
+          sha256sum "BaiZe-$BAIZE_TEST_LABEL.apk" > "BaiZe-$BAIZE_TEST_LABEL.apk.sha256"
+          sha256sum -c "BaiZe-$BAIZE_TEST_LABEL.apk.sha256"
+
+      - name: Upload verified test APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-${{ env.BAIZE_TEST_LABEL }}-Signed-Test-APK
+          path: v2/dist/ipc-hotfix/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 14
+
+      - name: Upload test and lint diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: BaiZe-${{ env.BAIZE_TEST_LABEL }}-Diagnostics
+          path: |
+            v2/app/build/reports
+            v2/app/build/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Remove temporary signing keystore
+        if: always()
+        shell: bash
+        run: rm -f "$RUNNER_TEMP/baize-ipc-test.jks"

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IBaiZeRootService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IBaiZeRootService.aidl
@@ -11,4 +11,6 @@ interface IBaiZeRootService {
     void cancelCurrentTask();
     // Appended: preserve the transaction IDs used by existing clients.
     ParcelFileDescriptor exchangeJson(String operation, in ParcelFileDescriptor request);
+    // App-created response FD: never return a Root-created inode to the App.
+    int exchangeJsonInto(String operation, in ParcelFileDescriptor request, in ParcelFileDescriptor response);
 }

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanPlanResumeService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/ICleanPlanResumeService.aidl
@@ -11,4 +11,6 @@ interface ICleanPlanResumeService {
     String finish(String planId);
     // Appended: preserve the transaction IDs used by existing clients.
     ParcelFileDescriptor exchangeJson(String operation, in ParcelFileDescriptor request);
+    // App-created response FD: never return a Root-created inode to the App.
+    int exchangeJsonInto(String operation, in ParcelFileDescriptor request, in ParcelFileDescriptor response);
 }

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IPersistentCleanPlanService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IPersistentCleanPlanService.aidl
@@ -11,4 +11,6 @@ interface IPersistentCleanPlanService {
     void cancelCurrentTask();
     // Appended: preserve the transaction IDs used by existing clients.
     ParcelFileDescriptor exchangeJson(String operation, in ParcelFileDescriptor request);
+    // App-created response FD: never return a Root-created inode to the App.
+    int exchangeJsonInto(String operation, in ParcelFileDescriptor request, in ParcelFileDescriptor response);
 }

--- a/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl
+++ b/v2/app/src/main/aidl/io/github/xgl34222220/baize/root/IProfileRootService.aidl
@@ -51,4 +51,6 @@ interface IProfileRootService {
     void cancelCurrentTask();
     // Appended: preserve the transaction IDs used by existing clients.
     ParcelFileDescriptor exchangeJson(String operation, in ParcelFileDescriptor request);
+    // App-created response FD: never return a Root-created inode to the App.
+    int exchangeJsonInto(String operation, in ParcelFileDescriptor request, in ParcelFileDescriptor response);
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchScreen.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchScreen.kt
@@ -211,10 +211,10 @@ internal fun ScanWorkbenchScreen(
             if (state.items.isEmpty()) {
                 item {
                     DetailEmptyState(
-                        when { state.running -> "正在查找可清理内容"; state.notice == WorkbenchNotice.ERROR -> "扫描未完成";
+                        when { state.running -> "正在查找可清理内容"; state.notice == WorkbenchNotice.ERROR -> "未取得完整扫描结果";
                             state.notice == WorkbenchNotice.SUCCESS -> "没有发现可清理项目"; else -> "按应用查看清理内容" },
                         when { state.running -> "找到的应用与文件会陆续显示在这里。";
-                            state.notice == WorkbenchNotice.ERROR -> "任务信息已保留，可查看详情后重试。";
+                            state.notice == WorkbenchNotice.ERROR -> "点击上方错误查看任务详情，再重新扫描。";
                             state.notice == WorkbenchNotice.SUCCESS -> "可以稍后重新扫描，或在清理页选择其他范围。";
                             else -> "扫描后可展开应用，核对文件并选择要处理的项目。" }
                     )
@@ -348,6 +348,22 @@ internal fun ScanWorkbenchScreen(
     }
 }
 
+private fun workbenchErrorSummary(state: WorkbenchUiState): String {
+    val details = "${state.phase}\n${state.resultText}"
+    // Binder failure does not establish whether the service died or its buffer was exhausted.
+    if (listOf("transaction failed", "deadobjectexception", "binder buffer", "failed binder transaction")
+            .any { details.contains(it, ignoreCase = true) }) {
+        return "清理服务通信失败，结果未确认"
+    }
+    if (details.contains("服务结果未确认")) return "清理服务结果未确认"
+    val summary = state.phase.ifBlank { state.resultText }.replace(Regex("\\s+"), " ").trim()
+    return when {
+        summary.isBlank() -> "本次任务未完成"
+        summary.length > 72 -> summary.take(72) + "…"
+        else -> summary
+    }
+}
+
 @Composable
 private fun WorkbenchStatus(state: WorkbenchUiState, onDetails: () -> Unit) {
     val color = when { state.notice == WorkbenchNotice.ERROR -> MaterialTheme.colorScheme.error;
@@ -355,7 +371,7 @@ private fun WorkbenchStatus(state: WorkbenchUiState, onDetails: () -> Unit) {
         state.notice == WorkbenchNotice.SUCCESS && !state.running -> BaiZeTokens.colors.success;
         else -> MaterialTheme.colorScheme.primary }
     val title = when { state.running -> if (state.loadingResults) "正在读取扫描结果" else "正在处理";
-        state.notice == WorkbenchNotice.ERROR -> "本次任务未完成";
+        state.notice == WorkbenchNotice.ERROR -> workbenchErrorSummary(state);
         state.notice == WorkbenchNotice.WARNING -> "有项目需要核对";
         state.scanReady -> "扫描完成，可以选择项目";
         state.notice == WorkbenchNotice.SUCCESS -> "任务已完成";
@@ -370,7 +386,10 @@ private fun WorkbenchStatus(state: WorkbenchUiState, onDetails: () -> Unit) {
                 state.notice == WorkbenchNotice.SUCCESS -> Icons.Rounded.CheckCircle; else -> Icons.Rounded.Info },
                 null, Modifier.size(21.dp), tint = color)
             Column(Modifier.weight(1f)) {
-                Text(title, fontSize = 13.sp, lineHeight = 19.sp, fontWeight = FontWeight.Medium, color = color)
+                Text(title, fontSize = 13.sp, lineHeight = 19.sp, fontWeight = FontWeight.Medium, color = color,
+                    maxLines = 2, overflow = TextOverflow.Ellipsis)
+                if (!state.running && state.notice == WorkbenchNotice.ERROR) Text("点击查看完整错误详情", fontSize = 11.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
                 if (state.running && state.currentPath.isNotBlank()) Text(state.currentPath, fontSize = 11.sp,
                     maxLines = 1, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
@@ -5,6 +5,7 @@ import android.os.IBinder
 import android.os.ParcelFileDescriptor
 import android.os.Process
 import com.topjohnwu.superuser.ipc.RootService
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 
@@ -41,87 +42,92 @@ class BaiZeProfileRootService : RootService() {
     private val binder = object : IProfileRootService.Stub() {
 
         override fun exchangeJson(operation: String?, request: ParcelFileDescriptor?): ParcelFileDescriptor =
-            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { arguments ->
-                when (operation) {
-                    "scanProfile" -> {
-                        require(arguments.length() == 2)
-                        scanProfile(arguments.getString(0), arguments.getString(1))
-                    }
-                    "getProfilePage" -> {
-                        require(arguments.length() == 3)
-                        getProfilePage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
-                    }
-                    "cleanProfileSelected" -> {
-                        require(arguments.length() == 3)
-                        cleanProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
-                    }
-                    "quarantineProfileSelected" -> {
-                        require(arguments.length() == 3)
-                        quarantineProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
-                    }
-                    "prepareCacheSelection" -> {
-                        require(arguments.length() == 2)
-                        prepareCacheSelection(arguments.getString(0), arguments.getString(1))
-                    }
-                    "getQuarantinePage" -> {
-                        require(arguments.length() == 2)
-                        getQuarantinePage(arguments.getInt(0), arguments.getInt(1))
-                    }
-                    "getModuleState" -> {
-                        require(arguments.length() == 0)
-                        getModuleState()
-                    }
-                    "getTaskHistory" -> {
-                        require(arguments.length() == 1)
-                        getTaskHistory(arguments.getInt(0))
-                    }
-                    "getTaskHistoryPage" -> {
-                        require(arguments.length() == 2)
-                        getTaskHistoryPage(arguments.getInt(0), arguments.getInt(1))
-                    }
-                    "getAuditTimelinePage" -> {
-                        require(arguments.length() == 2)
-                        getAuditTimelinePage(arguments.getInt(0), arguments.getInt(1))
-                    }
-                    "getScanCoverage" -> {
-                        require(arguments.length() == 0)
-                        getScanCoverage()
-                    }
-                    "clearPackageCaches" -> {
-                        require(arguments.length() == 1)
-                        clearPackageCaches(arguments.getString(0))
-                    }
-                    "scanFileOrganizer" -> {
-                        require(arguments.length() == 0)
-                        scanFileOrganizer()
-                    }
-                    "applyFileOrganizer" -> {
-                        require(arguments.length() == 2)
-                        applyFileOrganizer(arguments.getString(0), arguments.getString(1))
-                    }
-                    "undoFileOrganizer" -> {
-                        require(arguments.length() == 0)
-                        undoFileOrganizer()
-                    }
-                    "getInstalledPackageCatalog" -> {
-                        require(arguments.length() == 0)
-                        getInstalledPackageCatalog()
-                    }
-                    "getWhitelistPackages" -> {
-                        require(arguments.length() == 0)
-                        getWhitelistPackages()
-                    }
-                    "saveWhitelistPackages" -> {
-                        require(arguments.length() == 1)
-                        saveWhitelistPackages(arguments.getString(0))
-                    }
-                    "getWhitelistPaths" -> {
-                        require(arguments.length() == 0)
-                        getWhitelistPaths()
-                    }
-                    else -> throw IllegalArgumentException("不支持的服务请求")
+            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { dispatchJson(operation, it) }
+
+        override fun exchangeJsonInto(operation: String?, request: ParcelFileDescriptor?, response: ParcelFileDescriptor?): Int =
+            JsonFileTransport.serveInto(request, response) { dispatchJson(operation, it) }
+
+        private fun dispatchJson(operation: String?, arguments: JSONArray): String {
+            return when (operation) {
+                "scanProfile" -> {
+                    require(arguments.length() == 2)
+                    scanProfile(arguments.getString(0), arguments.getString(1))
                 }
+                "getProfilePage" -> {
+                    require(arguments.length() == 3)
+                    getProfilePage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
+                }
+                "cleanProfileSelected" -> {
+                    require(arguments.length() == 3)
+                    cleanProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
+                }
+                "quarantineProfileSelected" -> {
+                    require(arguments.length() == 3)
+                    quarantineProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
+                }
+                "prepareCacheSelection" -> {
+                    require(arguments.length() == 2)
+                    prepareCacheSelection(arguments.getString(0), arguments.getString(1))
+                }
+                "getQuarantinePage" -> {
+                    require(arguments.length() == 2)
+                    getQuarantinePage(arguments.getInt(0), arguments.getInt(1))
+                }
+                "getModuleState" -> {
+                    require(arguments.length() == 0)
+                    getModuleState()
+                }
+                "getTaskHistory" -> {
+                    require(arguments.length() == 1)
+                    getTaskHistory(arguments.getInt(0))
+                }
+                "getTaskHistoryPage" -> {
+                    require(arguments.length() == 2)
+                    getTaskHistoryPage(arguments.getInt(0), arguments.getInt(1))
+                }
+                "getAuditTimelinePage" -> {
+                    require(arguments.length() == 2)
+                    getAuditTimelinePage(arguments.getInt(0), arguments.getInt(1))
+                }
+                "getScanCoverage" -> {
+                    require(arguments.length() == 0)
+                    getScanCoverage()
+                }
+                "clearPackageCaches" -> {
+                    require(arguments.length() == 1)
+                    clearPackageCaches(arguments.getString(0))
+                }
+                "scanFileOrganizer" -> {
+                    require(arguments.length() == 0)
+                    scanFileOrganizer()
+                }
+                "applyFileOrganizer" -> {
+                    require(arguments.length() == 2)
+                    applyFileOrganizer(arguments.getString(0), arguments.getString(1))
+                }
+                "undoFileOrganizer" -> {
+                    require(arguments.length() == 0)
+                    undoFileOrganizer()
+                }
+                "getInstalledPackageCatalog" -> {
+                    require(arguments.length() == 0)
+                    getInstalledPackageCatalog()
+                }
+                "getWhitelistPackages" -> {
+                    require(arguments.length() == 0)
+                    getWhitelistPackages()
+                }
+                "saveWhitelistPackages" -> {
+                    require(arguments.length() == 1)
+                    saveWhitelistPackages(arguments.getString(0))
+                }
+                "getWhitelistPaths" -> {
+                    require(arguments.length() == 0)
+                    getWhitelistPaths()
+                }
+                else -> throw IllegalArgumentException("不支持的服务请求")
             }
+        }
 
         override fun ping(): String = JSONObject()
             .put("uid", Process.myUid())

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeRootService.kt
@@ -170,23 +170,28 @@ class BaiZeRootService : RootService() {
     private val binder = object : IBaiZeRootService.Stub() {
 
         override fun exchangeJson(operation: String?, request: ParcelFileDescriptor?): ParcelFileDescriptor =
-            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { arguments ->
-                when (operation) {
-                    "scanCandidates" -> {
-                        require(arguments.length() == 1)
-                        scanCandidates(arguments.getString(0))
-                    }
-                    "getResultPage" -> {
-                        require(arguments.length() == 3)
-                        getResultPage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
-                    }
-                    "cleanSelected" -> {
-                        require(arguments.length() == 3)
-                        cleanSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
-                    }
-                    else -> throw IllegalArgumentException("不支持的服务请求")
+            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { dispatchJson(operation, it) }
+
+        override fun exchangeJsonInto(operation: String?, request: ParcelFileDescriptor?, response: ParcelFileDescriptor?): Int =
+            JsonFileTransport.serveInto(request, response) { dispatchJson(operation, it) }
+
+        private fun dispatchJson(operation: String?, arguments: JSONArray): String {
+            return when (operation) {
+                "scanCandidates" -> {
+                    require(arguments.length() == 1)
+                    scanCandidates(arguments.getString(0))
                 }
+                "getResultPage" -> {
+                    require(arguments.length() == 3)
+                    getResultPage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
+                }
+                "cleanSelected" -> {
+                    require(arguments.length() == 3)
+                    cleanSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
+                }
+                else -> throw IllegalArgumentException("不支持的服务请求")
             }
+        }
 
         override fun ping(): String {
             val ready = restoreSnapshotFromDisk()

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/CleanPlanResumeRootService.kt
@@ -22,31 +22,36 @@ class CleanPlanResumeRootService : RootService() {
     private val binder = object : ICleanPlanResumeService.Stub() {
 
         override fun exchangeJson(operation: String?, request: ParcelFileDescriptor?): ParcelFileDescriptor =
-            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { arguments ->
-                when (operation) {
-                    "begin" -> {
-                        require(arguments.length() == 5)
-                        begin(arguments.getString(0), arguments.getString(1), arguments.getString(2), arguments.getInt(3), arguments.getInt(4))
-                    }
-                    "checkpointCache" -> {
-                        require(arguments.length() == 2)
-                        checkpointCache(arguments.getString(0), arguments.getString(1))
-                    }
-                    "checkpointSafe" -> {
-                        require(arguments.length() == 2)
-                        checkpointSafe(arguments.getString(0), arguments.getString(1))
-                    }
-                    "recover" -> {
-                        require(arguments.length() == 1)
-                        recover(arguments.getString(0))
-                    }
-                    "finish" -> {
-                        require(arguments.length() == 1)
-                        finish(arguments.getString(0))
-                    }
-                    else -> throw IllegalArgumentException("不支持的服务请求")
+            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { dispatchJson(operation, it) }
+
+        override fun exchangeJsonInto(operation: String?, request: ParcelFileDescriptor?, response: ParcelFileDescriptor?): Int =
+            JsonFileTransport.serveInto(request, response) { dispatchJson(operation, it) }
+
+        private fun dispatchJson(operation: String?, arguments: JSONArray): String {
+            return when (operation) {
+                "begin" -> {
+                    require(arguments.length() == 5)
+                    begin(arguments.getString(0), arguments.getString(1), arguments.getString(2), arguments.getInt(3), arguments.getInt(4))
                 }
+                "checkpointCache" -> {
+                    require(arguments.length() == 2)
+                    checkpointCache(arguments.getString(0), arguments.getString(1))
+                }
+                "checkpointSafe" -> {
+                    require(arguments.length() == 2)
+                    checkpointSafe(arguments.getString(0), arguments.getString(1))
+                }
+                "recover" -> {
+                    require(arguments.length() == 1)
+                    recover(arguments.getString(0))
+                }
+                "finish" -> {
+                    require(arguments.length() == 1)
+                    finish(arguments.getString(0))
+                }
+                else -> throw IllegalArgumentException("不支持的服务请求")
             }
+        }
 
         override fun ping(): String {
             pruneTransactions()

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/JsonFileTransport.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/JsonFileTransport.kt
@@ -1,9 +1,11 @@
 package io.github.xgl34222220.baize.root
 
 import android.os.ParcelFileDescriptor
+import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.ByteArrayOutputStream
+import java.io.Closeable
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
@@ -12,14 +14,148 @@ import java.nio.ByteBuffer
 import java.nio.charset.CodingErrorAction
 
 /**
- * JSON travels through private, unlinked, read-only files. Binder carries only a descriptor, so
- * candidate paths and per-item results cannot exhaust its shared transaction buffer. Files are
- * fully written before dispatch: malformed or oversized requests never start a deletion task.
+ * JSON travels through private, unlinked files. Current clients create both request and response
+ * inodes; Binder carries their descriptors to Root and only an integer acknowledgement back.
+ * Candidate paths and per-item results stay outside Binder's shared transaction buffer. Requests
+ * are fully written before dispatch: malformed or oversized requests never start a deletion task.
  * There is deliberately no fallback/retry of a mutating Binder call.
  */
 internal object JsonFileTransport {
     private const val MAX_BYTES = 32L * 1024L * 1024L
+    internal const val COMPLETE = 0
+    internal const val REQUEST_REJECTED = 1
+    internal const val OUTCOME_UNKNOWN = 2
 
+    /**
+     * Both inodes belong to the App. Returning an FD created under /data/adb can be rejected
+     * by SELinux during Binder's FD translation, even when the parcel itself is tiny.
+     * Root only writes the supplied sink and returns an integer acknowledgement.
+     */
+    fun callInto(
+        directory: File,
+        arguments: JSONArray,
+        exchange: (ParcelFileDescriptor, ParcelFileDescriptor) -> Int
+    ): String {
+        val request = try {
+            write(directory, arguments.toString())
+        } catch (error: Exception) {
+            throw RootJsonTransportException("服务请求尚未提交：${error.message.orEmpty()}", false, error)
+        }
+        request.use { source ->
+            val response = try {
+                createResponse(directory)
+            } catch (error: Exception) {
+                throw RootJsonTransportException("服务请求尚未提交：${error.message.orEmpty()}", false, error)
+            }
+            response.use { target ->
+                try {
+                    when (exchange(source, target.writer)) {
+                        COMPLETE -> return read(target.reader)
+                        REQUEST_REJECTED -> throw RootJsonTransportException(
+                            "服务请求尚未执行：传输文件校验失败", false, IOException("response channel rejected"))
+                        else -> throw IOException("服务执行结果未确认，请查看任务记录后重新扫描")
+                    }
+                } catch (error: RootJsonTransportException) {
+                    throw error
+                } catch (error: Exception) {
+                    // Never replay an operation after a lost acknowledgement, including when
+                    // the response file appears complete: its commit status is still unknown.
+                    throw RootJsonTransportException("服务结果未确认：${error.message.orEmpty()}", true, error)
+                }
+            }
+        }
+    }
+
+    fun serveInto(
+        request: ParcelFileDescriptor?,
+        response: ParcelFileDescriptor?,
+        operation: (JSONArray) -> String
+    ): Int = request.use { source ->
+        response.use responseScope@ { target ->
+            // Validate the sink before the operation. statSize rejects pipes/devices. Probe a
+            // real write: truncating an already-empty file can skip the write-access check.
+            val output = try {
+                requireNotNull(target) { "结果文件缺失" }
+                require(target.statSize == 0L) { "结果文件必须是空的普通文件" }
+                ParcelFileDescriptor.AutoCloseOutputStream(target).also {
+                    it.write(0)
+                    it.channel.truncate(0L).position(0L)
+                }
+            } catch (error: Exception) {
+                Log.w("BaiZeJsonTransport", "Response channel rejected before execution", error)
+                return@responseScope REQUEST_REJECTED
+            }
+            output.use sinkScope@ { sink ->
+                var executionStarted = false
+                try {
+                    val arguments = try {
+                        JSONArray(read(requireNotNull(source) { "请求文件缺失" }))
+                    } catch (error: Exception) {
+                        writeBounded(sink, JSONObject().put("success", false)
+                            .put("error", "transport_request_rejected").put("requestRejected", true)
+                            .put("message", "请求未执行：${error.message.orEmpty()}").toString())
+                        return@sinkScope COMPLETE
+                    }
+                    executionStarted = true
+                    writeBounded(sink, operation(arguments))
+                    COMPLETE
+                } catch (error: Exception) {
+                    Log.e("BaiZeJsonTransport", "JSON exchange failed; executionStarted=$executionStarted", error)
+                    if (executionStarted) OUTCOME_UNKNOWN else REQUEST_REJECTED
+                }
+            }
+        }
+    }
+
+    internal class ResponseFile(val writer: ParcelFileDescriptor, val reader: ParcelFileDescriptor) : Closeable {
+        override fun close() {
+            try { writer.close() } finally { reader.close() }
+        }
+    }
+
+    internal fun createResponse(directory: File): ResponseFile {
+        if (!directory.isDirectory && !directory.mkdirs()) throw IOException("无法创建服务传输目录")
+        val file = File.createTempFile("baize-ipc-", ".json", directory)
+        var writer: ParcelFileDescriptor? = null
+        var reader: ParcelFileDescriptor? = null
+        try {
+            file.setReadable(false, false)
+            file.setWritable(false, false)
+            file.setReadable(true, true)
+            file.setWritable(true, true)
+            writer = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_WRITE)
+            // Separate open descriptions: Root advancing its write cursor cannot move our read cursor.
+            reader = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            if (!file.delete()) throw IOException("无法移除服务传输临时文件")
+            return ResponseFile(writer, reader)
+        } catch (error: Exception) {
+            writer?.close()
+            reader?.close()
+            throw error
+        } finally {
+            file.delete()
+        }
+    }
+
+    private fun writeBounded(output: OutputStream, text: String) {
+        var bytesWritten = 0L
+        val bounded = object : OutputStream() {
+            override fun write(value: Int) {
+                if (bytesWritten >= MAX_BYTES) throw IOException("服务数据超出单次读取上限")
+                output.write(value)
+                bytesWritten++
+            }
+            override fun write(buffer: ByteArray, offset: Int, length: Int) {
+                if (bytesWritten + length > MAX_BYTES) throw IOException("服务数据超出单次读取上限")
+                output.write(buffer, offset, length)
+                bytesWritten += length
+            }
+        }
+        bounded.bufferedWriter(Charsets.UTF_8).use { it.write(text) }
+        output.flush()
+    }
+
+    /** Legacy transaction retained for old clients; current clients use [callInto]. */
     fun call(
         directory: File,
         arguments: JSONArray,
@@ -75,20 +211,7 @@ internal object JsonFileTransport {
                 descriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
                 // No named file remains even if the process dies while encoding a large reply.
                 if (!file.delete()) throw IOException("无法移除服务传输临时文件")
-                var bytesWritten = 0L
-                val bounded = object : OutputStream() {
-                    override fun write(value: Int) {
-                        if (bytesWritten >= MAX_BYTES) throw IOException("服务数据超出单次读取上限")
-                        output.write(value)
-                        bytesWritten++
-                    }
-                    override fun write(buffer: ByteArray, offset: Int, length: Int) {
-                        if (bytesWritten + length > MAX_BYTES) throw IOException("服务数据超出单次读取上限")
-                        output.write(buffer, offset, length)
-                        bytesWritten += length
-                    }
-                }
-                bounded.bufferedWriter(Charsets.UTF_8).use { it.write(text) }
+                writeBounded(output, text)
             }
             return requireNotNull(descriptor)
         } catch (error: Exception) {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/PersistentCleanPlanRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/PersistentCleanPlanRootService.kt
@@ -34,23 +34,28 @@ class PersistentCleanPlanRootService : RootService() {
     private val binder = object : IPersistentCleanPlanService.Stub() {
 
         override fun exchangeJson(operation: String?, request: ParcelFileDescriptor?): ParcelFileDescriptor =
-            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { arguments ->
-                when (operation) {
-                    "scanSafe" -> {
-                        require(arguments.length() == 1)
-                        scanSafe(arguments.getString(0))
-                    }
-                    "getPage" -> {
-                        require(arguments.length() == 3)
-                        getPage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
-                    }
-                    "cleanSafe" -> {
-                        require(arguments.length() == 3)
-                        cleanSafe(arguments.getString(0), arguments.getString(1), arguments.getString(2))
-                    }
-                    else -> throw IllegalArgumentException("不支持的服务请求")
+            JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { dispatchJson(operation, it) }
+
+        override fun exchangeJsonInto(operation: String?, request: ParcelFileDescriptor?, response: ParcelFileDescriptor?): Int =
+            JsonFileTransport.serveInto(request, response) { dispatchJson(operation, it) }
+
+        private fun dispatchJson(operation: String?, arguments: JSONArray): String {
+            return when (operation) {
+                "scanSafe" -> {
+                    require(arguments.length() == 1)
+                    scanSafe(arguments.getString(0))
                 }
+                "getPage" -> {
+                    require(arguments.length() == 3)
+                    getPage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
+                }
+                "cleanSafe" -> {
+                    require(arguments.length() == 3)
+                    cleanSafe(arguments.getString(0), arguments.getString(1), arguments.getString(2))
+                }
+                else -> throw IllegalArgumentException("不支持的服务请求")
             }
+        }
 
         override fun ping(): String = JSONObject()
             .put("uid", Process.myUid())

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootServiceClients.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/RootServiceClients.kt
@@ -10,80 +10,80 @@ internal object RootServiceClients {
         val remote = requireNotNull(IProfileRootService.Stub.asInterface(binder))
         return object : IProfileRootService by remote {
             override fun scanProfile(profile: String?, optionsJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(profile.orEmpty()).put(optionsJson.orEmpty())) { request ->
-                    remote.exchangeJson("scanProfile", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(profile.orEmpty()).put(optionsJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("scanProfile", request, response)
                 }
             override fun getProfilePage(snapshotId: String?, offset: Int, limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(offset).put(limit)) { request ->
-                    remote.exchangeJson("getProfilePage", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(offset).put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getProfilePage", request, response)
                 }
             override fun cleanProfileSelected(snapshotId: String?, selectionJson: String?, optionsJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(optionsJson.orEmpty())) { request ->
-                    remote.exchangeJson("cleanProfileSelected", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(optionsJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("cleanProfileSelected", request, response)
                 }
             override fun quarantineProfileSelected(snapshotId: String?, selectionJson: String?, optionsJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(optionsJson.orEmpty())) { request ->
-                    remote.exchangeJson("quarantineProfileSelected", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(optionsJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("quarantineProfileSelected", request, response)
                 }
             override fun prepareCacheSelection(snapshotId: String?, selectionJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty())) { request ->
-                    remote.exchangeJson("prepareCacheSelection", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("prepareCacheSelection", request, response)
                 }
             override fun getQuarantinePage(offset: Int, limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(offset).put(limit)) { request ->
-                    remote.exchangeJson("getQuarantinePage", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(offset).put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getQuarantinePage", request, response)
                 }
             override fun getModuleState(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("getModuleState", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("getModuleState", request, response)
                 }
             override fun getTaskHistory(limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(limit)) { request ->
-                    remote.exchangeJson("getTaskHistory", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getTaskHistory", request, response)
                 }
             override fun getTaskHistoryPage(offset: Int, limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(offset).put(limit)) { request ->
-                    remote.exchangeJson("getTaskHistoryPage", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(offset).put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getTaskHistoryPage", request, response)
                 }
             override fun getAuditTimelinePage(offset: Int, limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(offset).put(limit)) { request ->
-                    remote.exchangeJson("getAuditTimelinePage", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(offset).put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getAuditTimelinePage", request, response)
                 }
             override fun getScanCoverage(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("getScanCoverage", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("getScanCoverage", request, response)
                 }
             override fun clearPackageCaches(requestJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(requestJson.orEmpty())) { request ->
-                    remote.exchangeJson("clearPackageCaches", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(requestJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("clearPackageCaches", request, response)
                 }
             override fun scanFileOrganizer(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("scanFileOrganizer", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("scanFileOrganizer", request, response)
                 }
             override fun applyFileOrganizer(snapshotId: String?, selectionJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty())) { request ->
-                    remote.exchangeJson("applyFileOrganizer", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("applyFileOrganizer", request, response)
                 }
             override fun undoFileOrganizer(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("undoFileOrganizer", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("undoFileOrganizer", request, response)
                 }
             override fun getInstalledPackageCatalog(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("getInstalledPackageCatalog", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("getInstalledPackageCatalog", request, response)
                 }
             override fun getWhitelistPackages(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("getWhitelistPackages", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("getWhitelistPackages", request, response)
                 }
             override fun saveWhitelistPackages(packagesJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(packagesJson.orEmpty())) { request ->
-                    remote.exchangeJson("saveWhitelistPackages", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(packagesJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("saveWhitelistPackages", request, response)
                 }
             override fun getWhitelistPaths(): String =
-                JsonFileTransport.call(directory, JSONArray()) { request ->
-                    remote.exchangeJson("getWhitelistPaths", request)
+                JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                    remote.exchangeJsonInto("getWhitelistPaths", request, response)
                 }
         }
     }
@@ -91,16 +91,16 @@ internal object RootServiceClients {
         val remote = requireNotNull(IBaiZeRootService.Stub.asInterface(binder))
         return object : IBaiZeRootService by remote {
             override fun scanCandidates(whitelistJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(whitelistJson.orEmpty())) { request ->
-                    remote.exchangeJson("scanCandidates", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(whitelistJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("scanCandidates", request, response)
                 }
             override fun getResultPage(snapshotId: String?, offset: Int, limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(offset).put(limit)) { request ->
-                    remote.exchangeJson("getResultPage", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(offset).put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getResultPage", request, response)
                 }
             override fun cleanSelected(snapshotId: String?, selectionJson: String?, whitelistJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(whitelistJson.orEmpty())) { request ->
-                    remote.exchangeJson("cleanSelected", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(whitelistJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("cleanSelected", request, response)
                 }
         }
     }
@@ -108,16 +108,16 @@ internal object RootServiceClients {
         val remote = requireNotNull(IPersistentCleanPlanService.Stub.asInterface(binder))
         return object : IPersistentCleanPlanService by remote {
             override fun scanSafe(optionsJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(optionsJson.orEmpty())) { request ->
-                    remote.exchangeJson("scanSafe", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(optionsJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("scanSafe", request, response)
                 }
             override fun getPage(snapshotId: String?, offset: Int, limit: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(offset).put(limit)) { request ->
-                    remote.exchangeJson("getPage", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(offset).put(limit)) { request, response ->
+                    remote.exchangeJsonInto("getPage", request, response)
                 }
             override fun cleanSafe(snapshotId: String?, selectionJson: String?, optionsJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(optionsJson.orEmpty())) { request ->
-                    remote.exchangeJson("cleanSafe", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(snapshotId.orEmpty()).put(selectionJson.orEmpty()).put(optionsJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("cleanSafe", request, response)
                 }
         }
     }
@@ -125,24 +125,24 @@ internal object RootServiceClients {
         val remote = requireNotNull(ICleanPlanResumeService.Stub.asInterface(binder))
         return object : ICleanPlanResumeService by remote {
             override fun begin(planId: String?, cacheSnapshotId: String?, safeSnapshotId: String?, cacheCount: Int, safeCount: Int): String =
-                JsonFileTransport.call(directory, JSONArray().put(planId.orEmpty()).put(cacheSnapshotId.orEmpty()).put(safeSnapshotId.orEmpty()).put(cacheCount).put(safeCount)) { request ->
-                    remote.exchangeJson("begin", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(planId.orEmpty()).put(cacheSnapshotId.orEmpty()).put(safeSnapshotId.orEmpty()).put(cacheCount).put(safeCount)) { request, response ->
+                    remote.exchangeJsonInto("begin", request, response)
                 }
             override fun checkpointCache(planId: String?, resultJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(planId.orEmpty()).put(resultJson.orEmpty())) { request ->
-                    remote.exchangeJson("checkpointCache", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(planId.orEmpty()).put(resultJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("checkpointCache", request, response)
                 }
             override fun checkpointSafe(planId: String?, resultJson: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(planId.orEmpty()).put(resultJson.orEmpty())) { request ->
-                    remote.exchangeJson("checkpointSafe", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(planId.orEmpty()).put(resultJson.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("checkpointSafe", request, response)
                 }
             override fun recover(planId: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(planId.orEmpty())) { request ->
-                    remote.exchangeJson("recover", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(planId.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("recover", request, response)
                 }
             override fun finish(planId: String?): String =
-                JsonFileTransport.call(directory, JSONArray().put(planId.orEmpty())) { request ->
-                    remote.exchangeJson("finish", request)
+                JsonFileTransport.callInto(directory, JSONArray().put(planId.orEmpty())) { request, response ->
+                    remote.exchangeJsonInto("finish", request, response)
                 }
         }
     }

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/root/CallerOwnedJsonTransportTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/root/CallerOwnedJsonTransportTest.kt
@@ -1,0 +1,317 @@
+package io.github.xgl34222220.baize.root
+
+import android.app.Application
+import android.os.ParcelFileDescriptor
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowParcelFileDescriptor
+import java.io.File
+import java.io.FileDescriptor
+import java.io.IOException
+
+/**
+ * Exercises caller-owned descriptors and acknowledgement handling on JVM file descriptors.
+ * A real App/Root Binder exchange and OEM SELinux policy still need device validation.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28], application = Application::class)
+class CallerOwnedJsonTransportTest {
+    @get:Rule val folder = TemporaryFolder()
+
+    @Test fun largeUnicodeRequestAndResponseUseOnlyCallerOwnedFilesAndIntegerAcknowledgement() {
+        val directory = folder.newFolder("caller-only")
+        val paths = (0 until 1772).map { index ->
+            "/storage/emulated/0/Android/data/com.example.$index/cache/" +
+                "中文清理目录/".repeat(12) + "下载暂存 \"测试\" 文件-$index.tmp"
+        }
+        val selection = JSONObject()
+        val details = JSONArray()
+        paths.forEachIndexed { index, path ->
+            selection.put(path, true)
+            details.put(JSONObject().put("path", path).put("bytes", index + 1L))
+        }
+        val arguments = JSONArray().put("snapshot-1772").put(selection.toString())
+        val expected = JSONObject().put("success", true).put("details", details).toString()
+        assertTrue(arguments.toString().toByteArray(Charsets.UTF_8).size > 429480)
+        assertTrue(expected.toByteArray(Charsets.UTF_8).size > 429480)
+        var exchanges = 0
+        var mutations = 0
+        var requestHandle: FileDescriptor? = null
+        var responseHandle: FileDescriptor? = null
+
+        val actual = JsonFileTransport.callInto(directory, arguments) { request, response ->
+            exchanges++
+            requestHandle = request.fileDescriptor
+            responseHandle = response.fileDescriptor
+            assertTrue(request.statSize > 429480L)
+            // Both files exist before Root executes; neither has a name left in the directory.
+            assertEquals(0L, response.statSize)
+            assertEmptyDirectory(directory)
+            // No service directory and no service-created return descriptor are involved.
+            JsonFileTransport.serveInto(request, response) { received ->
+                mutations++
+                assertEquals("snapshot-1772", received.getString(0))
+                val receivedSelection = JSONObject(received.getString(1))
+                assertEquals(paths.size, receivedSelection.length())
+                paths.forEach { assertTrue(receivedSelection.getBoolean(it)) }
+                expected
+            }
+        }
+
+        assertEquals(expected, actual)
+        val returnedDetails = JSONObject(actual).getJSONArray("details")
+        paths.forEachIndexed { index, path ->
+            assertEquals(path, returnedDetails.getJSONObject(index).getString("path"))
+            assertEquals(index + 1L, returnedDetails.getJSONObject(index).getLong("bytes"))
+        }
+        assertEquals(1, exchanges)
+        assertEquals(1, mutations)
+        assertFalse(requireNotNull(requestHandle).valid())
+        assertFalse(requireNotNull(responseHandle).valid())
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun responseReaderStartsAtZeroAfterWriterAdvancesAndAllHandlesClose() {
+        val directory = folder.newFolder("independent-offsets")
+        val target = JsonFileTransport.createResponse(directory)
+        val writerHandle = target.writer.fileDescriptor
+        val readerHandle = target.reader.fileDescriptor
+        val expected = "{\"success\":true,\"path\":\"中文下载/📦.apk\"}"
+        target.use {
+            assertEquals(0L, target.writer.statSize)
+            assertEquals(0L, target.reader.statSize)
+            assertEmptyDirectory(directory)
+            ParcelFileDescriptor.AutoCloseOutputStream(target.writer).use { output ->
+                val bytes = expected.toByteArray(Charsets.UTF_8)
+                output.write(bytes)
+                assertEquals(bytes.size.toLong(), output.channel.position())
+            }
+            assertEquals(expected, JsonFileTransport.read(target.reader))
+        }
+        assertFalse(writerHandle.valid())
+        assertFalse(readerHandle.valid())
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun malformedOrMissingRequestReturnsExplicitRejectionWithoutMutation() {
+        val directory = folder.newFolder("rejected-requests")
+        var mutations = 0
+        listOf<String?>(null, "[", "{\"selected\":true}").forEach { text ->
+            val request = text?.let { JsonFileTransport.write(directory, it) }
+            JsonFileTransport.createResponse(directory).use { response ->
+                val status = JsonFileTransport.serveInto(request, response.writer) {
+                    mutations++
+                    "{\"success\":true}"
+                }
+                assertEquals(JsonFileTransport.COMPLETE, status)
+                val result = JSONObject(JsonFileTransport.read(response.reader))
+                assertFalse(result.getBoolean("success"))
+                assertTrue(result.getBoolean("requestRejected"))
+                assertEquals("transport_request_rejected", result.getString("error"))
+            }
+            assertEmptyDirectory(directory)
+        }
+        assertEquals(0, mutations)
+    }
+
+    @Test fun invalidUtf8RequestIsRejectedWithoutChangingItsPathOrStartingMutation() {
+        val directory = folder.newFolder("invalid-utf8")
+        val input = folder.newFile("invalid-utf8.json").apply {
+            writeBytes(byteArrayOf(0x5b, 0x22, 0xc3.toByte(), 0x28, 0x22, 0x5d))
+        }
+        var mutations = 0
+        JsonFileTransport.createResponse(directory).use { response ->
+            val status = JsonFileTransport.serveInto(
+                ParcelFileDescriptor.open(input, ParcelFileDescriptor.MODE_READ_ONLY), response.writer
+            ) {
+                mutations++
+                "{}"
+            }
+            assertEquals(JsonFileTransport.COMPLETE, status)
+            assertTrue(JSONObject(JsonFileTransport.read(response.reader)).getBoolean("requestRejected"))
+        }
+        assertEquals(0, mutations)
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun missingResponseIsRejectedBeforeMutation() {
+        val directory = folder.newFolder("missing-response")
+        var mutations = 0
+        val status = JsonFileTransport.serveInto(
+            JsonFileTransport.write(directory, "[]"), null
+        ) {
+            mutations++
+            "{}"
+        }
+        assertEquals(JsonFileTransport.REQUEST_REJECTED, status)
+        assertEquals(0, mutations)
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun emptyReadOnlyResponseIsRejectedBeforeMutation() {
+        val directory = folder.newFolder("read-only-response")
+        var mutations = 0
+        // An empty read-only file is the important case: truncate(0) alone may be a no-op.
+        val response = JsonFileTransport.write(directory, "")
+        val responseHandle = response.fileDescriptor
+        val status = JsonFileTransport.serveInto(JsonFileTransport.write(directory, "[]"), response) {
+            mutations++
+            "{}"
+        }
+        assertEquals(JsonFileTransport.REQUEST_REJECTED, status)
+        assertEquals(0, mutations)
+        assertFalse(responseHandle.valid())
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun nonEmptyResponseIsRejectedBeforeMutationAndDoesNotOverwriteExistingData() {
+        val directory = folder.newFolder("nonempty-response")
+        val input = folder.newFile("occupied-response.json").apply { writeText("preserve me") }
+        var mutations = 0
+        val status = JsonFileTransport.serveInto(
+            JsonFileTransport.write(directory, "[]"),
+            ParcelFileDescriptor.open(input, ParcelFileDescriptor.MODE_READ_WRITE)
+        ) {
+            mutations++
+            "{}"
+        }
+        assertEquals(JsonFileTransport.REQUEST_REJECTED, status)
+        assertEquals(0, mutations)
+        assertEquals("preserve me", input.readText())
+        assertEmptyDirectory(directory)
+    }
+
+    @Test
+    @Config(shadows = [NonRegularDescriptorShadow::class])
+    fun pipeResponseIsRejectedBeforeMutationOrWriting() {
+        val directory = folder.newFolder("pipe-response")
+        var mutations = 0
+        val pipe = ParcelFileDescriptor.createPipe()
+        pipe[0].use {
+            pipe[1].use { sink ->
+                assertEquals(-1L, sink.statSize)
+                val status = JsonFileTransport.serveInto(JsonFileTransport.write(directory, "[]"), sink) {
+                    mutations++
+                    "{}"
+                }
+                assertEquals(JsonFileTransport.REQUEST_REJECTED, status)
+            }
+        }
+        assertEquals(0, mutations)
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun lostAcknowledgementAfterMutationReportsUnknownOutcomeAndNeverRetries() {
+        val directory = folder.newFolder("lost-acknowledgement")
+        var exchanges = 0
+        var mutations = 0
+        val error = assertThrows(RootJsonTransportException::class.java) {
+            JsonFileTransport.callInto(directory, JSONArray().put("snapshot")) { request, response ->
+                exchanges++
+                assertEquals(JsonFileTransport.COMPLETE, JsonFileTransport.serveInto(request, response) {
+                    mutations++
+                    "{\"success\":true}"
+                })
+                // The result file is complete, but Binder never delivers its acknowledgement.
+                throw IOException("acknowledgement disconnected")
+            }
+        }
+        assertTrue(error.requestSubmitted)
+        assertEquals("acknowledgement disconnected", error.cause?.message)
+        assertEquals(1, exchanges)
+        assertEquals(1, mutations)
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun unknownStatusNeverReadsPartialResultEvenWhenSomeBytesWereWritten() {
+        val directory = folder.newFolder("unknown-status")
+        listOf(JsonFileTransport.OUTCOME_UNKNOWN, 71).forEach { status ->
+            var exchanges = 0
+            val error = assertThrows(RootJsonTransportException::class.java) {
+                JsonFileTransport.callInto(directory, JSONArray()) { _, response ->
+                    exchanges++
+                    ParcelFileDescriptor.AutoCloseOutputStream(response).use {
+                        // Deliberately invalid UTF-8: reading this would produce a different error.
+                        it.write(byteArrayOf(0xc3.toByte()))
+                    }
+                    status
+                }
+            }
+            assertTrue(error.requestSubmitted)
+            assertEquals("服务执行结果未确认，请查看任务记录后重新扫描", error.cause?.message)
+            assertEquals(1, exchanges)
+            assertEmptyDirectory(directory)
+        }
+    }
+
+    @Test fun failureDuringOperationIsUnknownAndDoesNotReplayTheOperation() {
+        val directory = folder.newFolder("operation-failure")
+        var exchanges = 0
+        var mutations = 0
+        val error = assertThrows(RootJsonTransportException::class.java) {
+            JsonFileTransport.callInto(directory, JSONArray()) { request, response ->
+                exchanges++
+                JsonFileTransport.serveInto(request, response) {
+                    mutations++
+                    throw IOException("operation interrupted after starting")
+                }
+            }
+        }
+        assertTrue(error.requestSubmitted)
+        assertEquals(1, exchanges)
+        assertEquals(1, mutations)
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun rejectedChannelReportsUnsubmittedWithoutRetryingOrReadingAResponse() {
+        val directory = folder.newFolder("channel-rejection")
+        var exchanges = 0
+        val error = assertThrows(RootJsonTransportException::class.java) {
+            JsonFileTransport.callInto(directory, JSONArray()) { _, _ ->
+                exchanges++
+                JsonFileTransport.REQUEST_REJECTED
+            }
+        }
+        assertFalse(error.requestSubmitted)
+        assertEquals(1, exchanges)
+        assertEmptyDirectory(directory)
+    }
+
+    @Test fun localPreparationFailureNeverDispatchesAndReportsUnsubmitted() {
+        val directoryIsAFile = folder.newFile("not-a-directory")
+        var exchanges = 0
+        val error = assertThrows(RootJsonTransportException::class.java) {
+            JsonFileTransport.callInto(directoryIsAFile, JSONArray()) { _, _ ->
+                exchanges++
+                JsonFileTransport.COMPLETE
+            }
+        }
+        assertFalse(error.requestSubmitted)
+        assertEquals(0, exchanges)
+        assertEquals(0L, directoryIsAFile.length())
+        assertEquals(listOf(directoryIsAFile), folder.root.listFiles()!!.toList())
+    }
+
+    private fun assertEmptyDirectory(directory: File) {
+        assertTrue("Caller-owned transport files must be unlinked: $directory", directory.listFiles()!!.isEmpty())
+    }
+
+    /** Robolectric implements pipes with temporary files; supply the platform's non-regular stat. */
+    @Implements(ParcelFileDescriptor::class)
+    class NonRegularDescriptorShadow : ShadowParcelFileDescriptor() {
+        @Implementation
+        public override fun getStatSize(): Long = -1L
+    }
+}

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
@@ -45,7 +45,7 @@ class WorkbenchVisualReviewTest {
     @Test fun reportedFailureRetainsReviewWithoutShowingASecondEmptyState() {
         render(ready().copy(notice = WorkbenchNotice.ERROR,
             phase = "所选项目清理失败：data parcel size 429480 bytes"))
-        compose.onNodeWithText("本次任务未完成").assertIsDisplayed()
+        compose.onNodeWithText("所选项目清理失败：data parcel size 429480 bytes").assertIsDisplayed()
         compose.onNodeWithText("清理已选 1800 项").assertIsDisplayed()
         compose.onNodeWithText("按应用查看清理内容").assertDoesNotExist()
         save("failure-preserved")

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
@@ -50,7 +50,8 @@ class WorkbenchVisualReviewTest {
         compose.onNodeWithText("按应用查看清理内容").assertDoesNotExist()
         save("failure-preserved")
         compose.onNodeWithContentDescription("查看任务详情").performClick()
-        compose.onNodeWithText("所选项目清理失败：data parcel size 429480 bytes").assertIsDisplayed()
+        compose.onNode(hasText("所选项目清理失败：data parcel size 429480 bytes") and hasAnyAncestor(isDialog()))
+            .assertIsDisplayed()
     }
 
     @Test


### PR DESCRIPTION
两台设备在扫描结果页均报“服务结果未确认：Transaction failed on small parcel”。v2.9.3 的响应 FD 来自 /data/adb/baize-v2/ipc，普通 App 接收该 Root 文件时可能被 SELinux 拒绝；小 parcel 报错本身不能证明 Root 进程死亡，尚无设备 AVC 日志确认具体失败点。

本修复由 App 预创建请求和响应文件，将请求只读 FD 与响应可写 FD 传给 Root，服务完成后只返回整数确认。响应使用独立读取 FD，避免共享写入偏移；四类服务统一切换新协议，AIDL 末尾追加方法保留旧事务编号。执行前校验空普通响应文件并实际探测写权限，保留 32 MiB / UTF-8 校验。未知状态或丢失确认不会重放清理。

扫描错误条直接显示通信失败或简短实际原因，完整详情保留。界面回归同步检查可见错误原因与详情弹窗，避免同文案的节点歧义。新增 workflow 只构建同签名测试 APK，不发布 Release 或更新 OTA。

验证结果：
- 本地核心回归 55 项通过、0 失败；4 项因缺少 busybox 跳过。
- 新增 13 项传输回归通过，覆盖大 Unicode 数据、独立读写偏移、只读/无效文件拒绝、丢确认不重放等。
- Release 单测、构建、Lint 和正式签名校验通过：https://github.com/xgl34222220-ops/BaiZe/actions/runs/34724075090
- 最终 Android UI CI（Debug 单测、编译、Lint、macrobenchmark 构建）通过：https://github.com/xgl34222220-ops/BaiZe/actions/runs/34724771241
- 复查窄屏大字号错误状态实际渲染；布局正常。

测试 APK 来自 dd72af40；后续两个提交仅更新 Debug 测试断言，App/Root 运行代码完全一致。已将该 APK 装入原正式模块 ZIP，只更新 app/baize.apk 和校验值，其余 63 项内容与权限保持；内部版本仍为 2.9.3 / 29003。完整测试模块 SHA-256：a83573cdbd82d0adb1972576b96fc295194b6ee40cc287002acdd824cf14100b。

Robolectric 不代表真机 Binder/SELinux 验证。下一步是在两台设备刷入测试模块并重启，验证扫描完成、结果展开、勾选清理和重启后的再次扫描。