### PR TITLE
按洛书当前界面统一白泽首页、设置与同源折射底栏

### DIFF
--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -9,6 +9,7 @@ on:
       - 'v2/macrobenchmark/**'
       - 'v2/build.gradle.kts'
       - 'v2/gradle.properties'
+      - 'v2/tests/**'
       - '.github/workflows/android-ui-ci.yml'
 
 permissions:
@@ -46,12 +47,15 @@ jobs:
           java-version: '17'
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
-      - name: Install Android platform
-        run: yes | sdkmanager 'platforms;android-37' 'build-tools;36.0.0'
+      # AGP resolves the compile SDK, as in LuoShu's proven Android UI smoke workflow.
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           gradle-version: '9.5.0'
+      - name: Verify scheduler and audit contracts
+        run: |
+          bash v2/tests/test-audit-center-contract.sh
+          bash v2/tests/test-schedule-modes-contract.sh
       - name: Compile and lint UI
         working-directory: v2
         shell: bash

--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -7,6 +7,8 @@ on:
       - 'v2/app/**'
       - 'v2/third_party/libsu-service/**'
       - 'v2/macrobenchmark/**'
+      - 'v2/build.gradle.kts'
+      - 'v2/gradle.properties'
       - '.github/workflows/android-ui-ci.yml'
 
 permissions:
@@ -21,7 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Attach matching UI review sources
         uses: actions/upload-artifact@v4
         with:
@@ -38,24 +39,19 @@ jobs:
             v2/settings.gradle.kts
             v2/gradle.properties
           if-no-files-found: error
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
-
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
-
       - name: Install Android platform
-        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
-
+        run: yes | sdkmanager 'platforms;android-37' 'build-tools;36.0.0'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.13'
-
+          gradle-version: '9.5.0'
       - name: Compile and lint UI
         working-directory: v2
         shell: bash
@@ -65,7 +61,6 @@ jobs:
           code=$?
           tail -n 200 /tmp/baize-android-ui.log
           exit "$code"
-
       - name: Upload actual UI renderings
         if: always()
         uses: actions/upload-artifact@v4
@@ -73,7 +68,6 @@ jobs:
           name: baize-ui-visual-review
           path: v2/app/build/reports/ui-screenshots/*.png
           if-no-files-found: warn
-
       - name: Upload Android diagnostics
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -40,11 +40,14 @@ jobs:
             v2/settings.gradle.kts
             v2/gradle.properties
           if-no-files-found: error
-      - name: Set up JDK 17
+      # The miuix 0.9.3 AAR contains Java 21 classes. D8 packages them for Android,
+      # but host-side Robolectric must load those classes on Java 21 as well.
+      # App Java/Kotlin target remains 17; this changes only the CI host runtime.
+      - name: Set up JDK 21 for UI host tests
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
       # AGP resolves the compile SDK, as in LuoShu's proven Android UI smoke workflow.

--- a/.github/workflows/android-ui-ci.yml
+++ b/.github/workflows/android-ui-ci.yml
@@ -22,6 +22,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Attach matching UI review sources
+        uses: actions/upload-artifact@v4
+        with:
+          name: baize-ui-review-sources
+          retention-days: 3
+          path: |
+            v2/app/src/main/java/
+            v2/app/src/testDebug/
+            v2/app/src/test/
+            v2/app/src/main/res/values/
+            v2/app/src/main/AndroidManifest.xml
+            v2/app/build.gradle.kts
+            v2/build.gradle.kts
+            v2/settings.gradle.kts
+            v2/gradle.properties
+          if-no-files-found: error
+
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/native-ui-preview-apk.yml
+++ b/.github/workflows/native-ui-preview-apk.yml
@@ -35,8 +35,7 @@ jobs:
           java-version: '17'
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
-      - name: Install Android platform
-        run: yes | sdkmanager 'platforms;android-37' 'build-tools;36.0.0'
+      # Match LuoShu: let the current AGP resolve its required compile platform.
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:

--- a/.github/workflows/native-ui-preview-apk.yml
+++ b/.github/workflows/native-ui-preview-apk.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'v2/app/**'
       - 'v2/third_party/libsu-service/**'
+      - 'v2/build.gradle.kts'
+      - 'v2/gradle.properties'
       - '.github/workflows/native-ui-preview-apk.yml'
   workflow_dispatch:
 
@@ -26,24 +28,19 @@ jobs:
     steps:
       - name: Checkout preview branch
         uses: actions/checkout@v4
-
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
-
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3
-
       - name: Install Android platform
-        run: yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
-
+        run: yes | sdkmanager 'platforms;android-37' 'build-tools;36.0.0'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.13'
-
+          gradle-version: '9.5.0'
       - name: Compile and assemble debug APK
         working-directory: v2
         shell: bash
@@ -52,7 +49,6 @@ jobs:
           gradle --no-daemon :app:compileDebugKotlin :app:assembleDebug
           test -f app/build/outputs/apk/debug/app-debug.apk
           cp app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/BaiZe-Native-UI-Preview.apk
-
       - name: Upload native UI preview APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -42,6 +42,12 @@ jobs:
           echo "BAIZE_RELEASE_TARGET_SHA=$TARGET" >> "$GITHUB_ENV"
           echo "BAIZE_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "BAIZE_VERSION_CODE=$CODE" >> "$GITHUB_ENV"
+          # Select the toolchain from the checked-out target, retaining historical releases.
+          if grep -Eq 'version "9\.3\.' v2/build.gradle.kts; then
+            echo 'BAIZE_GRADLE_VERSION=9.5.0' >> "$GITHUB_ENV"
+          else
+            echo 'BAIZE_GRADLE_VERSION=8.13' >> "$GITHUB_ENV"
+          fi
 
       - name: Install compatibility tools
         run: sudo apt-get update && sudo apt-get install -y busybox-static toybox
@@ -67,11 +73,12 @@ jobs:
         shell: bash
         run: |
           set +o pipefail
+          # AGP resolves any newer compile platform from the source configuration.
           yes | sdkmanager 'platforms;android-36' 'build-tools;36.0.0' 'ndk;27.2.12479018'
 
       - uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.13'
+          gradle-version: ${{ env.BAIZE_GRADLE_VERSION }}
 
       - name: Prepare formal signing certificate
         shell: bash

--- a/docs/UI-LUOSHU-BASELINE.md
+++ b/docs/UI-LUOSHU-BASELINE.md
@@ -8,14 +8,15 @@
 
 实际设置调用链：`AppearanceSettingsRoute -> SettingsHubRoute -> SettingsHome`，定义在 `ui/settings/SettingsHubScreen.kt`。
 
-本轮参考及适配的源文件：
+参考及适配的源文件：
 - `ui/home/HomeScreenCompact.kt`：状态胶囊、主卡渐变、单一主操作、双列工具卡。
 - `ui/settings/SettingsHubScreen.kt`：状态概览、导航分组、独立详情页；不是整屏展开表单。
 - `ui/theme/LuoShuCompactLayout.kt`：26/34sp 主标题、22/30sp 详情标题，64dp 最小头栏。
 - `ui/theme/LuoShuIconSystem.kt`：48dp 触控槽、44dp 圆形表面、21dp 头栏图标。
 - `ui/theme/LuoShuTheme.kt`：生成色板和页面/卡片层级；保留 Monet、主题色及 AMOLED。
+- `LuoShuAppShell.kt` 与 `ui/glass/LiquidGlassLens.kt`：真实背景取样、折射外壳、移动透镜及独立清晰标签层。
 
-同一所有者项目的组件适配，保留白泽仓库原许可证；未复制任何字体文件、字体引擎、挂载或 Root 操作。
+同一所有者项目的组件适配，保留白泽仓库原许可证；Apache-2.0 上游折射实现的声明与完整许可证位于 App assets/licenses/miuix-liquid-glass.txt。未复制字体文件、字体引擎、挂载或 Root 操作。
 
 ## 白泽接入
 
@@ -25,8 +26,12 @@
 
 清理执行条件、归类条件、通知及两个数值编辑器移入独立任务设置页。原有保存草稿、轮询状态合并和回调继续由 SettingsRoute 管理；开关不会隐式保存。
 
+## 底栏
+
+`BaiZeMiuixApp` 的 MIUIX 分支已接入 `LuoShuLiquidDock`，页面使用真实背景取样，标签置于折射层之外；设置详情通过 onDetailChanged 隐藏底栏，返回恢复。完整参数、门控和测试边界见 [UI-LUOSHU-DOCK.md](UI-LUOSHU-DOCK.md)。无真实模糊时使用不透明回退，不将背景透字当作玻璃效果。
+
 ## 不得混同的验证
 
-自动编译和交互测试不代表审美验收；Robolectric 图片使用模拟状态，不是用户手机容量或清理数据。须检查实际入口渲染，并回归窄屏大字、深浅色、断线重连、工具回调、设置返回和草稿保存。
+自动编译和交互测试不代表审美验收；Robolectric 图片使用模拟状态，不是用户手机容量或清理数据，也不证明 GPU 折射已经真机验收。须检查实际入口渲染，并回归窄屏大字、深浅色、断线重连、工具回调、设置返回和草稿保存。
 
-本轮不声称完整移植洛书底栏的 RuntimeShader 折射链。白泽现有底栏仍使用 Haze，硬件折射、降级透明度和设置详情页底栏隐藏需单独核验。不得将其标为已完成，也不因 UI 重构修改清理引擎、Root 通信修复、正式版本或发布签名。
+UI 重构不修改清理引擎、Root 通信修复、正式版本或发布签名。发布工作流仅按目标源码选择匹配 Gradle 版本，不改发布请求文件、不自动发布。

--- a/docs/UI-LUOSHU-BASELINE.md
+++ b/docs/UI-LUOSHU-BASELINE.md
@@ -1,0 +1,32 @@
+# 白泽 UI：以洛书当前活动页面为准
+
+## 固定参考来源
+
+仓库 `xgl34222220-ops/LuoShu`，提交 `fe4df5f224dca9bc77517ffa539ba021ed4b1a8e`。
+
+实际首页调用链：`LuoShuAppShell -> HomeRoute -> HomeScreenCompact`。`ui/home/HomeScreenMiuix.kt` 是旧实现，不是当前首页；不能再按这个文件重做白泽。
+
+实际设置调用链：`AppearanceSettingsRoute -> SettingsHubRoute -> SettingsHome`，定义在 `ui/settings/SettingsHubScreen.kt`。
+
+本轮参考及适配的源文件：
+- `ui/home/HomeScreenCompact.kt`：状态胶囊、主卡渐变、单一主操作、双列工具卡。
+- `ui/settings/SettingsHubScreen.kt`：状态概览、导航分组、独立详情页；不是整屏展开表单。
+- `ui/theme/LuoShuCompactLayout.kt`：26/34sp 主标题、22/30sp 详情标题，64dp 最小头栏。
+- `ui/theme/LuoShuIconSystem.kt`：48dp 触控槽、44dp 圆形表面、21dp 头栏图标。
+- `ui/theme/LuoShuTheme.kt`：生成色板和页面/卡片层级；保留 Monet、主题色及 AMOLED。
+
+同一所有者项目的组件适配，保留白泽仓库原许可证；未复制任何字体文件、字体引擎、挂载或 Root 操作。
+
+## 白泽接入
+
+`HomeRoute` 在 MIUIX 下调用 `LuoShuHomeScreen`；`SettingsRoute` 在 MIUIX 下调用 `LuoShuSettingsHub`。Material 页面分支保留旧实现。不是增加文件但不接入路由。
+
+共用参考组件位于 `ui/miuix/LuoShuComponents.kt`。首页主卡为 28dp 圆角、22dp 内边距、18dp 内部节奏；工具卡为 24dp 圆角、18dp 内边距及 44dp 图标容器。设置导航行采用 42dp 图标容器、18dp 图标、16/22sp 标题及 12/18sp 说明。
+
+清理执行条件、归类条件、通知及两个数值编辑器移入独立任务设置页。原有保存草稿、轮询状态合并和回调继续由 SettingsRoute 管理；开关不会隐式保存。
+
+## 不得混同的验证
+
+自动编译和交互测试不代表审美验收；Robolectric 图片使用模拟状态，不是用户手机容量或清理数据。须检查实际入口渲染，并回归窄屏大字、深浅色、断线重连、工具回调、设置返回和草稿保存。
+
+本轮不声称完整移植洛书底栏的 RuntimeShader 折射链。白泽现有底栏仍使用 Haze，硬件折射、降级透明度和设置详情页底栏隐藏需单独核验。不得将其标为已完成，也不因 UI 重构修改清理引擎、Root 通信修复、正式版本或发布签名。

--- a/docs/UI-LUOSHU-DOCK.md
+++ b/docs/UI-LUOSHU-DOCK.md
@@ -1,0 +1,33 @@
+# 白泽：洛书同源底栏
+
+参考固定为 `xgl34222220-ops/LuoShu@fe4df5f224dca9bc77517ffa539ba021ed4b1a8e` 的 `LuoShuAppShell.kt`（MiuixAppDock / AppDockLayout）和 `ui/glass/LiquidGlassLens.kt`。
+
+## 接入而非独立样例
+
+`BaiZeMiuixApp` 的 MIUIX 路由实际调用 `LuoShuLiquidDock`。页面背景与当前内容通过 `layerBackdrop` 取样；外壳单独录制给移动透镜使用；图标与标签处于两层取样及着色器之外。Material 保留旧底栏，不跟随替换。
+
+常规字体大小采用 72dp 总高度、60dp 项目高度、20dp 左右外边距、系统导航 inset + 12dp 底部距离、6dp 内边距。外壳 31dp 连续圆角，透镜 23dp 连续圆角；图标 22dp，标签 12/17sp。大字体只增加必要高度，不压扁或裁切标签。
+
+光学参数保留洛书：外壳 9dp blur、17dp refractionHeight、13dp refractionAmount、.045 色散；透镜 3dp blur、13→17dp 高度、14→19dp 折射、.08→.18 色散；最大拉伸 13dp，选中位移弹簧 .68/310，按压缩放 .92，玻璃选中缩放 1.035。修正非对称圆角着色器坐标并对 sqrt 输入作浮点保护。
+
+## 降级和导航
+
+仅在 API 33+、硬件加速、玻璃与模糊开启、且性能策略允许时初始化 runtime backdrop。API 31-32 可走真实 Haze；无硬件加速、低版本、关闭效果或 AMOLED 纯黑时使用不透明表面，不能透出后方文字。关闭取样时不保留每帧运行的折射动画。
+
+设置的自动任务、连接诊断详情通过 `onDetailChanged` 隐藏底栏，返回恢复原选中项；详情不保留悬浮底栏的额外空白。进入/返回使用洛书同参数侧滑。退出设置组件时清理详情可见状态。
+
+## 构建与测试边界
+
+同源组件使用 miuix-blur-android / miuix-squircle-android 0.9.3，需要 compileSdk 37 和 Kotlin 2.4；构建使用 AGP 9.3.2、Gradle 9.5、Kotlin/Compose compiler 2.4.10。minSdk 26、targetSdk 36、签名检查与版本号不改。API 33 blur 的 manifest override 只配合实际能力门控使用。
+
+状态模型从原界面文件原样移动到 DashboardUiModels.kt，JSON 序列化和清理回调不改。Root 服务、清理规则、调度执行代码不改。
+
+自动测试新增：渲染能力策略、四标签导航不执行清理、详情进入/系统返回/标题返回、旧 Android 回退、深色回退，以及改变后方背景后底栏内部像素不变的真实位图断言。Robolectric 截图只证明布局和回退，不等于 K80 至尊版/一加 15 的 GPU 折射真机验证。
+
+## 第三方声明
+
+折射着色器由洛书改写自 compose-miuix-ui/miuix LiquidGlass Lens 示例，其原始来源为 Kyant0/AndroidLiquidGlass；上述上游实现使用 Apache License 2.0。保留源码 SPDX 标识，修改包括包名、合并有无色散分支、非对称圆角坐标修正和浮点保护；不包含字体文件。
+
+来源：https://github.com/compose-miuix-ui/miuix ，https://github.com/Kyant0/AndroidLiquidGlass 。许可证：https://www.apache.org/licenses/LICENSE-2.0 。
+
+此文是实现与验证说明，不表示已合并主分支或发布正式版。

--- a/docs/UI-LUOSHU-HOST-TESTS.md
+++ b/docs/UI-LUOSHU-HOST-TESTS.md
@@ -1,0 +1,16 @@
+# 洛书同源底栏的主机测试环境
+
+miuix blur/squircle 0.9.3 的 AAR 包含 class file version 65（Java 21）字节码。Android APK 由 D8 转换，已能在构建主机 JDK 17 上打包；Robolectric 在主机 JVM 直接加载这些类，必须使用 JDK 21。
+
+本次 UI CI 切换主机到 JDK 21。App 的 Java/Kotlin JVM target 仍为 17，minSdk 26、targetSdk 36 不变。没有通过跳过 Miuix 组件、移除断言或忽略失败来绕过测试。
+
+本地完整 UI 验证需 JDK 21、Gradle 9.5：
+
+```sh
+cd v2
+gradle --no-daemon --continue :app:testDebugUnitTest :app:compileDebugKotlin :app:lintDebug :macrobenchmark:assemble
+```
+
+排查依据：3020c93 的 UI CI 输出 247 tests / 27 failed；27 个失败全部是 UnsupportedClassVersionError，分别来自 SquircleBackgroundKt 和 RuntimeShaderKt。编译、lint、宏基准 APK 组装和另外 220 项测试通过。修正环境后仍需完整重跑，不能把环境修复本身当作测试通过。
+
+Robolectric 的绘制用于布局、回退和导航验证；真实 GPU 折射、厂商系统表现与触控流畅度仍须真机验证。

--- a/v2/app/build.gradle.kts
+++ b/v2/app/build.gradle.kts
@@ -17,7 +17,7 @@ val releaseSigningReady = listOf(
 
 android {
     namespace = "io.github.xgl34222220.baize"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "io.github.xgl34222220.baize"
@@ -43,10 +43,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
     }
 
     testOptions {
@@ -114,8 +110,12 @@ gradle.taskGraph.whenReady {
     }
 }
 
+kotlin {
+    compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
+}
+
 dependencies {
-    val composeBom = platform("androidx.compose:compose-bom:2025.06.01")
+    val composeBom = platform("androidx.compose:compose-bom:2026.03.00")
     implementation(composeBom)
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.7.1")
@@ -138,6 +138,9 @@ dependencies {
     implementation("com.materialkolor:material-kolor:2.0.0")
     implementation("dev.chrisbanes.haze:haze:1.6.10")
     implementation("dev.chrisbanes.haze:haze-materials:1.6.10")
+    // Match LuoShu's actual backdrop/squircle implementation; calls are API/hardware gated.
+    implementation("top.yukonga.miuix.kmp:miuix-blur-android:0.9.3")
+    implementation("top.yukonga.miuix.kmp:miuix-squircle-android:0.9.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("com.github.topjohnwu.libsu:core:6.0.0")
     // libsu 6.0.0 service sources with bounded startup and pending-bind cleanup.

--- a/v2/app/src/main/AndroidManifest.xml
+++ b/v2/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Blur is instantiated only on API 33+ hardware canvases; older devices keep Haze/opaque UI. -->
+    <uses-sdk tools:overrideLibrary="top.yukonga.miuix.kmp.blur" />
+
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS" tools:ignore="ProtectedPermissions" />
     <uses-permission

--- a/v2/app/src/main/assets/licenses/miuix-liquid-glass.txt
+++ b/v2/app/src/main/assets/licenses/miuix-liquid-glass.txt
@@ -1,0 +1,217 @@
+Miuix liquid-glass attribution
+
+The backdrop, squircle and glass lens integration is adapted from LuoShu
+(fe4df5f224dca9bc77517ffa539ba021ed4b1a8e). The lens shader is based on the
+compose-miuix-ui/miuix LiquidGlass Lens example, itself adapted from
+Kyant0/AndroidLiquidGlass. These upstream implementations are Apache-2.0.
+
+Sources:
+https://github.com/compose-miuix-ui/miuix
+https://github.com/Kyant0/AndroidLiquidGlass
+https://github.com/xgl34222220-ops/LuoShu
+
+BaiZe modifications: package names, capability fallback, navigation integration,
+combined dispersion branch, asymmetric-corner coordinate and sqrt guard.
+Original SPDX identifiers are retained in the shader source.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/AppJunkResultComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/AppJunkResultComponents.kt
@@ -6,6 +6,8 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,7 +21,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 @Composable
 internal fun AppJunkCardContent(item: AppJunkUiItem) {
@@ -49,35 +51,26 @@ internal fun AppJunkCardContent(item: AppJunkUiItem) {
             .clickable(enabled = categories.isNotEmpty()) { expanded = !expanded }
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            ApplicationIcon(item.packageName, item.label, Modifier.size(50.dp))
-            Spacer(Modifier.width(14.dp))
+            ApplicationIcon(item.packageName, item.label, Modifier.size(42.dp))
+            Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         item.label,
                         modifier = Modifier.weight(1f),
-                        fontSize = 17.sp,
-                        fontWeight = FontWeight.Bold,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Medium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         Formatter.formatFileSize(context, item.bytes),
                         color = MaterialTheme.colorScheme.primary,
-                        fontWeight = FontWeight.Black,
-                        fontSize = 17.sp
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp
                     )
                 }
-                Text(
-                    item.packageName,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 10.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-                Spacer(Modifier.height(8.dp))
-                CategoryChipRow(categories, item.category)
-                Spacer(Modifier.height(7.dp))
+                Spacer(Modifier.height(5.dp))
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
                         "${item.files} 个文件${if (item.errors > 0) " · ${item.errors} 个未清理" else ""}",
@@ -97,18 +90,21 @@ internal fun AppJunkCardContent(item: AppJunkUiItem) {
             }
         }
 
+        Spacer(Modifier.height(12.dp))
+        CategoryChipRow(categories, item.category)
         AnimatedVisibility(visible = expanded && categories.isNotEmpty()) {
-            Column {
-                HorizontalDivider(
-                    modifier = Modifier.padding(top = 14.dp, bottom = 7.dp),
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = .08f)
-                )
+            Column(Modifier.padding(top = 12.dp).clip(RoundedCornerShape(16.dp))
+                .background(BaiZeTokens.colors.surfaceBase).padding(12.dp)) {
+                Text(item.packageName, fontSize = 11.sp, lineHeight = 17.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis)
                 categories.forEach { CategoryDetailRow(it) }
             }
         }
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun CategoryChipRow(categories: List<AppJunkCategoryUiItem>, fallback: String) {
     val labels = if (categories.isNotEmpty()) {
@@ -116,7 +112,7 @@ private fun CategoryChipRow(categories: List<AppJunkCategoryUiItem>, fallback: S
     } else {
         fallback.split('、', ',', '，').map { friendlyCategory(it) }.filter { it.isNotBlank() }.distinct()
     }
-    Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
         labels.take(3).forEach { CategoryChip(it) }
         if (labels.size > 3) CategoryChip("+${labels.size - 3}")
     }
@@ -127,10 +123,10 @@ private fun CategoryChip(label: String) {
     Box(
         Modifier
             .clip(RoundedCornerShape(10.dp))
-            .background(MaterialTheme.colorScheme.primary.copy(alpha = .09f))
+            .background(BaiZeTokens.colors.surfaceBase)
             .padding(horizontal = 8.dp, vertical = 4.dp)
     ) {
-        Text(label, color = MaterialTheme.colorScheme.primary, fontSize = 9.sp, fontWeight = FontWeight.Bold)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, lineHeight = 16.sp)
     }
 }
 
@@ -143,13 +139,13 @@ private fun CategoryDetailRow(category: AppJunkCategoryUiItem) {
             Text(
                 "${category.files} 个文件${if (category.errors > 0) " · ${category.errors} 个未清理" else ""}",
                 color = if (category.errors > 0) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant,
-                fontSize = 10.sp
+                fontSize = 12.sp
             )
             if (category.samplePath.isNotBlank()) {
                 Text(
                     category.samplePath,
                     color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .72f),
-                    fontSize = 9.sp,
+                    fontSize = 11.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
@@ -159,7 +155,7 @@ private fun CategoryDetailRow(category: AppJunkCategoryUiItem) {
             Formatter.formatFileSize(context, category.bytes),
             color = MaterialTheme.colorScheme.primary,
             fontSize = 13.sp,
-            fontWeight = FontWeight.Bold
+            fontWeight = FontWeight.Medium
         )
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt
@@ -1,118 +1,30 @@
 package io.github.xgl34222220.baize
 
 import android.os.Build
-import android.text.format.Formatter
-import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
-import androidx.compose.animation.togetherWith
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.animation.core.spring
+import androidx.compose.animation.*
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.AutoAwesome
-import androidx.compose.material.icons.rounded.BugReport
-import androidx.compose.material.icons.rounded.CalendarMonth
-import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.CleaningServices
-import androidx.compose.material.icons.rounded.DeleteSweep
-import androidx.compose.material.icons.rounded.Description
-import androidx.compose.material.icons.rounded.ErrorOutline
-import androidx.compose.material.icons.rounded.FolderDelete
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Home
-import androidx.compose.material.icons.rounded.InstallMobile
-import androidx.compose.material.icons.rounded.Notifications
-import androidx.compose.material.icons.rounded.Palette
-import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.Rule
-import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Settings
-import androidx.compose.material.icons.rounded.Shield
-import androidx.compose.material.icons.rounded.Stop
-import androidx.compose.material.icons.rounded.Tune
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.lightColorScheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.android.material.color.MaterialColors
 import dev.chrisbanes.haze.hazeSource
 import dev.chrisbanes.haze.rememberHazeState
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
@@ -124,359 +36,12 @@ import io.github.xgl34222220.baize.ui.history.HistoryRoute
 import io.github.xgl34222220.baize.ui.settings.SettingsRoute
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidDock
 import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidNavItem
-import io.github.xgl34222220.baize.ui.miuix.MiuixLiquidPrimaryButton
-import io.github.xgl34222220.baize.ui.miuix.MiuixOverviewHero
+import io.github.xgl34222220.baize.ui.miuix.LuoShuLiquidDock
 import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
-import org.json.JSONObject
-import kotlin.math.roundToInt
-
-@Immutable
-data class ScanPerformanceUiState(
-    val available: Boolean = false,
-    val workerPolicy: String = "auto",
-    val workerReason: String = "not_measured",
-    val actualWorkers: Int = 1,
-    val recommendedWorkers: Int = 1,
-    val parallelGainPercent: Int = 0,
-    val serialRate: Long = 0,
-    val parallelRate: Long = 0,
-    val successfulRuns: Int = 0,
-    val nextProbeRun: Int = 0,
-    val parallelBlockedUntil: Long = 0
-)
-
-@Immutable
-data class DashboardUiState(
-    val connecting: Boolean = false,
-    val connectionFailed: Boolean = false,
-    val connected: Boolean = false,
-    val ready: Boolean = false,
-    val running: Boolean = false,
-    val serviceText: String = "正在等待 Root 服务…",
-    val versionWarning: String = "",
-    val taskPhase: String = "等待下一次清理",
-    val taskOperation: String = "",
-    val taskProgressCurrent: Long = 0L,
-    val taskProgressTotal: Long = 0L,
-    val taskProgressPath: String = "",
-    val taskProgressBytes: Long = 0L,
-    val taskProgressFiles: Long = 0L,
-    val taskProgressElapsedMs: Long = 0L,
-    val schedulerText: String = "等待调度器状态",
-    val device: String = Build.MODEL,
-    val android: String = "Android ${Build.VERSION.RELEASE}",
-    val storageTotal: Long = 0,
-    val storageUsed: Long = 0,
-    val storageFree: Long = 0,
-    val storagePercent: Float = 0f,
-    val lastReleased: Long = 0,
-    val scanCompleted: Boolean = false,
-    val scanBytes: Long = 0,
-    val scanFiles: Long = 0,
-    val scanEmptyFiles: Long = 0,
-    val scanEmptyDirs: Long = 0,
-    val scanFragments: Long = 0,
-    val scanErrors: Long = 0,
-    val scanElapsed: Long = 0,
-    val lifetimeRuns: Long = 0,
-    val lifetimeReleased: Long = 0,
-    val lifetimeFiles: Long = 0,
-    val lifetimeEmptyFiles: Long = 0,
-    val lifetimeEmptyDirs: Long = 0,
-    val lifetimeFragments: Long = 0,
-    val lifetimeElapsed: Long = 0,
-    val whitelistCount: Int = 0,
-    val recentApps: List<AppJunkUiItem> = emptyList(),
-    val recentJunk: List<GeneralJunkUiItem> = emptyList(),
-    val rawLogName: String = "",
-    val rawLog: String = "",
-    val lastTaskTime: String = "",
-    val protectedItems: List<ProtectedUiItem> = emptyList(),
-    val history: List<HistoryUiItem> = emptyList(),
-    val scanPerformance: ScanPerformanceUiState = ScanPerformanceUiState()
-) {
-    val connectionLabel: String
-        get() = when {
-            running -> "执行中"
-            connectionFailed -> "连接失败"
-            ready -> "已就绪"
-            connecting -> "连接中"
-            connected -> "未就绪"
-            else -> "未连接"
-        }
-}
-
-@Immutable
-data class AppJunkUiItem(
-    val packageName: String,
-    val label: String,
-    val category: String,
-    val files: Long,
-    val bytes: Long,
-    val errors: Long = 0,
-    val categories: List<AppJunkCategoryUiItem> = emptyList()
-)
-
-@Immutable
-data class AppJunkCategoryUiItem(
-    val name: String,
-    val files: Long,
-    val bytes: Long,
-    val errors: Long,
-    val samplePath: String
-)
-
-@Immutable
-data class GeneralJunkUiItem(
-    val name: String,
-    val files: Long,
-    val bytes: Long,
-    val errors: Long,
-    val samplePath: String
-)
-
-@Immutable
-data class ProtectedUiItem(
-    val id: String,
-    val category: String,
-    val path: String,
-    val reason: String,
-    val risk: String,
-    val selectable: Boolean
-)
-
-@Immutable
-data class HistoryUiItem(
-    val title: String,
-    val time: String,
-    val trigger: String,
-    val result: String,
-    val bytes: Long,
-    val files: Int,
-    val emptyDirs: Int,
-    val errors: Int,
-    val cleaned: Boolean,
-    val categories: List<HistoryCategoryUiItem> = emptyList(),
-    val apps: List<HistoryAppUiItem> = emptyList()
-)
-
-@Immutable
-data class HistoryCategoryUiItem(
-    val name: String,
-    val bytes: Long,
-    val files: Long
-)
-
-@Immutable
-data class HistoryAppUiItem(
-    val packageName: String,
-    val label: String,
-    val category: String,
-    val bytes: Long,
-    val files: Long
-)
-
-@Immutable
-data class SchedulerUiState(
-    val enabled: Boolean = true,
-    val cacheEnabled: Boolean = true,
-    val cacheMinutes: Int = 1_440,
-    val emptyEnabled: Boolean = true,
-    val emptyMinutes: Int = 1_440,
-    val rulesEnabled: Boolean = true,
-    val rulesMinutes: Int = 1_440,
-    val fragmentEnabled: Boolean = true,
-    val fragmentMinutes: Int = 4_320,
-    val deepEnabled: Boolean = false,
-    val deepMinutes: Int = 10_080,
-    val organizeEnabled: Boolean = false,
-    val organizeMinutes: Int = 1_440,
-    val organizeScreenOffOnly: Boolean = false,
-    val organizeChargingOnly: Boolean = false,
-    val organizeIdleOnly: Boolean = false,
-    val organizeRunImmediately: Boolean = false,
-    val organizerConflictPolicy: Int = 1,
-    val organizerUndoRetention: Int = 10,
-    val scheduleMode: Int = 0,
-    val dailyEnabled: Boolean = false,
-    val dailyHour: Int = 3,
-    val dailyMinute: Int = 30,
-    val dailyGraceMinutes: Int = 240,
-    val screenOffOnly: Boolean = true,
-    val chargingOnly: Boolean = false,
-    val idleOnly: Boolean = false,
-    val minBattery: Int = 25,
-    val notifyOnComplete: Boolean = true,
-    val notifyZero: Boolean = false,
-    val maxFileMb: Int = 256,
-    val apkPackagesEnabled: Boolean = true,
-    val apkPackageDays: Int = 30,
-    val apkMinutes: Int = 1_440,
-    val scanRootWorkers: Int = 0,
-    val runtimeState: String = "waiting",
-    val runtimeReason: String = "等待调度器首次轮询",
-    val queueCount: Int = 0,
-    val queueGroups: String = "",
-    val nextTask: String = "",
-    val blockedGroups: String = "",
-    val nextCheckEpoch: Long = 0L,
-    val runtimeGroup: String = "",
-    val cacheNextEpoch: Long = 0L,
-    val apkNextEpoch: Long = 0L,
-    val emptyNextEpoch: Long = 0L,
-    val rulesNextEpoch: Long = 0L,
-    val fragmentNextEpoch: Long = 0L,
-    val deepNextEpoch: Long = 0L,
-    val organizeNextEpoch: Long = 0L,
-    val supervisorStatus: String = "unknown",
-    val supervisorHeartbeatAge: Long = -1L,
-    val runtimeStale: Boolean = false,
-    val saving: Boolean = false
-) {
-    fun toJson(): JSONObject = JSONObject()
-        .put("enabled", enabled.flag())
-        .put("schedule_cache_enabled", cacheEnabled.flag())
-        .put("schedule_cache_minutes", cacheMinutes.coerceIn(5, 43_200))
-        .put("schedule_cache_hours", ((cacheMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_empty_enabled", emptyEnabled.flag())
-        .put("schedule_empty_minutes", emptyMinutes.coerceIn(5, 43_200))
-        .put("schedule_empty_hours", ((emptyMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_rules_enabled", rulesEnabled.flag())
-        .put("schedule_rules_minutes", rulesMinutes.coerceIn(5, 43_200))
-        .put("schedule_rules_hours", ((rulesMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_fragment_enabled", fragmentEnabled.flag())
-        .put("schedule_fragment_minutes", fragmentMinutes.coerceIn(5, 43_200))
-        .put("schedule_fragment_hours", ((fragmentMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_deep_enabled", deepEnabled.flag())
-        .put("schedule_deep_minutes", deepMinutes.coerceIn(5, 43_200))
-        .put("schedule_deep_hours", ((deepMinutes + 59) / 60).coerceIn(1, 720))
-        .put("schedule_organize_enabled", organizeEnabled.flag())
-        .put("schedule_organize_minutes", organizeMinutes.coerceIn(15, 43_200))
-        .put("schedule_organize_hours", ((organizeMinutes + 59) / 60).coerceIn(1, 720))
-        .put("organize_screen_off_only", organizeScreenOffOnly.flag())
-        .put("organize_charging_only", organizeChargingOnly.flag())
-        .put("organize_device_idle_only", organizeIdleOnly.flag())
-        .put("organize_run_immediately", organizeRunImmediately.flag())
-        .put("organizer_conflict_policy", organizerConflictPolicy.coerceIn(0, 2))
-        .put("organizer_undo_retention", organizerUndoRetention.coerceIn(1, 20))
-        .put("schedule_mode", scheduleMode.coerceIn(0, 2))
-        .put("autopilot_enabled", if (scheduleMode == 0) 1 else 0)
-        .put("daily_schedule_enabled", (scheduleMode == 2).flag())
-        .put("daily_schedule_hour", dailyHour.coerceIn(0, 23))
-        .put("daily_schedule_minute", dailyMinute.coerceIn(0, 59))
-        .put("daily_grace_minutes", dailyGraceMinutes.coerceIn(15, 720))
-        .put("screen_off_only", screenOffOnly.flag())
-        .put("charging_only", chargingOnly.flag())
-        .put("device_idle_only", idleOnly.flag())
-        .put("min_battery", minBattery.coerceIn(0, 100))
-        .put("notify_on_complete", notifyOnComplete.flag())
-        .put("notify_zero_result", notifyZero.flag())
-        .put("max_file_mb", maxFileMb.coerceIn(16, 2048))
-        .put("clean_apk_packages", apkPackagesEnabled.flag())
-        .put("apk_package_days", apkPackageDays.coerceIn(0, 365))
-        .put("schedule_apk_minutes", apkMinutes.coerceIn(5, 43_200))
-        .put("schedule_apk_hours", ((apkMinutes + 59) / 60).coerceIn(1, 720))
-        .put("scan_root_workers", 0)
-
-    companion object {
-        fun fromJson(json: JSONObject): SchedulerUiState {
-            val runtime = json.optJSONObject("runtime") ?: JSONObject()
-            val nextRuns = runtime.optJSONObject("nextRuns") ?: JSONObject()
-            val legacyDailyEnabled = json.optInt("daily_schedule_enabled", 0) == 1
-            val scheduleMode = when {
-                json.has("schedule_mode") -> json.optInt("schedule_mode", 0).coerceIn(0, 2)
-                legacyDailyEnabled -> 2
-                json.optInt("autopilot_enabled", 1) == 0 -> 1
-                else -> 0
-            }
-            return SchedulerUiState(
-                enabled = json.optInt("enabled", 1) == 1,
-                cacheEnabled = json.optInt("schedule_cache_enabled", 1) == 1,
-                cacheMinutes = json.optInt("schedule_cache_minutes", json.optInt("schedule_cache_hours", 24) * 60).coerceIn(5, 43_200),
-                emptyEnabled = json.optInt("schedule_empty_enabled", 1) == 1,
-                emptyMinutes = json.optInt("schedule_empty_minutes", json.optInt("schedule_empty_hours", 24) * 60).coerceIn(5, 43_200),
-                rulesEnabled = json.optInt("schedule_rules_enabled", 1) == 1,
-                rulesMinutes = json.optInt("schedule_rules_minutes", json.optInt("schedule_rules_hours", 24) * 60).coerceIn(5, 43_200),
-                fragmentEnabled = json.optInt("schedule_fragment_enabled", 1) == 1,
-                fragmentMinutes = json.optInt("schedule_fragment_minutes", json.optInt("schedule_fragment_hours", 72) * 60).coerceIn(5, 43_200),
-                deepEnabled = json.optInt("schedule_deep_enabled", 0) == 1,
-                deepMinutes = json.optInt("schedule_deep_minutes", json.optInt("schedule_deep_hours", 168) * 60).coerceIn(5, 43_200),
-                organizeEnabled = json.optInt("schedule_organize_enabled", 0) == 1,
-                organizeMinutes = json.optInt("schedule_organize_minutes", json.optInt("schedule_organize_hours", 24) * 60).coerceIn(15, 43_200),
-                organizeScreenOffOnly = json.optInt("organize_screen_off_only", 0) == 1,
-                organizeChargingOnly = json.optInt("organize_charging_only", 0) == 1,
-                organizeIdleOnly = json.optInt("organize_device_idle_only", 0) == 1,
-                organizeRunImmediately = json.optInt("organize_run_immediately", 0) == 1,
-                organizerConflictPolicy = json.optInt("organizer_conflict_policy", 1).coerceIn(0, 2),
-                organizerUndoRetention = json.optInt("organizer_undo_retention", 10).coerceIn(1, 20),
-                scheduleMode = scheduleMode,
-                dailyEnabled = scheduleMode == 2,
-                dailyHour = json.optInt("daily_schedule_hour", 3).coerceIn(0, 23),
-                dailyMinute = json.optInt("daily_schedule_minute", 30).coerceIn(0, 59),
-                dailyGraceMinutes = json.optInt("daily_grace_minutes", 240).coerceIn(15, 720),
-                screenOffOnly = json.optInt("screen_off_only", 1) == 1,
-                chargingOnly = json.optInt("charging_only", 0) == 1,
-                idleOnly = json.optInt("device_idle_only", 0) == 1,
-                minBattery = json.optInt("min_battery", 25).coerceIn(0, 100),
-                notifyOnComplete = json.optInt("notify_on_complete", 1) == 1,
-                notifyZero = json.optInt("notify_zero_result", 0) == 1,
-                maxFileMb = json.optInt("max_file_mb", 256).coerceIn(16, 2048),
-                apkPackagesEnabled = json.optInt("clean_apk_packages", 1) == 1,
-                apkPackageDays = json.optInt("apk_package_days", 30).coerceIn(0, 365),
-                apkMinutes = json.optInt("schedule_apk_minutes", json.optInt("schedule_rules_minutes", 1_440)).coerceIn(5, 43_200),
-                runtimeState = runtime.optString("state", "waiting"),
-                runtimeReason = runtime.optString("reason", "等待调度器首次轮询"),
-                queueCount = runtime.optInt("queueCount", 0).coerceAtLeast(0),
-                queueGroups = runtime.optString("queueGroups"),
-                nextTask = runtime.optString("nextTask"),
-                blockedGroups = runtime.optString("blockedGroups"),
-                nextCheckEpoch = runtime.optLong("nextCheckEpoch", 0L).coerceAtLeast(0L),
-                runtimeGroup = runtime.optString("group"),
-                cacheNextEpoch = nextRuns.optLong("cache", 0L).coerceAtLeast(0L),
-                apkNextEpoch = nextRuns.optLong("apk", 0L).coerceAtLeast(0L),
-                emptyNextEpoch = nextRuns.optLong("empty", 0L).coerceAtLeast(0L),
-                rulesNextEpoch = nextRuns.optLong("rules", 0L).coerceAtLeast(0L),
-                fragmentNextEpoch = nextRuns.optLong("fragment", 0L).coerceAtLeast(0L),
-                deepNextEpoch = nextRuns.optLong("deep", 0L).coerceAtLeast(0L),
-                organizeNextEpoch = nextRuns.optLong("organize", 0L).coerceAtLeast(0L),
-                supervisorStatus = runtime.optString("supervisorStatus", "unknown"),
-                supervisorHeartbeatAge = runtime.optLong("supervisorHeartbeatAge", -1L),
-                runtimeStale = runtime.optBoolean("stale", false),
-                scanRootWorkers = 0
-            )
-        }
-    }
-}
-
-private fun Boolean.flag() = if (this) 1 else 0
-
-data class DashboardActions(
-    val refresh: () -> Unit,
-    val clean: () -> Unit,
-    val organize: () -> Unit,
-    val scan: () -> Unit,
-    val apkScan: () -> Unit,
-    val cleanScan: () -> Unit,
-    val dismissScan: () -> Unit,
-    val stop: () -> Unit,
-    val deep: () -> Unit,
-    val corpses: () -> Unit,
-    val audit: () -> Unit,
-    val updateScheduler: (SchedulerUiState) -> Unit,
-    val saveScheduler: (SchedulerUiState) -> Unit,
-    val schedulerCommand: (String) -> Unit,
-    val clearHistory: () -> Unit,
-    val clearRawLog: () -> Unit,
-    val reviewProtected: () -> Unit,
-    val whitelist: () -> Unit,
-    /** 打开断点续清工作台：消费已持久化的扫描快照，支持中断后继续。 */
-    val resumableScan: () -> Unit,
-    val theme: () -> Unit,
-    val reconnect: () -> Unit,
-    val resetScanPerformance: () -> Unit,
-    val crash: () -> Unit
-)
+import top.yukonga.miuix.kmp.blur.isRuntimeShaderSupported
+import top.yukonga.miuix.kmp.blur.layerBackdrop
+import top.yukonga.miuix.kmp.blur.rememberLayerBackdrop
 
 private enum class BaiZePage(val title: String, val icon: ImageVector) {
     Home("首页", Icons.Rounded.Home),
@@ -502,8 +67,13 @@ fun BaiZeMiuixApp(
                 appearance.blurEnabled && appearance.glassEnabled &&
                 !amoled && !(appearance.adaptiveSmoothMode && runtimeDegraded)
             val hazeState = rememberHazeState(blurEnabled = blurActive)
+            val hardware = LocalView.current.isHardwareAccelerated
+            val liquidSupported = blurActive && hardware && Build.VERSION.SDK_INT >= 33 && isRuntimeShaderSupported()
+            val liquidBackdrop = if (liquidSupported) rememberLayerBackdrop() else null
+            var settingsDetailVisible by remember { mutableStateOf(false) }
             var page by rememberSaveable { mutableStateOf(BaiZePage.entries[initialPage.coerceIn(0, BaiZePage.entries.lastIndex)]) }
             var expandedCleanCategory by rememberSaveable { mutableStateOf("") }
+            val showDock = page != BaiZePage.Settings || !settingsDetailVisible
             val miuixNavItems = remember {
                 BaiZePage.entries.map { MiuixLiquidNavItem(it.title, it.icon) }
             }
@@ -563,7 +133,8 @@ fun BaiZeMiuixApp(
                             Box(
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .then(if (blurActive) Modifier.hazeSource(state = hazeState) else Modifier)
+                                    .then(if (liquidBackdrop != null && showDock) Modifier.layerBackdrop(liquidBackdrop)
+                                        else if (blurActive && showDock) Modifier.hazeSource(state = hazeState) else Modifier)
                             ) {
                                 MiuiXBackdrop(dark, amoled)
                                 AnimatedPageHost(
@@ -588,16 +159,18 @@ fun BaiZeMiuixApp(
                                             onExpandedCategoryChanged = { expandedCleanCategory = it }
                                         )
                                         BaiZePage.Records -> HistoryRoute(UiStyle.MIUIX, state.forHistoryPage(), actions)
-                                        BaiZePage.Settings -> SettingsRoute(UiStyle.MIUIX, state.forSettingsPage(), scheduler, appearance, actions) { page = BaiZePage.Records }
+                                        BaiZePage.Settings -> SettingsRoute(UiStyle.MIUIX, state.forSettingsPage(), scheduler, appearance, actions,
+                                            onDetailChanged = { settingsDetailVisible = it }) { page = BaiZePage.Records }
                                     }
                                 }
                             }
-                            MiuixLiquidDock(
+                            if (showDock) LuoShuLiquidDock(
                                 selectedIndex = page.ordinal,
                                 items = miuixNavItems,
                                 onSelected = { index -> page = BaiZePage.entries[index] },
                                 hazeState = hazeState,
-                                floating = appearance.floatingDock,
+                                backdrop = liquidBackdrop,
+                                effectsEnabled = blurActive,
                                 modifier = Modifier.align(Alignment.BottomCenter)
                             )
                         }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/CleanupSummaryComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/CleanupSummaryComponents.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 @Composable
 internal fun CurrentCleanupSummaryContent(apps: List<AppJunkUiItem>, junk: List<GeneralJunkUiItem>) {
@@ -41,35 +42,26 @@ internal fun CurrentCleanupSummaryContent(apps: List<AppJunkUiItem>, junk: List<
 
     Column(Modifier.fillMaxWidth()) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(
-                Modifier.size(44.dp).clip(RoundedCornerShape(14.dp))
-                    .background(MaterialTheme.colorScheme.primary.copy(alpha = .10f)),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(Icons.Rounded.AutoAwesome, null, tint = MaterialTheme.colorScheme.primary, modifier = Modifier.size(23.dp))
-            }
-            Column(Modifier.padding(start = 13.dp).weight(1f)) {
-                Text("本次结果", fontSize = 20.sp, fontWeight = FontWeight.Black)
-                Text("全部按实际扫描或删除结果统计", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
-            }
-            Text(
-                Formatter.formatFileSize(context, totalBytes),
-                color = MaterialTheme.colorScheme.primary,
-                fontSize = 21.sp,
-                fontWeight = FontWeight.Black
-            )
+            Icon(Icons.Rounded.AutoAwesome, null, tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(18.dp))
+            Text("本次结果", Modifier.padding(start = 7.dp), fontSize = 13.sp,
+                lineHeight = 19.sp, fontWeight = FontWeight.Medium)
         }
-
+        Text(Formatter.formatFileSize(context, totalBytes), Modifier.padding(top = 12.dp),
+            style = BaiZeTokens.type.hero, color = MaterialTheme.colorScheme.onSurface)
+        Text("按实际扫描或删除结果统计", Modifier.padding(top = 3.dp),
+            color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 18.sp)
         Spacer(Modifier.height(18.dp))
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            SummaryStat("${apps.size + junk.size}", "分类来源")
-            SummaryStat("$totalFiles", "文件项目")
-            SummaryStat("$totalErrors", "未处理")
+        Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))
+            .background(BaiZeTokens.colors.surfaceBase).padding(vertical = 13.dp)) {
+            SummaryStat("${apps.size + junk.size}", "分类来源", Modifier.weight(1f))
+            SummaryStat("$totalFiles", "文件项目", Modifier.weight(1f))
+            SummaryStat("$totalErrors", "未处理", Modifier.weight(1f))
         }
 
         if (largestApp != null || largestJunk != null) {
             Spacer(Modifier.height(16.dp))
-            Text("最大来源", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+            Text("最大来源", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp)
             Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 if (appWins && largestApp != null) {
                     ApplicationIcon(largestApp.packageName, largestApp.label, Modifier.size(30.dp))
@@ -77,11 +69,11 @@ internal fun CurrentCleanupSummaryContent(apps: List<AppJunkUiItem>, junk: List<
                         largestApp.label,
                         modifier = Modifier.padding(start = 9.dp).weight(1f),
                         fontSize = 13.sp,
-                        fontWeight = FontWeight.Bold,
+                        fontWeight = FontWeight.Medium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
-                    Text(Formatter.formatFileSize(context, largestApp.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                    Text(Formatter.formatFileSize(context, largestApp.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Medium)
                 } else if (largestJunk != null) {
                     Icon(
                         if (largestJunk.name.contains("APK", true) || largestJunk.name.contains("安装包")) Icons.Rounded.InstallMobile else Icons.Rounded.DeleteSweep,
@@ -93,11 +85,11 @@ internal fun CurrentCleanupSummaryContent(apps: List<AppJunkUiItem>, junk: List<
                         friendlyGeneralName(largestJunk.name),
                         modifier = Modifier.padding(start = 9.dp).weight(1f),
                         fontSize = 13.sp,
-                        fontWeight = FontWeight.Bold,
+                        fontWeight = FontWeight.Medium,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis
                     )
-                    Text(Formatter.formatFileSize(context, largestJunk.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                    Text(Formatter.formatFileSize(context, largestJunk.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 12.sp, fontWeight = FontWeight.Medium)
                 }
             }
         }
@@ -109,7 +101,7 @@ internal fun GeneralJunkCardContent(item: GeneralJunkUiItem) {
     val context = LocalContext.current
     Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         Box(
-            Modifier.size(48.dp).clip(RoundedCornerShape(15.dp))
+            Modifier.size(42.dp).clip(RoundedCornerShape(14.dp))
                 .background(MaterialTheme.colorScheme.primary.copy(alpha = .09f)),
             contentAlignment = Alignment.Center
         ) {
@@ -117,13 +109,13 @@ internal fun GeneralJunkCardContent(item: GeneralJunkUiItem) {
                 if (item.name.contains("APK", true) || item.name.contains("安装包")) Icons.Rounded.InstallMobile else Icons.Rounded.DeleteSweep,
                 null,
                 tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(25.dp)
+                modifier = Modifier.size(23.dp)
             )
         }
-        Column(Modifier.padding(start = 14.dp).weight(1f)) {
+        Column(Modifier.padding(start = 12.dp).weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(friendlyGeneralName(item.name), modifier = Modifier.weight(1f), fontSize = 17.sp, fontWeight = FontWeight.Bold)
-                Text(Formatter.formatFileSize(context, item.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 17.sp, fontWeight = FontWeight.Black)
+                Text(friendlyGeneralName(item.name), modifier = Modifier.weight(1f), fontSize = 15.sp, lineHeight = 21.sp, fontWeight = FontWeight.Medium, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Text(Formatter.formatFileSize(context, item.bytes), color = MaterialTheme.colorScheme.primary, fontSize = 15.sp, fontWeight = FontWeight.SemiBold)
             }
             Text(
                 "${item.files} 个文件${if (item.errors > 0) " · ${item.errors} 个未处理" else ""}",
@@ -131,17 +123,17 @@ internal fun GeneralJunkCardContent(item: GeneralJunkUiItem) {
                 fontSize = 11.sp
             )
             if (item.samplePath.isNotBlank()) {
-                Text(item.samplePath, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .72f), fontSize = 9.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(item.samplePath, color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .72f), fontSize = 11.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
         }
     }
 }
 
 @Composable
-private fun SummaryStat(value: String, label: String) {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Text(value, color = MaterialTheme.colorScheme.primary, fontSize = 18.sp, fontWeight = FontWeight.Black)
-        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 10.sp)
+private fun SummaryStat(value: String, label: String, modifier: Modifier = Modifier) {
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(value, color = MaterialTheme.colorScheme.onSurface, fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.Medium)
+        Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 11.sp, lineHeight = 16.sp)
     }
 }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/DashboardUiModels.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/DashboardUiModels.kt
@@ -1,0 +1,353 @@
+package io.github.xgl34222220.baize
+
+import android.os.Build
+import androidx.compose.runtime.Immutable
+import org.json.JSONObject
+
+@Immutable
+data class ScanPerformanceUiState(
+    val available: Boolean = false,
+    val workerPolicy: String = "auto",
+    val workerReason: String = "not_measured",
+    val actualWorkers: Int = 1,
+    val recommendedWorkers: Int = 1,
+    val parallelGainPercent: Int = 0,
+    val serialRate: Long = 0,
+    val parallelRate: Long = 0,
+    val successfulRuns: Int = 0,
+    val nextProbeRun: Int = 0,
+    val parallelBlockedUntil: Long = 0
+)
+
+@Immutable
+data class DashboardUiState(
+    val connecting: Boolean = false,
+    val connectionFailed: Boolean = false,
+    val connected: Boolean = false,
+    val ready: Boolean = false,
+    val running: Boolean = false,
+    val serviceText: String = "正在等待 Root 服务…",
+    val versionWarning: String = "",
+    val taskPhase: String = "等待下一次清理",
+    val taskOperation: String = "",
+    val taskProgressCurrent: Long = 0L,
+    val taskProgressTotal: Long = 0L,
+    val taskProgressPath: String = "",
+    val taskProgressBytes: Long = 0L,
+    val taskProgressFiles: Long = 0L,
+    val taskProgressElapsedMs: Long = 0L,
+    val schedulerText: String = "等待调度器状态",
+    val device: String = Build.MODEL,
+    val android: String = "Android ${Build.VERSION.RELEASE}",
+    val storageTotal: Long = 0,
+    val storageUsed: Long = 0,
+    val storageFree: Long = 0,
+    val storagePercent: Float = 0f,
+    val lastReleased: Long = 0,
+    val scanCompleted: Boolean = false,
+    val scanBytes: Long = 0,
+    val scanFiles: Long = 0,
+    val scanEmptyFiles: Long = 0,
+    val scanEmptyDirs: Long = 0,
+    val scanFragments: Long = 0,
+    val scanErrors: Long = 0,
+    val scanElapsed: Long = 0,
+    val lifetimeRuns: Long = 0,
+    val lifetimeReleased: Long = 0,
+    val lifetimeFiles: Long = 0,
+    val lifetimeEmptyFiles: Long = 0,
+    val lifetimeEmptyDirs: Long = 0,
+    val lifetimeFragments: Long = 0,
+    val lifetimeElapsed: Long = 0,
+    val whitelistCount: Int = 0,
+    val recentApps: List<AppJunkUiItem> = emptyList(),
+    val recentJunk: List<GeneralJunkUiItem> = emptyList(),
+    val rawLogName: String = "",
+    val rawLog: String = "",
+    val lastTaskTime: String = "",
+    val protectedItems: List<ProtectedUiItem> = emptyList(),
+    val history: List<HistoryUiItem> = emptyList(),
+    val scanPerformance: ScanPerformanceUiState = ScanPerformanceUiState()
+) {
+    val connectionLabel: String
+        get() = when {
+            running -> "执行中"
+            connectionFailed -> "连接失败"
+            ready -> "已就绪"
+            connecting -> "连接中"
+            connected -> "未就绪"
+            else -> "未连接"
+        }
+}
+
+@Immutable
+data class AppJunkUiItem(
+    val packageName: String,
+    val label: String,
+    val category: String,
+    val files: Long,
+    val bytes: Long,
+    val errors: Long = 0,
+    val categories: List<AppJunkCategoryUiItem> = emptyList()
+)
+
+@Immutable
+data class AppJunkCategoryUiItem(
+    val name: String,
+    val files: Long,
+    val bytes: Long,
+    val errors: Long,
+    val samplePath: String
+)
+
+@Immutable
+data class GeneralJunkUiItem(
+    val name: String,
+    val files: Long,
+    val bytes: Long,
+    val errors: Long,
+    val samplePath: String
+)
+
+@Immutable
+data class ProtectedUiItem(
+    val id: String,
+    val category: String,
+    val path: String,
+    val reason: String,
+    val risk: String,
+    val selectable: Boolean
+)
+
+@Immutable
+data class HistoryUiItem(
+    val title: String,
+    val time: String,
+    val trigger: String,
+    val result: String,
+    val bytes: Long,
+    val files: Int,
+    val emptyDirs: Int,
+    val errors: Int,
+    val cleaned: Boolean,
+    val categories: List<HistoryCategoryUiItem> = emptyList(),
+    val apps: List<HistoryAppUiItem> = emptyList()
+)
+
+@Immutable
+data class HistoryCategoryUiItem(
+    val name: String,
+    val bytes: Long,
+    val files: Long
+)
+
+@Immutable
+data class HistoryAppUiItem(
+    val packageName: String,
+    val label: String,
+    val category: String,
+    val bytes: Long,
+    val files: Long
+)
+
+@Immutable
+data class SchedulerUiState(
+    val enabled: Boolean = true,
+    val cacheEnabled: Boolean = true,
+    val cacheMinutes: Int = 1_440,
+    val emptyEnabled: Boolean = true,
+    val emptyMinutes: Int = 1_440,
+    val rulesEnabled: Boolean = true,
+    val rulesMinutes: Int = 1_440,
+    val fragmentEnabled: Boolean = true,
+    val fragmentMinutes: Int = 4_320,
+    val deepEnabled: Boolean = false,
+    val deepMinutes: Int = 10_080,
+    val organizeEnabled: Boolean = false,
+    val organizeMinutes: Int = 1_440,
+    val organizeScreenOffOnly: Boolean = false,
+    val organizeChargingOnly: Boolean = false,
+    val organizeIdleOnly: Boolean = false,
+    val organizeRunImmediately: Boolean = false,
+    val organizerConflictPolicy: Int = 1,
+    val organizerUndoRetention: Int = 10,
+    val scheduleMode: Int = 0,
+    val dailyEnabled: Boolean = false,
+    val dailyHour: Int = 3,
+    val dailyMinute: Int = 30,
+    val dailyGraceMinutes: Int = 240,
+    val screenOffOnly: Boolean = true,
+    val chargingOnly: Boolean = false,
+    val idleOnly: Boolean = false,
+    val minBattery: Int = 25,
+    val notifyOnComplete: Boolean = true,
+    val notifyZero: Boolean = false,
+    val maxFileMb: Int = 256,
+    val apkPackagesEnabled: Boolean = true,
+    val apkPackageDays: Int = 30,
+    val apkMinutes: Int = 1_440,
+    val scanRootWorkers: Int = 0,
+    val runtimeState: String = "waiting",
+    val runtimeReason: String = "等待调度器首次轮询",
+    val queueCount: Int = 0,
+    val queueGroups: String = "",
+    val nextTask: String = "",
+    val blockedGroups: String = "",
+    val nextCheckEpoch: Long = 0L,
+    val runtimeGroup: String = "",
+    val cacheNextEpoch: Long = 0L,
+    val apkNextEpoch: Long = 0L,
+    val emptyNextEpoch: Long = 0L,
+    val rulesNextEpoch: Long = 0L,
+    val fragmentNextEpoch: Long = 0L,
+    val deepNextEpoch: Long = 0L,
+    val organizeNextEpoch: Long = 0L,
+    val supervisorStatus: String = "unknown",
+    val supervisorHeartbeatAge: Long = -1L,
+    val runtimeStale: Boolean = false,
+    val saving: Boolean = false
+) {
+    fun toJson(): JSONObject = JSONObject()
+        .put("enabled", enabled.flag())
+        .put("schedule_cache_enabled", cacheEnabled.flag())
+        .put("schedule_cache_minutes", cacheMinutes.coerceIn(5, 43_200))
+        .put("schedule_cache_hours", ((cacheMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_empty_enabled", emptyEnabled.flag())
+        .put("schedule_empty_minutes", emptyMinutes.coerceIn(5, 43_200))
+        .put("schedule_empty_hours", ((emptyMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_rules_enabled", rulesEnabled.flag())
+        .put("schedule_rules_minutes", rulesMinutes.coerceIn(5, 43_200))
+        .put("schedule_rules_hours", ((rulesMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_fragment_enabled", fragmentEnabled.flag())
+        .put("schedule_fragment_minutes", fragmentMinutes.coerceIn(5, 43_200))
+        .put("schedule_fragment_hours", ((fragmentMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_deep_enabled", deepEnabled.flag())
+        .put("schedule_deep_minutes", deepMinutes.coerceIn(5, 43_200))
+        .put("schedule_deep_hours", ((deepMinutes + 59) / 60).coerceIn(1, 720))
+        .put("schedule_organize_enabled", organizeEnabled.flag())
+        .put("schedule_organize_minutes", organizeMinutes.coerceIn(15, 43_200))
+        .put("schedule_organize_hours", ((organizeMinutes + 59) / 60).coerceIn(1, 720))
+        .put("organize_screen_off_only", organizeScreenOffOnly.flag())
+        .put("organize_charging_only", organizeChargingOnly.flag())
+        .put("organize_device_idle_only", organizeIdleOnly.flag())
+        .put("organize_run_immediately", organizeRunImmediately.flag())
+        .put("organizer_conflict_policy", organizerConflictPolicy.coerceIn(0, 2))
+        .put("organizer_undo_retention", organizerUndoRetention.coerceIn(1, 20))
+        .put("schedule_mode", scheduleMode.coerceIn(0, 2))
+        .put("autopilot_enabled", if (scheduleMode == 0) 1 else 0)
+        .put("daily_schedule_enabled", (scheduleMode == 2).flag())
+        .put("daily_schedule_hour", dailyHour.coerceIn(0, 23))
+        .put("daily_schedule_minute", dailyMinute.coerceIn(0, 59))
+        .put("daily_grace_minutes", dailyGraceMinutes.coerceIn(15, 720))
+        .put("screen_off_only", screenOffOnly.flag())
+        .put("charging_only", chargingOnly.flag())
+        .put("device_idle_only", idleOnly.flag())
+        .put("min_battery", minBattery.coerceIn(0, 100))
+        .put("notify_on_complete", notifyOnComplete.flag())
+        .put("notify_zero_result", notifyZero.flag())
+        .put("max_file_mb", maxFileMb.coerceIn(16, 2048))
+        .put("clean_apk_packages", apkPackagesEnabled.flag())
+        .put("apk_package_days", apkPackageDays.coerceIn(0, 365))
+        .put("schedule_apk_minutes", apkMinutes.coerceIn(5, 43_200))
+        .put("schedule_apk_hours", ((apkMinutes + 59) / 60).coerceIn(1, 720))
+        .put("scan_root_workers", 0)
+
+    companion object {
+        fun fromJson(json: JSONObject): SchedulerUiState {
+            val runtime = json.optJSONObject("runtime") ?: JSONObject()
+            val nextRuns = runtime.optJSONObject("nextRuns") ?: JSONObject()
+            val legacyDailyEnabled = json.optInt("daily_schedule_enabled", 0) == 1
+            val scheduleMode = when {
+                json.has("schedule_mode") -> json.optInt("schedule_mode", 0).coerceIn(0, 2)
+                legacyDailyEnabled -> 2
+                json.optInt("autopilot_enabled", 1) == 0 -> 1
+                else -> 0
+            }
+            return SchedulerUiState(
+                enabled = json.optInt("enabled", 1) == 1,
+                cacheEnabled = json.optInt("schedule_cache_enabled", 1) == 1,
+                cacheMinutes = json.optInt("schedule_cache_minutes", json.optInt("schedule_cache_hours", 24) * 60).coerceIn(5, 43_200),
+                emptyEnabled = json.optInt("schedule_empty_enabled", 1) == 1,
+                emptyMinutes = json.optInt("schedule_empty_minutes", json.optInt("schedule_empty_hours", 24) * 60).coerceIn(5, 43_200),
+                rulesEnabled = json.optInt("schedule_rules_enabled", 1) == 1,
+                rulesMinutes = json.optInt("schedule_rules_minutes", json.optInt("schedule_rules_hours", 24) * 60).coerceIn(5, 43_200),
+                fragmentEnabled = json.optInt("schedule_fragment_enabled", 1) == 1,
+                fragmentMinutes = json.optInt("schedule_fragment_minutes", json.optInt("schedule_fragment_hours", 72) * 60).coerceIn(5, 43_200),
+                deepEnabled = json.optInt("schedule_deep_enabled", 0) == 1,
+                deepMinutes = json.optInt("schedule_deep_minutes", json.optInt("schedule_deep_hours", 168) * 60).coerceIn(5, 43_200),
+                organizeEnabled = json.optInt("schedule_organize_enabled", 0) == 1,
+                organizeMinutes = json.optInt("schedule_organize_minutes", json.optInt("schedule_organize_hours", 24) * 60).coerceIn(15, 43_200),
+                organizeScreenOffOnly = json.optInt("organize_screen_off_only", 0) == 1,
+                organizeChargingOnly = json.optInt("organize_charging_only", 0) == 1,
+                organizeIdleOnly = json.optInt("organize_device_idle_only", 0) == 1,
+                organizeRunImmediately = json.optInt("organize_run_immediately", 0) == 1,
+                organizerConflictPolicy = json.optInt("organizer_conflict_policy", 1).coerceIn(0, 2),
+                organizerUndoRetention = json.optInt("organizer_undo_retention", 10).coerceIn(1, 20),
+                scheduleMode = scheduleMode,
+                dailyEnabled = scheduleMode == 2,
+                dailyHour = json.optInt("daily_schedule_hour", 3).coerceIn(0, 23),
+                dailyMinute = json.optInt("daily_schedule_minute", 30).coerceIn(0, 59),
+                dailyGraceMinutes = json.optInt("daily_grace_minutes", 240).coerceIn(15, 720),
+                screenOffOnly = json.optInt("screen_off_only", 1) == 1,
+                chargingOnly = json.optInt("charging_only", 0) == 1,
+                idleOnly = json.optInt("device_idle_only", 0) == 1,
+                minBattery = json.optInt("min_battery", 25).coerceIn(0, 100),
+                notifyOnComplete = json.optInt("notify_on_complete", 1) == 1,
+                notifyZero = json.optInt("notify_zero_result", 0) == 1,
+                maxFileMb = json.optInt("max_file_mb", 256).coerceIn(16, 2048),
+                apkPackagesEnabled = json.optInt("clean_apk_packages", 1) == 1,
+                apkPackageDays = json.optInt("apk_package_days", 30).coerceIn(0, 365),
+                apkMinutes = json.optInt("schedule_apk_minutes", json.optInt("schedule_rules_minutes", 1_440)).coerceIn(5, 43_200),
+                runtimeState = runtime.optString("state", "waiting"),
+                runtimeReason = runtime.optString("reason", "等待调度器首次轮询"),
+                queueCount = runtime.optInt("queueCount", 0).coerceAtLeast(0),
+                queueGroups = runtime.optString("queueGroups"),
+                nextTask = runtime.optString("nextTask"),
+                blockedGroups = runtime.optString("blockedGroups"),
+                nextCheckEpoch = runtime.optLong("nextCheckEpoch", 0L).coerceAtLeast(0L),
+                runtimeGroup = runtime.optString("group"),
+                cacheNextEpoch = nextRuns.optLong("cache", 0L).coerceAtLeast(0L),
+                apkNextEpoch = nextRuns.optLong("apk", 0L).coerceAtLeast(0L),
+                emptyNextEpoch = nextRuns.optLong("empty", 0L).coerceAtLeast(0L),
+                rulesNextEpoch = nextRuns.optLong("rules", 0L).coerceAtLeast(0L),
+                fragmentNextEpoch = nextRuns.optLong("fragment", 0L).coerceAtLeast(0L),
+                deepNextEpoch = nextRuns.optLong("deep", 0L).coerceAtLeast(0L),
+                organizeNextEpoch = nextRuns.optLong("organize", 0L).coerceAtLeast(0L),
+                supervisorStatus = runtime.optString("supervisorStatus", "unknown"),
+                supervisorHeartbeatAge = runtime.optLong("supervisorHeartbeatAge", -1L),
+                runtimeStale = runtime.optBoolean("stale", false),
+                scanRootWorkers = 0
+            )
+        }
+    }
+}
+
+private fun Boolean.flag() = if (this) 1 else 0
+
+data class DashboardActions(
+    val refresh: () -> Unit,
+    val clean: () -> Unit,
+    val organize: () -> Unit,
+    val scan: () -> Unit,
+    val apkScan: () -> Unit,
+    val cleanScan: () -> Unit,
+    val dismissScan: () -> Unit,
+    val stop: () -> Unit,
+    val deep: () -> Unit,
+    val corpses: () -> Unit,
+    val audit: () -> Unit,
+    val updateScheduler: (SchedulerUiState) -> Unit,
+    val saveScheduler: (SchedulerUiState) -> Unit,
+    val schedulerCommand: (String) -> Unit,
+    val clearHistory: () -> Unit,
+    val clearRawLog: () -> Unit,
+    val reviewProtected: () -> Unit,
+    val whitelist: () -> Unit,
+    /** 打开断点续清工作台：消费已持久化的扫描快照，支持中断后继续。 */
+    val resumableScan: () -> Unit,
+    val theme: () -> Unit,
+    val reconnect: () -> Unit,
+    val resetScanPerformance: () -> Unit,
+    val crash: () -> Unit
+)
+

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchScreen.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -29,6 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
@@ -171,9 +173,8 @@ internal fun ScanWorkbenchScreen(
     state: WorkbenchUiState,
     actions: WorkbenchActions
 ) {
-    val context = LocalContext.current
     val density = LocalDensity.current
-    var bottomBarHeight by remember { mutableStateOf(112.dp) }
+    var bottomBarHeight by remember { mutableStateOf(88.dp) }
     var filter by rememberSaveable { mutableStateOf("all") }
     var expandedGroups by remember { mutableStateOf(emptySet<String>()) }
     var showFilters by rememberSaveable { mutableStateOf(false) }
@@ -207,49 +208,34 @@ internal fun ScanWorkbenchScreen(
                     IconButton(onClick = { showGuide = true }) { Icon(Icons.Rounded.Info, "扫描说明", Modifier.size(22.dp)) }
                 }
             }
-            item { WorkbenchStatus(state, { showReport = true }) }
             if (state.items.isEmpty()) {
-                item {
-                    DetailEmptyState(
-                        when { state.running -> "正在查找可清理内容"; state.notice == WorkbenchNotice.ERROR -> "未取得完整扫描结果";
-                            state.notice == WorkbenchNotice.SUCCESS -> "没有发现可清理项目"; else -> "按应用查看清理内容" },
-                        when { state.running -> "找到的应用与文件会陆续显示在这里。";
-                            state.notice == WorkbenchNotice.ERROR -> "点击上方错误查看任务详情，再重新扫描。";
-                            state.notice == WorkbenchNotice.SUCCESS -> "可以稍后重新扫描，或在清理页选择其他范围。";
-                            else -> "扫描后可展开应用，核对文件并选择要处理的项目。" }
-                    )
-                }
+                item { WorkbenchEmptyCard(state, onDetails = { showReport = true }) }
             } else {
                 item {
-                    Column(Modifier.padding(horizontal = 24.dp, vertical = 17.dp)) {
-                        Text(if (state.scanReady) "已选项目 · 预计释放" else "保留的扫描记录",
-                            fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        Row(Modifier.fillMaxWidth().padding(top = 5.dp), verticalAlignment = Alignment.Bottom,
-                            horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                            Text(if (state.scanReady) Formatter.formatFileSize(context, presentation.selectedBytes)
-                                else "${state.items.size} 项", fontSize = 29.sp, lineHeight = 36.sp, fontWeight = FontWeight.Medium)
-                            if (state.scanReady) Text("已选 ${selected.size} 项", Modifier.padding(bottom = 5.dp),
-                                fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        }
-                        Text("${presentation.appCount} 个应用 · ${presentation.profileCount} 个其他项目 · ${presentation.protectedCount} 项不可选",
-                            Modifier.padding(top = 7.dp), fontSize = 12.sp, lineHeight = 18.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        if (state.scanReady && selected.any { it.bytes < 0L }) Text("部分大小尚未统计，实际释放量以清理结果为准",
-                            Modifier.padding(top = 4.dp), fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
+                    WorkbenchSummaryCard(state, presentation, selected.size, selectedHigh.size,
+                        selected.any { it.bytes < 0L }, onDetails = { showReport = true })
                 }
                 item {
-                    Row(Modifier.fillMaxWidth().padding(start = 20.dp, end = 16.dp, bottom = 6.dp),
-                        verticalAlignment = Alignment.CenterVertically) {
-                        Text("应用与文件", Modifier.weight(1f), fontSize = 15.sp, fontWeight = FontWeight.Medium)
-                        TextButton(onClick = { showFilters = true }, contentPadding = PaddingValues(horizontal = 8.dp)) {
-                            Text(filters.first { it.first == filter }.second, fontSize = 13.sp)
-                            Icon(Icons.Rounded.ExpandMore, "筛选结果", Modifier.size(18.dp))
+                    Column(Modifier.padding(horizontal = 20.dp).padding(top = 20.dp, bottom = 4.dp)) {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Text("应用与文件", Modifier.weight(1f), style = BaiZeTokens.type.title)
+                            TextButton(onClick = { showFilters = true },
+                                colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.onSurfaceVariant),
+                                contentPadding = PaddingValues(horizontal = 10.dp)) {
+                                Text(filters.first { it.first == filter }.second, fontSize = 12.sp)
+                                Spacer(Modifier.width(4.dp))
+                                Icon(Icons.Rounded.Tune, "筛选结果", Modifier.size(17.dp))
+                            }
                         }
-                    }
-                    if (editable) Row(Modifier.fillMaxWidth().padding(horizontal = 14.dp), verticalAlignment = Alignment.CenterVertically) {
-                        TextButton(actions.onSelectAll) { Text("选中低、中风险", fontSize = 12.sp) }
-                        TextButton(actions.onClear, enabled = selected.isNotEmpty()) { Text("清空选择", fontSize = 12.sp) }
+                        if (editable) Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            TextButton(actions.onSelectAll, contentPadding = PaddingValues(end = 12.dp)) {
+                                Text("选中低、中风险", fontSize = 12.sp)
+                            }
+                            TextButton(actions.onClear, enabled = selected.isNotEmpty(),
+                                contentPadding = PaddingValues(horizontal = 8.dp)) {
+                                Text("清空选择", fontSize = 12.sp)
+                            }
+                        }
                     }
                 }
                 if (presentation.rows.isEmpty()) item {
@@ -271,29 +257,29 @@ internal fun ScanWorkbenchScreen(
                 }
             }
         }
-        // The action remains reachable even when thousands of results are present.
-        Surface(Modifier.align(Alignment.BottomCenter).fillMaxWidth()
-            .onSizeChanged { bottomBarHeight = with(density) { it.height.toDp() } }, color = BaiZeTokens.colors.surfaceRaised,
-            tonalElevation = 0.dp, shadowElevation = 8.dp, shape = RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp)) {
-            Column(Modifier.padding(horizontal = 20.dp).padding(top = 12.dp, bottom = inset + 12.dp)) {
-                if (state.scanReady && !state.running) Row(Modifier.fillMaxWidth().padding(bottom = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically) {
-                    Text(if (selectedHigh.isNotEmpty()) "包含 ${selectedHigh.size} 个高风险项目，清理前将再次确认" else "核对所选内容后清理",
-                        Modifier.weight(1f), fontSize = 11.sp, lineHeight = 16.sp,
-                        color = if (selectedHigh.isNotEmpty()) BaiZeTokens.colors.warning else MaterialTheme.colorScheme.onSurfaceVariant)
-                    TextButton(actions.onScan, contentPadding = PaddingValues(horizontal = 8.dp, vertical = 0.dp)) {
-                        Text("重扫", fontSize = 12.sp)
+        // A compact floating dock keeps the only primary action reachable above system navigation.
+        Box(Modifier.align(Alignment.BottomCenter).fillMaxWidth()
+            .onSizeChanged { bottomBarHeight = with(density) { it.height.toDp() } }
+            .padding(horizontal = 20.dp).padding(top = 12.dp, bottom = inset + 12.dp)) {
+            Surface(color = BaiZeTokens.colors.surfaceRaised.copy(alpha = .97f),
+                tonalElevation = 0.dp, shadowElevation = 8.dp, shape = RoundedCornerShape(24.dp)) {
+                Row(Modifier.fillMaxWidth().padding(8.dp), verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (state.scanReady && !state.running) IconButton(onClick = actions.onScan,
+                        modifier = Modifier.size(48.dp).clip(RoundedCornerShape(16.dp))
+                            .background(BaiZeTokens.colors.surfaceOverlay)) {
+                        Icon(Icons.Rounded.Refresh, "重扫", Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onSurface)
                     }
+                    GlassActionButton(
+                        label = when { state.running -> "停止当前任务"; state.scanReady -> "清理已选 ${selected.size} 项";
+                            !state.connected -> "重新连接并扫描"; state.items.isNotEmpty() || state.notice == WorkbenchNotice.ERROR -> "重新扫描"; else -> "开始扫描" },
+                        onClick = when { state.running -> actions.onStop; state.scanReady -> clean; else -> actions.onScan },
+                        modifier = Modifier.weight(1f),
+                        enabled = if (state.scanReady && !state.running) canClean else true,
+                        secondary = state.running,
+                        icon = if (state.running) Icons.Rounded.Stop else if (state.scanReady) Icons.Rounded.CleaningServices else Icons.Rounded.Search
+                    )
                 }
-                GlassActionButton(
-                    label = when { state.running -> "停止当前任务"; state.scanReady -> "清理已选 ${selected.size} 项";
-                        !state.connected -> "重新连接并扫描"; state.items.isNotEmpty() || state.notice == WorkbenchNotice.ERROR -> "重新扫描"; else -> "开始扫描" },
-                    onClick = when { state.running -> actions.onStop; state.scanReady -> clean; else -> actions.onScan },
-                    modifier = Modifier.fillMaxWidth(),
-                    enabled = if (state.scanReady && !state.running) canClean else true,
-                    secondary = state.running,
-                    icon = if (state.running) Icons.Rounded.Stop else if (state.scanReady) Icons.Rounded.CleaningServices else Icons.Rounded.Search
-                )
             }
         }
     }
@@ -365,87 +351,189 @@ private fun workbenchErrorSummary(state: WorkbenchUiState): String {
 }
 
 @Composable
-private fun WorkbenchStatus(state: WorkbenchUiState, onDetails: () -> Unit) {
-    val color = when { state.notice == WorkbenchNotice.ERROR -> MaterialTheme.colorScheme.error;
-        state.notice == WorkbenchNotice.WARNING -> BaiZeTokens.colors.warning;
-        state.notice == WorkbenchNotice.SUCCESS && !state.running -> BaiZeTokens.colors.success;
-        else -> MaterialTheme.colorScheme.primary }
-    val title = when { state.running -> if (state.loadingResults) "正在读取扫描结果" else "正在处理";
-        state.notice == WorkbenchNotice.ERROR -> workbenchErrorSummary(state);
-        state.notice == WorkbenchNotice.WARNING -> "有项目需要核对";
-        state.scanReady -> "扫描完成，可以选择项目";
-        state.notice == WorkbenchNotice.SUCCESS -> "任务已完成";
-        !state.connected -> "等待清理服务连接";
-        state.items.isNotEmpty() -> "上次结果已保留，请重新扫描";
-        else -> "清理服务已就绪" }
-    Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp).clip(RoundedCornerShape(16.dp))
-        .background(color.copy(alpha = .055f)).clickable(onClickLabel = "查看任务详情", onClick = onDetails).padding(13.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            Icon(when { state.running -> Icons.Rounded.Sync; state.notice == WorkbenchNotice.ERROR -> Icons.Rounded.ErrorOutline;
-                state.notice == WorkbenchNotice.WARNING -> Icons.Rounded.WarningAmber;
-                state.notice == WorkbenchNotice.SUCCESS -> Icons.Rounded.CheckCircle; else -> Icons.Rounded.Info },
-                null, Modifier.size(21.dp), tint = color)
-            Column(Modifier.weight(1f)) {
-                Text(title, fontSize = 13.sp, lineHeight = 19.sp, fontWeight = FontWeight.Medium, color = color,
-                    maxLines = 2, overflow = TextOverflow.Ellipsis)
-                if (!state.running && state.notice == WorkbenchNotice.ERROR) Text("点击查看完整错误详情", fontSize = 11.sp,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-                if (state.running && state.currentPath.isNotBlank()) Text(state.currentPath, fontSize = 11.sp,
-                    maxLines = 1, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurfaceVariant)
+private fun workbenchStatusColor(state: WorkbenchUiState) = when {
+    state.notice == WorkbenchNotice.ERROR -> MaterialTheme.colorScheme.error
+    state.notice == WorkbenchNotice.WARNING -> BaiZeTokens.colors.warning
+    state.notice == WorkbenchNotice.SUCCESS && !state.running -> BaiZeTokens.colors.success
+    else -> MaterialTheme.colorScheme.primary
+}
+
+private fun workbenchStatusTitle(state: WorkbenchUiState) = when {
+    state.running -> if (state.loadingResults) "正在读取扫描结果" else "正在处理"
+    state.notice == WorkbenchNotice.ERROR -> workbenchErrorSummary(state)
+    state.notice == WorkbenchNotice.WARNING -> "有项目需要核对"
+    state.scanReady -> "扫描完成"
+    state.notice == WorkbenchNotice.SUCCESS -> "任务已完成"
+    !state.connected -> "等待清理服务连接"
+    state.items.isNotEmpty() -> "上次结果已保留，请重新扫描"
+    else -> "清理服务已就绪"
+}
+
+@Composable
+private fun WorkbenchSummaryCard(
+    state: WorkbenchUiState,
+    presentation: WorkbenchPresentation,
+    selectedCount: Int,
+    highRiskCount: Int,
+    hasUnknownSize: Boolean,
+    onDetails: () -> Unit
+) {
+    val color = workbenchStatusColor(state)
+    Surface(Modifier.fillMaxWidth().padding(horizontal = 20.dp),
+        shape = RoundedCornerShape(24.dp), color = BaiZeTokens.colors.surfaceRaised) {
+        Column(Modifier.padding(20.dp)) {
+            Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
+                .clickable(onClickLabel = "查看任务详情", onClick = onDetails)
+                .semantics { contentDescription = "查看任务详情" },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.size(8.dp).background(color, CircleShape))
+                Text(workbenchStatusTitle(state), Modifier.weight(1f), fontSize = 12.sp, lineHeight = 18.sp,
+                    fontWeight = FontWeight.Medium, color = color, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Icon(Icons.Rounded.ChevronRight, "查看任务详情", Modifier.size(18.dp), tint = color)
-        }
-        if (state.running) {
-            Spacer(Modifier.height(10.dp))
-            if (state.progressTotal > 0L) LinearProgressIndicator(
-                progress = { (state.progressCurrent.toFloat() / state.progressTotal).coerceIn(0f, 1f) }, modifier = Modifier.fillMaxWidth())
-            else LinearProgressIndicator(Modifier.fillMaxWidth())
-            if (state.progressTotal > 0L) Text("${state.progressCurrent.coerceIn(0L, state.progressTotal)} / ${state.progressTotal}",
-                Modifier.padding(top = 5.dp), fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Spacer(Modifier.height(20.dp))
+            Text(if (state.scanReady) "已选项目 · 预计释放" else "保留的扫描记录",
+                style = BaiZeTokens.type.caption, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text(if (state.scanReady) Formatter.formatFileSize(LocalContext.current, presentation.selectedBytes)
+                else "${state.items.size} 项", Modifier.padding(top = 3.dp),
+                style = BaiZeTokens.type.hero, color = MaterialTheme.colorScheme.onSurface)
+            Row(Modifier.fillMaxWidth().padding(top = 18.dp).clip(RoundedCornerShape(16.dp))
+                .background(BaiZeTokens.colors.surfaceBase).padding(vertical = 12.dp)) {
+                WorkbenchStat("${presentation.appCount}", "应用", Modifier.weight(1f))
+                WorkbenchStat("$selectedCount", "已选项目", Modifier.weight(1f))
+                WorkbenchStat("${presentation.protectedCount}", "不可选", Modifier.weight(1f))
+            }
+            when {
+                highRiskCount > 0 -> Text("含 $highRiskCount 个高风险项目，清理前需再次确认", Modifier.padding(top = 12.dp),
+                    fontSize = 12.sp, lineHeight = 18.sp, color = BaiZeTokens.colors.warning)
+                state.scanReady && hasUnknownSize -> Text("部分大小待统计，释放量以清理结果为准", Modifier.padding(top = 12.dp),
+                    fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                !state.scanReady && !state.running -> Text("记录可继续查看，重新扫描后可选择清理", Modifier.padding(top = 12.dp),
+                    fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (state.running) WorkbenchProgress(state)
         }
     }
 }
 
 @Composable
+private fun WorkbenchStat(value: String, label: String, modifier: Modifier = Modifier) {
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp)) {
+        Text(value, fontSize = 17.sp, lineHeight = 23.sp, fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onSurface)
+        Text(label, fontSize = 11.sp, lineHeight = 16.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun WorkbenchEmptyCard(state: WorkbenchUiState, onDetails: () -> Unit) {
+    val color = workbenchStatusColor(state)
+    val error = state.notice == WorkbenchNotice.ERROR
+    val complete = state.notice == WorkbenchNotice.SUCCESS && !state.running
+    Surface(Modifier.fillMaxWidth().padding(horizontal = 20.dp), shape = RoundedCornerShape(24.dp),
+        color = BaiZeTokens.colors.surfaceRaised) {
+        Column(Modifier.padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Box(Modifier.padding(top = 8.dp, bottom = 20.dp).size(72.dp)
+                .background(color.copy(alpha = .07f), RoundedCornerShape(24.dp)), contentAlignment = Alignment.Center) {
+                Icon(when { state.running -> Icons.Rounded.ManageSearch; error -> Icons.Rounded.ErrorOutline;
+                    complete -> Icons.Rounded.CheckCircle; else -> Icons.Rounded.ManageSearch },
+                    null, Modifier.size(34.dp), tint = color)
+            }
+            Text(when { state.running -> "正在查找可清理内容"; error -> workbenchErrorSummary(state);
+                complete -> "没有发现可清理项目"; else -> "按应用查看清理内容" },
+                fontSize = 20.sp, lineHeight = 28.sp, fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center, color = MaterialTheme.colorScheme.onSurface)
+            Text(when { state.running -> "找到的应用与文件会陆续显示。";
+                error -> "任务信息已保留。查看详情后，可以重新发起扫描。";
+                complete -> "当前扫描范围内暂无可清理内容，可以稍后再试。";
+                else -> "展开应用，核对文件，再选择需要清理的内容。" },
+                Modifier.padding(top = 10.dp), fontSize = 13.sp, lineHeight = 21.sp,
+                textAlign = TextAlign.Center, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            if (state.running) WorkbenchProgress(state)
+            else {
+                Spacer(Modifier.height(24.dp))
+                Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))
+                    .background(BaiZeTokens.colors.surfaceBase)
+                    .clickable(onClickLabel = "查看任务详情", onClick = onDetails)
+                    .semantics { contentDescription = "查看任务详情" }
+                    .padding(horizontal = 14.dp, vertical = 14.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(if (error) Icons.Rounded.Description else Icons.Rounded.Info, null,
+                        Modifier.size(19.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text(if (error || complete) "查看任务详情" else workbenchStatusTitle(state), Modifier.weight(1f),
+                        fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WorkbenchProgress(state: WorkbenchUiState) {
+    Column(Modifier.fillMaxWidth().padding(top = 18.dp)) {
+        if (state.progressTotal > 0L) LinearProgressIndicator(
+            progress = { (state.progressCurrent.toFloat() / state.progressTotal).coerceIn(0f, 1f) },
+            modifier = Modifier.fillMaxWidth().clip(CircleShape))
+        else LinearProgressIndicator(Modifier.fillMaxWidth().clip(CircleShape))
+        if (state.currentPath.isNotBlank()) Text(state.currentPath, Modifier.padding(top = 8.dp),
+            fontSize = 11.sp, lineHeight = 17.sp, maxLines = 1, overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+        if (state.progressTotal > 0L) Text("${state.progressCurrent.coerceIn(0L, state.progressTotal)} / ${state.progressTotal}",
+            Modifier.padding(top = 4.dp), fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
 private fun WorkbenchGroupRow(group: WorkbenchGroup, expanded: Boolean, enabled: Boolean, onExpand: () -> Unit, onSelect: () -> Unit) {
-    Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp).padding(top = 7.dp)
-        .clip(RoundedCornerShape(17.dp)).background(BaiZeTokens.colors.surfaceRaised)) {
+    Surface(Modifier.fillMaxWidth().padding(horizontal = 20.dp).padding(top = 8.dp, bottom = 4.dp),
+        shape = RoundedCornerShape(24.dp), color = BaiZeTokens.colors.surfaceRaised) {
         Row(Modifier.fillMaxWidth().clickable(onClickLabel = if (expanded) "收起应用明细" else "展开应用明细", onClick = onExpand)
-            .padding(start = 4.dp, end = 12.dp, top = 9.dp, bottom = 9.dp), verticalAlignment = Alignment.CenterVertically) {
+            .padding(start = 14.dp, end = 10.dp, top = 14.dp, bottom = 14.dp), verticalAlignment = Alignment.CenterVertically) {
+            val owner = group.items.firstOrNull()?.packageName.orEmpty()
+            if (owner.isNotBlank()) ApplicationIcon(owner, group.title, Modifier.size(42.dp))
+            else Box(Modifier.size(42.dp).background(MaterialTheme.colorScheme.primary.copy(alpha = .075f), RoundedCornerShape(14.dp)),
+                contentAlignment = Alignment.Center) {
+                Icon(categoryIcon(group.items.firstOrNull()?.profile.orEmpty()), null,
+                    Modifier.size(23.dp), tint = MaterialTheme.colorScheme.primary)
+            }
+            Column(Modifier.weight(1f).padding(start = 12.dp, end = 2.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(group.title, fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.SemiBold,
+                    maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Text("${Formatter.formatFileSize(LocalContext.current, group.bytes)} · ${group.items.size} 项",
+                    fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis)
+                if (group.selectedCount > 0) Text("已选 ${group.selectedCount} 项", fontSize = 11.sp, lineHeight = 15.sp,
+                    color = MaterialTheme.colorScheme.primary)
+            }
             TriStateCheckbox(state = when { group.bulkSelectedCount == 0 -> ToggleableState.Off;
                 group.bulkSelectedCount == group.selectableCount -> ToggleableState.On; else -> ToggleableState.Indeterminate },
                 onClick = onSelect, enabled = enabled && group.selectableCount > 0,
                 modifier = Modifier.semantics { contentDescription = "选择${group.title}的低中风险项目" })
-            val owner = group.items.firstOrNull()?.packageName.orEmpty()
-            if (owner.isNotBlank()) ApplicationIcon(owner, group.title, Modifier.size(34.dp))
-            else Icon(categoryIcon(group.items.firstOrNull()?.profile.orEmpty()), null, Modifier.size(28.dp), tint = MaterialTheme.colorScheme.primary)
-            Column(Modifier.weight(1f).padding(horizontal = 10.dp), verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                Text(group.title, fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.Medium, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                Text("${group.items.size} 项 · 已选 ${group.selectedCount}", fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(Formatter.formatFileSize(LocalContext.current, group.bytes), fontSize = 12.sp)
-                Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
+            Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, null,
+                Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
         }
     }
 }
 
 @Composable
 private fun WorkbenchCandidateRow(item: WorkbenchItem, selected: Boolean, enabled: Boolean, onToggle: () -> Unit, onDetails: () -> Unit) {
-    Row(Modifier.fillMaxWidth().padding(horizontal = 27.dp).background(BaiZeTokens.colors.surfaceRaised.copy(alpha = .65f))
-        .padding(start = 1.dp, end = 3.dp, top = 7.dp, bottom = 7.dp), verticalAlignment = Alignment.Top) {
+    Row(Modifier.fillMaxWidth().padding(horizontal = 28.dp).padding(bottom = 4.dp)
+        .clip(RoundedCornerShape(16.dp)).background(BaiZeTokens.colors.surfaceRaised.copy(alpha = .72f))
+        .padding(start = 2.dp, end = 3.dp, top = 8.dp, bottom = 8.dp), verticalAlignment = Alignment.Top) {
         Checkbox(selected, onCheckedChange = { onToggle() }, enabled = enabled && item.selectable,
             modifier = Modifier.semantics { contentDescription = "选择${item.title}" })
-        Column(Modifier.weight(1f).clickable(onClickLabel = "查看文件明细", onClick = onDetails).padding(top = 8.dp, bottom = 5.dp),
-            verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        Column(Modifier.weight(1f).clickable(onClickLabel = "查看文件明细", onClick = onDetails).padding(top = 7.dp, bottom = 5.dp),
+            verticalArrangement = Arrangement.spacedBy(7.dp)) {
             Text(item.title, fontSize = 13.sp, lineHeight = 19.sp, fontWeight = FontWeight.Medium, maxLines = 2, overflow = TextOverflow.Ellipsis)
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
                 RiskBadge(item.risk)
                 Text(if (item.bytes < 0L) "大小待统计" else Formatter.formatFileSize(LocalContext.current, item.bytes),
-                    fontSize = 11.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    fontSize = 11.sp, lineHeight = 16.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Text(item.outcome.ifBlank { if (!item.selectable) item.reason else item.path }, fontSize = 11.sp, lineHeight = 16.sp,
+            Text(item.outcome.ifBlank { if (!item.selectable) item.reason else item.path }, fontSize = 11.sp, lineHeight = 17.sp,
                 maxLines = 2, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
         IconButton(onDetails, Modifier.size(40.dp)) { Icon(Icons.Rounded.MoreHoriz, "${item.title}详情", Modifier.size(19.dp)) }
@@ -457,7 +545,7 @@ private fun RiskBadge(risk: String) {
     val (label, color) = when (risk) { "low" -> "低风险" to BaiZeTokens.colors.success;
         "medium" -> "中风险" to MaterialTheme.colorScheme.primary;
         "high" -> "高风险" to BaiZeTokens.colors.warning; else -> "关键数据" to MaterialTheme.colorScheme.error }
-    Text(label, Modifier.clip(RoundedCornerShape(5.dp)).background(color.copy(alpha = .075f)).padding(horizontal = 5.dp, vertical = 2.dp),
+    Text(label, Modifier.clip(RoundedCornerShape(6.dp)).background(color.copy(alpha = .075f)).padding(horizontal = 6.dp, vertical = 3.dp),
         color = color, fontSize = 10.sp, lineHeight = 14.sp)
 }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/VideoCleanScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/VideoCleanScreenMiuix.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -75,6 +76,7 @@ import io.github.xgl34222220.baize.ui.miuix.VideoLeadingIcon
 import io.github.xgl34222220.baize.ui.miuix.VideoListRow
 import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
 import io.github.xgl34222220.baize.ui.miuix.VideoTabs
+import io.github.xgl34222220.baize.ui.miuix.VideoStatusPill
 import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import androidx.compose.ui.semantics.semantics
@@ -135,7 +137,7 @@ fun VideoCleanScreenMiuix(
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = bottomInset + 112.dp),
-        verticalArrangement = Arrangement.spacedBy(18.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         item { VideoTopBar(title = "清理") }
         item {
@@ -145,37 +147,33 @@ fun VideoCleanScreenMiuix(
             item { ScanSummary(state, actions) }
             item {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    VideoSectionTitle("专项清理")
+                    VideoSectionTitle("常用清理")
                     Row(
                         Modifier.padding(horizontal = 20.dp).fillMaxWidth().height(IntrinsicSize.Min),
                         horizontalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        ToolTile(Icons.Rounded.CleaningServices, "应用缓存", "缓存与临时文件",
+                        ToolTile(Icons.Rounded.CleaningServices, "应用缓存", "释放日常缓存",
                             MaterialTheme.colorScheme.primary, actions.onInstantCache,
                             Modifier.weight(1f).fillMaxHeight())
-                        ToolTile(Icons.Rounded.InstallMobile, "安装包", "多种安装包格式",
+                        ToolTile(Icons.Rounded.InstallMobile, "安装包", "查找已下载安装包",
                             MaterialTheme.colorScheme.secondary, actions.onApkScan,
-                            Modifier.weight(1f).fillMaxHeight())
-                    }
-                    Row(
-                        Modifier.padding(horizontal = 20.dp).fillMaxWidth().height(IntrinsicSize.Min),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        ToolTile(Icons.Rounded.FolderDelete, "卸载残留", "找出无用目录",
-                            BaiZeTokens.colors.warning, actions.onCorpses,
-                            Modifier.weight(1f).fillMaxHeight())
-                        ToolTile(Icons.Rounded.AutoAwesome, "深度清理", "日志与下载碎片",
-                            MaterialTheme.colorScheme.primary, actions.onDeepClean,
                             Modifier.weight(1f).fillMaxHeight())
                     }
                 }
             }
             item {
                 VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
-                    VideoListRow(Icons.Rounded.FolderCopy, "文件归类", "按类型整理下载文件", onClick = actions.onFileOrganizer)
+                    VideoListRow(Icons.Rounded.AutoAwesome, "深度清理", "日志、碎片与更多残留", onClick = actions.onDeepClean)
                     VideoDivider()
-                    VideoListRow(Icons.Rounded.Security, "清理规则与保护", "查看规则、明细和保留内容", onClick = actions.onAudit)
+                    VideoListRow(Icons.Rounded.FolderDelete, "卸载残留", "找出应用卸载后的目录", onClick = actions.onCorpses)
                     VideoDivider()
+                    VideoListRow(Icons.Rounded.FolderCopy, "文件归类", "整理下载目录", onClick = actions.onFileOrganizer)
+                    VideoDivider()
+                    VideoListRow(Icons.Rounded.Security, "清理规则与保护", "规则、清理明细与保留项", onClick = actions.onAudit)
+                }
+            }
+            item {
+                VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
                     VideoListRow(Icons.Rounded.CalendarMonth, "自动清理计划",
                         if (state.automaticCleaningEnabled) "${state.enabledCategoryCount} 个类别 · ${state.scheduleMode.title}" else "设置周期与保留时间",
                         value = if (state.automaticCleaningEnabled) "已开启" else "已暂停",
@@ -224,25 +222,47 @@ fun VideoCleanScreenMiuix(
 
 @Composable
 private fun ScanSummary(state: CleanUiState, actions: CleanUiActions) {
-    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(), contentPadding = 18) {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            VideoLeadingIcon(Icons.Rounded.Search)
-            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+    val primary = MaterialTheme.colorScheme.primary
+    VideoCard(
+        Modifier.padding(horizontal = 20.dp).fillMaxWidth(),
+        containerColor = lerp(BaiZeTokens.colors.surfaceRaised, primary, .04f),
+        contentPadding = 20
+    ) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("空间扫描", Modifier.weight(1f), style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            VideoStatusPill(when {
+                state.running -> "进行中"
+                state.scanSnapshotReady -> "结果已就绪"
+                state.engineReady -> "服务已就绪"
+                else -> "待连接"
+            }, positive = state.engineReady || state.running || state.scanSnapshotReady)
+        }
+        Spacer(Modifier.height(18.dp))
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 Text(when {
-                    state.running -> "清理任务进行中"
-                    state.scanSnapshotReady -> "扫描结果已就绪"
-                    state.engineReady -> "空间扫描"
-                    else -> "等待清理服务连接"
-                }, fontSize = 17.sp, lineHeight = 23.sp, fontWeight = FontWeight.SemiBold)
+                    state.running -> "任务进行中"
+                    state.scanSnapshotReady -> "扫描已完成"
+                    state.engineReady -> "检查可清理空间"
+                    else -> "连接后开始扫描"
+                }, fontSize = 24.sp, lineHeight = 32.sp, fontWeight = FontWeight.SemiBold,
+                    letterSpacing = (-.5).sp)
                 Text(when {
-                    state.running -> "查看进度或停止任务"
-                    state.scanSnapshotReady -> "先查看明细，再选择清理"
-                    state.engineReady -> "缓存、规则垃圾与临时文件"
-                    else -> state.serviceText.ifBlank { "连接后即可开始扫描" }
-                }, fontSize = 13.sp, lineHeight = 19.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    state.running -> "点按下方查看任务进度"
+                    state.scanSnapshotReady -> "查看明细，选择需要清理的内容"
+                    state.engineReady -> "一次检查缓存、垃圾与临时文件"
+                    else -> state.serviceText.ifBlank { "等待清理服务连接" }
+                }, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            Box(Modifier.size(64.dp).clip(RoundedCornerShape(22.dp)).background(primary.copy(alpha = .07f)),
+                contentAlignment = Alignment.Center) {
+                Icon(if (state.scanSnapshotReady) Icons.Rounded.CheckCircle else Icons.Rounded.Search,
+                    null, Modifier.size(32.dp), tint = primary)
             }
         }
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(20.dp))
         if (state.running) {
             LinearProgressIndicator(Modifier.fillMaxWidth().clip(RoundedCornerShape(2.dp)))
             Spacer(Modifier.height(12.dp))
@@ -270,12 +290,17 @@ private fun ToolTile(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    VideoCard(modifier.clip(RoundedCornerShape(20.dp)).clickable(role = Role.Button, onClick = onClick), contentPadding = 16) {
-        Box(Modifier.size(38.dp).clip(RoundedCornerShape(13.dp)).background(tint.copy(alpha = .09f)),
-            contentAlignment = Alignment.Center) {
-            Icon(icon, null, Modifier.size(21.dp), tint = tint)
+    VideoCard(modifier.clip(RoundedCornerShape(24.dp)).clickable(role = Role.Button, onClick = onClick), contentPadding = 18) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Box(Modifier.size(40.dp).clip(RoundedCornerShape(14.dp)).background(tint.copy(alpha = .08f)),
+                contentAlignment = Alignment.Center) {
+                Icon(icon, null, Modifier.size(22.dp), tint = tint)
+            }
+            Spacer(Modifier.weight(1f))
+            Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .45f))
         }
-        Spacer(Modifier.height(10.dp))
+        Spacer(Modifier.height(16.dp))
         Text(title, fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold)
         Spacer(Modifier.height(3.dp))
         Text(caption, fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
@@ -284,11 +309,12 @@ private fun ToolTile(
 
 @Composable
 private fun AutomaticSummary(state: CleanUiState, actions: CleanUiActions) {
-    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(), contentPadding = 18) {
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(),
+        containerColor = lerp(BaiZeTokens.colors.surfaceRaised, MaterialTheme.colorScheme.primary, .04f), contentPadding = 20) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             VideoLeadingIcon(Icons.Rounded.CalendarMonth)
             Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text("自动清理", fontSize = 17.sp, lineHeight = 23.sp, fontWeight = FontWeight.SemiBold)
+                Text("自动清理", fontSize = 20.sp, lineHeight = 27.sp, fontWeight = FontWeight.SemiBold)
                 Text(when {
                     state.saving -> "正在保存计划…"
                     state.automaticCleaningEnabled -> "${state.enabledCategoryCount} 个类别已开启 · 自动保存"
@@ -297,6 +323,20 @@ private fun AutomaticSummary(state: CleanUiState, actions: CleanUiActions) {
             }
             Switch(checked = state.automaticCleaningEnabled, onCheckedChange = actions.onAutomaticCleaningChanged,
                 modifier = Modifier.semantics { contentDescription = "自动清理" })
+        }
+        Spacer(Modifier.height(16.dp))
+        Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = .045f)).padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("执行方式", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text(state.scheduleMode.title, style = MaterialTheme.typography.titleMedium)
+            }
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("已启用类别", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("${state.enabledCategoryCount} / ${state.categories.size}", style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary)
+            }
         }
     }
 }
@@ -380,7 +420,7 @@ private fun CategoryRow(
         if (item.id == CleanCategoryId.APK) {
             PlanValueRow("安装包保留时间", if (retentionDays == 0) "不保留" else "$retentionDays 天", onEditRetention,
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
-                    .clip(RoundedCornerShape(12.dp)).background(BaiZeTokens.colors.surfaceOverlay.copy(alpha = .62f)))
+                    .clip(RoundedCornerShape(16.dp)).background(BaiZeTokens.colors.surfaceOverlay.copy(alpha = .62f)))
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/components/DetailPageComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/components/DetailPageComponents.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.xgl34222220.baize.ui.miuix.GlassActionButton
+import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
 import io.github.xgl34222220.baize.ui.miuix.glassSurface
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
@@ -42,19 +43,16 @@ fun DetailPageHeader(
 ) {
     Column(modifier.fillMaxWidth()
         .then(if (statusBarInset) Modifier.statusBarsPadding() else Modifier)
-        .padding(horizontal = 16.dp).padding(bottom = 10.dp)) {
-        Row(Modifier.fillMaxWidth().heightIn(min = 60.dp), verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = onBack, modifier = Modifier.size(44.dp)) {
-                Icon(Icons.AutoMirrored.Rounded.ArrowBack, "返回", Modifier.size(23.dp),
-                    tint = MaterialTheme.colorScheme.onSurface)
-            }
-            Text(title, Modifier.weight(1f).padding(horizontal = 8.dp),
-                fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Medium,
+        .padding(horizontal = 20.dp).padding(bottom = 12.dp)) {
+        Row(Modifier.fillMaxWidth().heightIn(min = 72.dp), verticalAlignment = Alignment.CenterVertically) {
+            VideoIconButton(Icons.AutoMirrored.Rounded.ArrowBack, "返回", onBack)
+            Text(title, Modifier.weight(1f).padding(horizontal = 12.dp),
+                fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface)
             CompositionLocalProvider(LocalContentColor provides MaterialTheme.colorScheme.onSurface) { actions() }
         }
         if (subtitle.isNotBlank()) Text(subtitle, Modifier.padding(horizontal = 4.dp),
-            fontSize = 12.sp, lineHeight = 17.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            fontSize = 13.sp, lineHeight = 19.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
@@ -75,7 +73,7 @@ fun DetailGlassPanel(modifier: Modifier = Modifier, content: @Composable ColumnS
     val dark = surface.luminance() < .3f
     Column(modifier.fillMaxWidth().padding(horizontal = 20.dp)
         .glassSurface(color = surface, shape = shape, dark = dark)
-        .padding(16.dp), content = content)
+        .padding(20.dp), content = content)
 }
 
 @Composable
@@ -180,8 +178,8 @@ fun DetailResultRow(
     accent: Color = MaterialTheme.colorScheme.primary
 ) {
     var showDetails by rememberSaveable(title, path) { mutableStateOf(false) }
-    val shape = RoundedCornerShape(topStart = if (first) 18.dp else 0.dp, topEnd = if (first) 18.dp else 0.dp,
-        bottomStart = if (last) 18.dp else 0.dp, bottomEnd = if (last) 18.dp else 0.dp)
+    val shape = RoundedCornerShape(topStart = if (first) 24.dp else 0.dp, topEnd = if (first) 24.dp else 0.dp,
+        bottomStart = if (last) 24.dp else 0.dp, bottomEnd = if (last) 24.dp else 0.dp)
     Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp).clip(shape)
         .background(BaiZeTokens.colors.surfaceRaised.copy(alpha = .92f))
         .clickable(onClickLabel = "查看完整路径与详情") { showDetails = true }) {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/glass/LiquidGlassLens.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/glass/LiquidGlassLens.kt
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+package io.github.xgl34222220.baize.ui.glass
+
+// Adapted from LuoShu@fe4df5f, based on compose-miuix-ui/miuix's LiquidGlass Lens
+// and Kyant0/AndroidLiquidGlass (Apache-2.0). See docs/UI-LUOSHU-DOCK.md.
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.ui.unit.LayoutDirection
+import top.yukonga.miuix.kmp.blur.BackdropEffectScope
+import top.yukonga.miuix.kmp.blur.isRuntimeShaderSupported
+import top.yukonga.miuix.kmp.blur.runtimeShaderEffect
+
+internal fun BackdropEffectScope.liquidGlassLens(
+    refractionHeight: Float, refractionAmount: Float,
+    depthEffect: Boolean = false, chromaticAberration: Float = 0f,
+) {
+    if (!isRuntimeShaderSupported() || refractionHeight <= 0f || refractionAmount <= 0f) return
+    if (padding < refractionAmount) padding = refractionAmount
+    val radii = roundedRectCornerRadii() ?: return
+    val scale = downscaleFactor.coerceAtLeast(1).toFloat()
+    runtimeShaderEffect(
+        key = "BaiZeLuoShuLiquidLens",
+        shaderString = REFRACTION_SHADER,
+        uniformShaderName = "content",
+    ) {
+        setFloatUniform("size", size.width / scale, size.height / scale)
+        setFloatUniform("offset", -padding / scale, -padding / scale)
+        setFloatUniform("cornerRadii", FloatArray(4) { radii[it] / scale })
+        setFloatUniform("refractionHeight", refractionHeight / scale)
+        setFloatUniform("refractionAmount", -refractionAmount / scale)
+        setFloatUniform("depthEffect", if (depthEffect) 1f else 0f)
+        setFloatUniform("chromaticAberration", chromaticAberration)
+    }
+}
+
+private fun BackdropEffectScope.roundedRectCornerRadii(): FloatArray? {
+    val s = shape as? CornerBasedShape ?: return null
+    val maxRadius = size.minDimension / 2f
+    val ltr = layoutDirection == LayoutDirection.Ltr
+    return floatArrayOf(
+        (if (ltr) s.topStart else s.topEnd).toPx(size, this),
+        (if (ltr) s.topEnd else s.topStart).toPx(size, this),
+        (if (ltr) s.bottomEnd else s.bottomStart).toPx(size, this),
+        (if (ltr) s.bottomStart else s.bottomEnd).toPx(size, this),
+    ).map { it.coerceAtMost(maxRadius) }.toFloatArray()
+}
+
+// Same dispersion sampling and optical mapping as LuoShu. centeredCoord selects
+// asymmetric corner radii correctly in non-floating/RTL layouts.
+private const val REFRACTION_SHADER = """
+uniform shader content;
+uniform float2 size;
+uniform float2 offset;
+uniform float4 cornerRadii;
+uniform float refractionHeight;
+uniform float refractionAmount;
+uniform float depthEffect;
+uniform float chromaticAberration;
+float radiusAt(float2 coord, float4 radii) {
+    if (coord.x >= 0.0) {
+        if (coord.y <= 0.0) return radii.y;
+        else return radii.z;
+    } else {
+        if (coord.y <= 0.0) return radii.x;
+        else return radii.w;
+    }
+}
+float sdRoundedRect(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    float outside = length(max(cornerCoord, 0.0)) - radius;
+    float inside = min(max(cornerCoord.x, cornerCoord.y), 0.0);
+    return outside + inside;
+}
+float2 gradSdRoundedRect(float2 coord, float2 halfSize, float radius) {
+    float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
+    if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
+        return sign(coord) * normalize(max(cornerCoord, 0.0));
+    } else {
+        float gradX = step(cornerCoord.y, cornerCoord.x);
+        return sign(coord) * float2(gradX, 1.0 - gradX);
+    }
+}
+float circleMap(float x) { return 1.0 - sqrt(max(0.0, 1.0 - x * x)); }
+half4 main(float2 coord) {
+    float2 halfSize = size * 0.5;
+    float2 centeredCoord = (coord + offset) - halfSize;
+    float radius = radiusAt(centeredCoord, cornerRadii);
+    float sd = sdRoundedRect(centeredCoord, halfSize, radius);
+    if (-sd >= refractionHeight) return content.eval(coord);
+    sd = min(sd, 0.0);
+    float d = circleMap(1.0 - -sd / refractionHeight) * refractionAmount;
+    float gradRadius = min(radius * 1.5, min(halfSize.x, halfSize.y));
+    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    float2 refractedCoord = coord + d * grad;
+    if (chromaticAberration <= 0.0) return content.eval(refractedCoord);
+    float dispersion = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));
+    float2 split = d * grad * dispersion;
+    half4 color = half4(0.0);
+    half4 red = content.eval(refractedCoord + split);
+    color.r += red.r / 3.5; color.a += red.a / 7.0;
+    half4 orange = content.eval(refractedCoord + split * (2.0 / 3.0));
+    color.r += orange.r / 3.5; color.g += orange.g / 7.0; color.a += orange.a / 7.0;
+    half4 yellow = content.eval(refractedCoord + split * (1.0 / 3.0));
+    color.r += yellow.r / 3.5; color.g += yellow.g / 3.5; color.a += yellow.a / 7.0;
+    half4 green = content.eval(refractedCoord);
+    color.g += green.g / 3.5; color.a += green.a / 7.0;
+    half4 cyan = content.eval(refractedCoord - split * (1.0 / 3.0));
+    color.g += cyan.g / 3.5; color.b += cyan.b / 3.0; color.a += cyan.a / 7.0;
+    half4 blue = content.eval(refractedCoord - split * (2.0 / 3.0));
+    color.b += blue.b / 3.0; color.a += blue.a / 7.0;
+    half4 purple = content.eval(refractedCoord - split);
+    color.r += purple.r / 7.0; color.b += purple.b / 3.0; color.a += purple.a / 7.0;
+    return color;
+}
+"""

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/VideoHistoryScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/history/miuix/VideoHistoryScreenMiuix.kt
@@ -2,8 +2,10 @@ package io.github.xgl34222220.baize.ui.history.miuix
 
 import android.text.format.Formatter
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -21,10 +23,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.ChevronRight
-import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Refresh
@@ -40,8 +43,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
@@ -62,13 +65,15 @@ import io.github.xgl34222220.baize.ui.miuix.VideoListRow
 import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
 import io.github.xgl34222220.baize.ui.miuix.VideoTabs
 import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 @Composable
 fun VideoHistoryScreenMiuix(state: HistoryUiState, actions: HistoryUiActions) {
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
     LazyColumn(
-        modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = bottomInset + 112.dp)
+        modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = bottomInset + 112.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         item {
             VideoTopBar("记录", actions = {
@@ -81,19 +86,23 @@ fun VideoHistoryScreenMiuix(state: HistoryUiState, actions: HistoryUiActions) {
             item { CurrentResultCard(state, actions.onReviewProtected) }
         }
         item {
-            VideoTabs(listOf("任务时间线", "应用与文件"), selectedTab, { selectedTab = it }, Modifier.padding(top = 14.dp, bottom = 18.dp))
+            VideoTabs(listOf("任务时间线", "应用与文件"), selectedTab, { selectedTab = it })
         }
         if (selectedTab == 0) {
             if (state.records.isEmpty()) item {
-                VideoEmptyState(Icons.Rounded.History, "暂无清理记录", "任务完成后会保存在这里。", Modifier.padding(horizontal = 20.dp))
+                VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+                    VideoEmptyState(Icons.Rounded.History, "暂无清理记录", "完成一次清理后，在这里回看结果。")
+                }
             } else {
-                itemsIndexed(state.records, key = { index, record -> "${record.time}|${record.title}|$index" }) { index, record ->
-                    HistoryTimelineRow(record, index == 0, index == state.records.lastIndex)
+                itemsIndexed(state.records, key = { index, record -> "${record.time}|${record.title}|$index" }) { _, record ->
+                    HistoryTimelineRow(record)
                 }
             }
         } else {
             if (state.recentApps.isEmpty() && state.recentJunk.isEmpty()) item {
-                VideoEmptyState(Icons.Rounded.Folder, "暂无分类结果", "扫描或清理后可查看应用与文件明细。", Modifier.padding(horizontal = 20.dp))
+                VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+                    VideoEmptyState(Icons.Rounded.Folder, "暂无分类结果", "扫描后可按应用、文件查看明细。")
+                }
             }
             if (state.recentApps.isNotEmpty()) {
                 item { VideoSectionTitle("按应用", "最近一次任务") }
@@ -105,9 +114,8 @@ fun VideoHistoryScreenMiuix(state: HistoryUiState, actions: HistoryUiActions) {
                 item { VideoSectionTitle("其他文件", modifier = Modifier.padding(top = 16.dp)) }
                 itemsIndexed(state.recentJunk, key = { index, junk -> "junk:${junk.name}:$index" }) { _, junk ->
                     val context = LocalContext.current
-                    Column(Modifier.padding(horizontal = 20.dp)) {
+                    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
                         VideoListRow(Icons.Rounded.Folder, junk.name, junk.samplePath.ifBlank { "未记录示例路径" }, value = "${Formatter.formatFileSize(context, junk.bytes)}\n${junk.files} 项")
-                        VideoDivider(start = 0)
                     }
                 }
             }
@@ -119,38 +127,47 @@ fun VideoHistoryScreenMiuix(state: HistoryUiState, actions: HistoryUiActions) {
 private fun LifetimeSummary(state: HistoryUiState) {
     val context = LocalContext.current
     var expanded by rememberSaveable { mutableStateOf(false) }
-    Column(Modifier.padding(horizontal = 24.dp, vertical = 4.dp)) {
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            Text("累计释放", Modifier.weight(1f), fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            Text(if (expanded) "收起统计" else "详细统计",
-                Modifier.heightIn(min = 40.dp).clickable(role = Role.Button) { expanded = !expanded }.padding(vertical = 10.dp),
-                fontSize = 12.sp, fontWeight = FontWeight.Medium, color = MaterialTheme.colorScheme.primary)
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(),
+        containerColor = lerp(BaiZeTokens.colors.surfaceRaised, MaterialTheme.colorScheme.primary, .04f),
+        contentPadding = 20) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text("累计释放", Modifier.weight(1f), style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Row(Modifier.heightIn(min = 44.dp).clip(RoundedCornerShape(12.dp))
+                .clickable(role = Role.Button) { expanded = !expanded }.padding(start = 8.dp, top = 10.dp, bottom = 10.dp),
+                verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(if (expanded) "收起统计" else "详细统计", style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary)
+                Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ChevronRight,
+                    null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.primary)
+            }
         }
-        Text(Formatter.formatFileSize(context, state.lifetimeReleased), fontSize = 30.sp, lineHeight = 38.sp,
-            fontWeight = FontWeight.Medium, letterSpacing = (-.6).sp)
-        Spacer(Modifier.height(12.dp))
-        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+        Text(Formatter.formatFileSize(context, state.lifetimeReleased), fontSize = 38.sp, lineHeight = 46.sp,
+            fontWeight = FontWeight.SemiBold, letterSpacing = (-1.1).sp)
+        Spacer(Modifier.height(20.dp))
+        Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = .045f)).padding(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(20.dp)) {
             SmallMetric("完成任务", state.lifetimeRuns.toString(), Modifier.weight(1f))
             SmallMetric("处理文件", state.lifetimeFiles.toString(), Modifier.weight(1f))
         }
         AnimatedVisibility(expanded) {
-            Column(Modifier.padding(top = 16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                VideoDivider(start = 0)
+            Column(Modifier.padding(top = 18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 StatisticRow("累计运行时长", formatElapsed(state.lifetimeElapsed))
                 StatisticRow("空文件", state.lifetimeEmptyFiles.toString())
                 StatisticRow("空目录", state.lifetimeEmptyDirs.toString())
                 StatisticRow("残留碎片", state.lifetimeFragments.toString())
             }
         }
-        Spacer(Modifier.height(16.dp))
     }
 }
 
 @Composable
 private fun SmallMetric(label: String, value: String, modifier: Modifier = Modifier) {
-    Column(modifier, verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(value, fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.Medium)
-        Text(label, fontSize = 12.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        Text(value, fontSize = 21.sp, lineHeight = 28.sp, fontWeight = FontWeight.SemiBold)
+        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
@@ -166,9 +183,9 @@ private fun StatisticRow(label: String, value: String) {
 private fun CurrentResultCard(state: HistoryUiState, onReviewProtected: () -> Unit) {
     val context = LocalContext.current
     val hasResult = state.hasCurrentResult || state.latestResult.isNotBlank()
-    VideoCard(Modifier.padding(horizontal = 20.dp, vertical = 4.dp).fillMaxWidth()) {
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
         if (hasResult) {
-            Column(Modifier.padding(16.dp)) {
+            Column(Modifier.padding(18.dp)) {
                 Text(listOf("最近一次", state.lastTaskTime).filter { it.isNotBlank() }.joinToString(" · "),
                     fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 DetailStatusText(state.latestResult.ifBlank { "最近一次任务已完成" }, Modifier.padding(top = 6.dp))
@@ -190,8 +207,8 @@ private fun CurrentResultCard(state: HistoryUiState, onReviewProtected: () -> Un
 @Composable
 private fun AppResultRow(packageName: String, label: String, subtitle: String, bytes: Long, files: Long) {
     val context = LocalContext.current
-    Column(Modifier.padding(horizontal = 24.dp)) {
-        Row(Modifier.padding(vertical = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(), contentPadding = 16) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
             AppPackageIcon(packageName = packageName, label = label, size = 38.dp, corner = 12.dp)
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -206,37 +223,41 @@ private fun AppResultRow(packageName: String, label: String, subtitle: String, b
                 Text("$subtitle · $files 项", color = MaterialTheme.colorScheme.onSurfaceVariant, fontSize = 12.sp, lineHeight = 18.sp)
             }
         }
-        VideoDivider(start = 50)
     }
 }
 
 @Composable
-private fun HistoryTimelineRow(record: HistoryUiItem, first: Boolean, last: Boolean) {
+private fun HistoryTimelineRow(record: HistoryUiItem) {
     val context = LocalContext.current
     var expanded by rememberSaveable(record.time, record.title) { mutableStateOf(false) }
     val accent = MaterialTheme.colorScheme.primary
-    Column(Modifier.fillMaxWidth().drawBehind {
-        val x = 28.dp.toPx()
-        val y = 10.dp.toPx()
-        drawLine(accent.copy(alpha = .15f), Offset(x, if (first) y else 0f), Offset(x, if (last) y else size.height), 1.dp.toPx())
-        drawCircle(accent.copy(alpha = .12f), 7.dp.toPx(), Offset(x, y))
-        drawCircle(accent, 3.dp.toPx(), Offset(x, y))
-    }.clickable(role = Role.Button, onClickLabel = if (expanded) "收起任务详情" else "展开任务详情") { expanded = !expanded }
-        .padding(start = 48.dp, end = 24.dp, bottom = 20.dp)) {
-        Text("${record.time} · ${record.trigger}", fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Spacer(Modifier.height(5.dp))
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(record.title, Modifier.weight(1f), fontSize = 15.sp, lineHeight = 22.sp, fontWeight = FontWeight.Medium)
-            Icon(if (expanded) Icons.Rounded.ExpandMore else Icons.Rounded.ChevronRight, null,
-                Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .55f))
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+        Column(Modifier.fillMaxWidth().clickable(role = Role.Button,
+            onClickLabel = if (expanded) "收起任务详情" else "展开任务详情") { expanded = !expanded }.padding(18.dp)) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Box(Modifier.size(7.dp).clip(RoundedCornerShape(4.dp)).background(accent.copy(alpha = .7f)))
+                Text("${record.time} · ${record.trigger}", Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ChevronRight, null,
+                    Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .55f))
+            }
+            Spacer(Modifier.height(10.dp))
+            Text(record.title, fontSize = 17.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold)
+            Spacer(Modifier.height(5.dp))
+            Text(record.result.ifBlank { "任务已完成" }, style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = if (expanded) Int.MAX_VALUE else 2, overflow = TextOverflow.Ellipsis)
+            Spacer(Modifier.height(14.dp))
+            Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(12.dp))
+                .background(accent.copy(alpha = .045f)).padding(horizontal = 12.dp, vertical = 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                Text("${Formatter.formatFileSize(context, record.bytes)} · ${record.files} 项", Modifier.weight(1f),
+                    style = MaterialTheme.typography.labelLarge, color = accent)
+                Text(if (record.cleaned) "已清理" else "已记录", style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
         }
-        Spacer(Modifier.height(5.dp))
-        Text(record.result.ifBlank { "任务已完成" }, fontSize = 13.sp, lineHeight = 20.sp, color = MaterialTheme.colorScheme.onSurfaceVariant,
-            maxLines = if (expanded) Int.MAX_VALUE else 2, overflow = TextOverflow.Ellipsis)
-        Spacer(Modifier.height(8.dp))
-        Text("${Formatter.formatFileSize(context, record.bytes)} · ${record.files} 项 · ${if (record.cleaned) "已清理" else "已记录"}",
-            fontSize = 12.sp, lineHeight = 19.sp, fontWeight = FontWeight.Medium, color = accent)
     }
 }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/HomeRoute.kt
@@ -6,6 +6,7 @@ import io.github.xgl34222220.baize.DashboardUiState
 import io.github.xgl34222220.baize.SchedulerUiState
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.home.miuix.VideoHomeScreenMiuix
+import io.github.xgl34222220.baize.ui.home.miuix.LuoShuHomeScreen
 import io.github.xgl34222220.baize.ui.miuix.ProvideVideoSkin
 import io.github.xgl34222220.baize.ui.miuix.VideoSkin
 
@@ -23,6 +24,7 @@ fun HomeRoute(
         UiStyle.MIUIX -> VideoSkin.MIUIX
     }
     ProvideVideoSkin(skin) {
-        VideoHomeScreenMiuix(state, scheduler, actions, onOpenClean, onOpenPlan)
+        if (style == UiStyle.MIUIX) LuoShuHomeScreen(state, scheduler, actions, onOpenClean, onOpenPlan)
+        else VideoHomeScreenMiuix(state, scheduler, actions, onOpenClean, onOpenPlan)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/LuoShuHomeScreen.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/LuoShuHomeScreen.kt
@@ -1,0 +1,222 @@
+package io.github.xgl34222220.baize.ui.home.miuix
+
+import android.text.format.Formatter
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.BuildConfig
+import io.github.xgl34222220.baize.DashboardActions
+import io.github.xgl34222220.baize.DashboardUiState
+import io.github.xgl34222220.baize.SchedulerUiState
+import io.github.xgl34222220.baize.ui.home.*
+import io.github.xgl34222220.baize.ui.miuix.*
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+import kotlin.math.roundToInt
+
+/** LuoShu HomeRoute -> HomeScreenCompact hierarchy, with BaiZe's real state and actions. */
+@Composable
+fun LuoShuHomeScreen(state: DashboardUiState, scheduler: SchedulerUiState, actions: DashboardActions,
+    onOpenClean: () -> Unit, onOpenPlan: () -> Unit) {
+    val context = LocalContext.current
+    val now = rememberHomeNowEpoch()
+    val next = scheduler.homeTaskItems().nextTask(now)
+    val bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = bottom + 118.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        item(key = "header") {
+            LuoShuPageHeader("白泽") {
+                LuoShuHeaderButton(Icons.Rounded.Refresh, "刷新状态", actions.refresh)
+            }
+        }
+        item(key = "space") { SpaceHero(state, actions) }
+        // Keep the real plan reachable in the first regular-size viewport, not behind statistics.
+        item(key = "plan") {
+            LuoShuGroup {
+                LuoShuNavigationRow(Icons.Rounded.CalendarMonth, "自动清理",
+                    if (scheduler.enabled) taskCountdownLabel(next, now, scheduler) else "设置时间，让白泽按计划整理",
+                    onOpenPlan)
+            }
+        }
+        item(key = "shortcuts") {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                LuoShuSection("常用工具", "先看清文件，再决定清理哪些")
+                BoxWithConstraints(Modifier.fillMaxWidth()) {
+                    if (maxWidth.value / LocalDensity.current.fontScale < 240f) {
+                        Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                            LuoShuShortcut("安装包", "查找 · 选择 · 清理", Icons.Rounded.InstallMobile, actions.apkScan, Modifier.fillMaxWidth())
+                            LuoShuShortcut("文件归类", "整理散落的文件", Icons.Rounded.FolderCopy, actions.organize, Modifier.fillMaxWidth())
+                        }
+                    } else Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        LuoShuShortcut("安装包", "查找 · 选择 · 清理", Icons.Rounded.InstallMobile, actions.apkScan, Modifier.weight(1f))
+                        LuoShuShortcut("文件归类", "整理散落的文件", Icons.Rounded.FolderCopy, actions.organize, Modifier.weight(1f))
+                    }
+                }
+                LuoShuGroup {
+                    LuoShuNavigationRow(Icons.Rounded.CleaningServices, "深度清理", "查看应用占用、缓存与残留", actions.deep)
+                    LuoShuGroupDivider()
+                    LuoShuNavigationRow(Icons.Rounded.Shield, "白名单", "保留指定应用与路径", actions.whitelist)
+                    LuoShuGroupDivider()
+                    LuoShuNavigationRow(Icons.Rounded.Tune, "全部工具", "清理类别与自动计划", onOpenClean)
+                }
+            }
+        }
+        item(key = "history") {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                LuoShuSection("清理记录")
+                LuoShuGroup {
+                    Row(Modifier.fillMaxWidth().padding(20.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        Metric("累计释放", Formatter.formatFileSize(context, state.lifetimeReleased), Modifier.weight(1f))
+                        Metric("完成清理", "${state.lifetimeRuns} 次", Modifier.weight(1f))
+                    }
+                    if (state.lastTaskTime.isNotBlank()) Text(
+                        "上次清理 ${state.lastTaskTime} · 释放 ${Formatter.formatFileSize(context, state.lastReleased)}",
+                        Modifier.padding(start = 20.dp, end = 20.dp, bottom = 18.dp),
+                        style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            }
+        }
+        if (!state.running && state.ready && !state.scanCompleted) item(key = "rule-clean") {
+            TextButton(onClick = actions.clean, modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp)) {
+                Text("按现有规则清理")
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpaceHero(state: DashboardUiState, actions: DashboardActions) {
+    val scheme = MaterialTheme.colorScheme
+    val colors = BaiZeTokens.colors
+    val context = LocalContext.current
+    val progress = if (state.taskProgressTotal > 0)
+        (state.taskProgressCurrent.toFloat() / state.taskProgressTotal).coerceIn(0f, 1f) else 0f
+    val hasResults = state.scanCompleted && state.scanFiles > 0
+    val value = when {
+        state.running && state.taskProgressTotal > 0 -> "${(progress * 100).roundToInt()}%"
+        state.running -> "处理中"
+        hasResults && state.scanBytes > 0 -> Formatter.formatFileSize(context, state.scanBytes)
+        hasResults -> "${state.scanFiles} 项"
+        state.scanCompleted && state.scanErrors > 0 -> "未完成"
+        state.scanCompleted -> "已扫描"
+        state.storageTotal > 0 -> Formatter.formatFileSize(context, state.storageFree)
+        else -> "—"
+    }
+    val label = when {
+        state.running -> "当前任务"
+        hasResults -> "本次可清理"
+        state.scanCompleted && state.scanErrors > 0 -> "扫描有异常"
+        state.scanCompleted -> "暂无待清理文件"
+        else -> "可用空间"
+    }
+    val description = when {
+        state.running -> state.taskPhase.ifBlank { "正在处理文件" }
+        hasResults -> "发现 ${state.scanFiles} 个可清理文件" + if (state.scanErrors > 0) " · ${state.scanErrors} 处未完成" else ""
+        state.scanCompleted && state.scanErrors > 0 -> "${state.scanErrors} 处扫描异常，请查看记录后重试"
+        state.scanCompleted -> "本次扫描未发现可清理文件"
+        !state.ready -> state.serviceText
+        state.storageTotal > 0 -> "已用 ${Formatter.formatFileSize(context, state.storageUsed)} · 共 ${Formatter.formatFileSize(context, state.storageTotal)}"
+        else -> "扫描缓存、安装包与应用残留"
+    }
+    val status = when {
+        state.running -> "任务进行中"
+        state.connectionFailed -> "连接异常"
+        state.ready -> "服务已就绪"
+        state.connecting -> "正在连接"
+        else -> "等待连接"
+    }
+    val actionLabel = when {
+        state.running -> "停止当前任务"
+        hasResults -> "清理扫描结果"
+        state.scanCompleted -> "重新扫描"
+        state.connecting -> "正在连接…"
+        !state.ready -> "连接 Root 服务"
+        else -> "开始扫描"
+    }
+    val action = when {
+        state.running -> actions.stop
+        hasResults -> actions.cleanScan
+        state.scanCompleted -> actions.scan
+        !state.ready -> actions.reconnect
+        else -> actions.scan
+    }
+    Surface(shape = RoundedCornerShape(28.dp), color = colors.surfaceRaised, shadowElevation = 2.dp) {
+        Column(Modifier.fillMaxWidth()
+            .background(Brush.linearGradient(listOf(scheme.primaryContainer.copy(alpha = .46f), colors.surfaceRaised)))
+            .padding(22.dp), verticalArrangement = Arrangement.spacedBy(18.dp)) {
+            BoxWithConstraints(Modifier.fillMaxWidth()) {
+                val compact = maxWidth.value / LocalDensity.current.fontScale < 230f
+                val badge: @Composable () -> Unit = {
+                    Surface(shape = CircleShape, color = colors.surfaceRaised.copy(alpha = .72f)) {
+                        Row(Modifier.padding(horizontal = 10.dp, vertical = 6.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Box(Modifier.size(6.dp).background(if (state.ready) colors.success else colors.warning, CircleShape))
+                            Spacer(Modifier.width(6.dp))
+                            Text(status, style = MaterialTheme.typography.labelMedium)
+                        }
+                    }
+                }
+                if (compact) Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    badge()
+                    Text(BuildConfig.VERSION_NAME, style = MaterialTheme.typography.labelMedium, color = scheme.onSurfaceVariant)
+                } else Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    badge()
+                    Spacer(Modifier.weight(1f))
+                    Text(BuildConfig.VERSION_NAME, style = MaterialTheme.typography.labelMedium, color = scheme.onSurfaceVariant)
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text(label, style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant)
+                Text(value, fontSize = 32.sp, lineHeight = 40.sp, fontWeight = FontWeight.SemiBold,
+                    maxLines = 2, overflow = TextOverflow.Ellipsis)
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                if (state.running && state.taskProgressTotal <= 0) {
+                    LinearProgressIndicator(Modifier.fillMaxWidth().height(5.dp))
+                } else if (state.running || (!state.scanCompleted && state.storageTotal > 0)) {
+                    LinearProgressIndicator(progress = { if (state.running) progress else state.storagePercent.coerceIn(0f, 1f) },
+                        modifier = Modifier.fillMaxWidth().height(5.dp))
+                }
+                Text(description, style = MaterialTheme.typography.bodySmall,
+                    color = if (state.scanCompleted && state.scanErrors > 0) colors.warning else scheme.onSurfaceVariant)
+            }
+            Button(onClick = action, enabled = state.running || !state.connecting || state.scanCompleted,
+                modifier = Modifier.fillMaxWidth().heightIn(min = 50.dp), shape = RoundedCornerShape(18.dp)) {
+                Icon(when {
+                    state.running -> Icons.Rounded.Stop
+                    hasResults -> Icons.Rounded.CleaningServices
+                    !state.ready && !state.scanCompleted -> Icons.Rounded.Security
+                    else -> Icons.Rounded.Search
+                }, null, Modifier.size(20.dp))
+                Spacer(Modifier.width(8.dp))
+                Text(actionLabel, style = MaterialTheme.typography.labelLarge)
+            }
+            if (!state.running && state.scanCompleted) Column(Modifier.fillMaxWidth()) {
+                if (hasResults) TextButton(actions.scan, Modifier.fillMaxWidth()) { Text("重新扫描") }
+                TextButton(actions.dismissScan, Modifier.fillMaxWidth()) { Text("收起结果") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Metric(label: String, value: String, modifier: Modifier) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(value, style = MaterialTheme.typography.titleLarge)
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/VideoHomeScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/VideoHomeScreenMiuix.kt
@@ -1,64 +1,27 @@
 package io.github.xgl34222220.baize.ui.home.miuix
 
 import android.text.format.Formatter
-import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.CalendarMonth
-import androidx.compose.material.icons.rounded.ChevronRight
-import androidx.compose.material.icons.rounded.CleaningServices
-import androidx.compose.material.icons.rounded.FolderCopy
-import androidx.compose.material.icons.rounded.InstallMobile
-import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.Search
-import androidx.compose.material.icons.rounded.Security
-import androidx.compose.material.icons.rounded.Shield
-import androidx.compose.material.icons.rounded.Stop
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -69,16 +32,11 @@ import io.github.xgl34222220.baize.ui.home.homeTaskItems
 import io.github.xgl34222220.baize.ui.home.nextTask
 import io.github.xgl34222220.baize.ui.home.rememberHomeNowEpoch
 import io.github.xgl34222220.baize.ui.home.taskCountdownLabel
-import io.github.xgl34222220.baize.ui.miuix.GlassActionButton
-import io.github.xgl34222220.baize.ui.miuix.VideoCard
-import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
-import io.github.xgl34222220.baize.ui.miuix.VideoStatusPill
-import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
-import io.github.xgl34222220.baize.ui.miuix.glassSurface
+import io.github.xgl34222220.baize.ui.miuix.*
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import kotlin.math.roundToInt
 
-/** Storage, task progress and scan results each retain their real meaning in the same primary card. */
+/** A primary scan action, a compact tool group, then the real automatic plan. */
 @Composable
 fun VideoHomeScreenMiuix(
     state: DashboardUiState,
@@ -90,10 +48,9 @@ fun VideoHomeScreenMiuix(
     val context = LocalContext.current
     val scheme = MaterialTheme.colorScheme
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-    val nowEpoch = rememberHomeNowEpoch()
-    val nextTask = scheduler.homeTaskItems().nextTask(nowEpoch)
-    val horizontal = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth()
-
+    val now = rememberHomeNowEpoch()
+    val next = scheduler.homeTaskItems().nextTask(now)
+    val inset = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth()
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = bottomInset + 118.dp),
@@ -104,31 +61,31 @@ fun VideoHomeScreenMiuix(
                 VideoIconButton(Icons.Rounded.Refresh, "刷新状态", actions.refresh)
             })
         }
-        item(key = "space") {
-            HomeSpaceCard(state, actions, horizontal)
-        }
-        item(key = "shortcuts") {
-            Column(horizontal, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        item(key = "space") { HomeSpaceCard(state, actions, inset) }
+        item(key = "tools") {
+            Column(inset, verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                     Text("常用工具", Modifier.weight(1f), style = MaterialTheme.typography.titleMedium)
-                    TextButton(onClick = onOpenClean, contentPadding = PaddingValues(start = 10.dp),
-                        modifier = Modifier.heightIn(min = 44.dp)) {
+                    TextButton(onClick = onOpenClean, modifier = Modifier.heightIn(min = 48.dp),
+                        contentPadding = PaddingValues(start = 10.dp)) {
                         Text("全部工具", style = MaterialTheme.typography.labelMedium)
                         Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp))
                     }
                 }
                 val tools = listOf(
-                    HomeTool(Icons.Rounded.InstallMobile, "安装包", "查找并清理安装文件", scheme.primary, actions.apkScan),
-                    HomeTool(Icons.Rounded.FolderCopy, "文件归类", "整理散落的文件", scheme.tertiary, actions.organize),
-                    HomeTool(Icons.Rounded.CleaningServices, "深度清理", "查看应用占用与残留", scheme.primary, actions.deep),
-                    HomeTool(Icons.Rounded.Shield, "白名单", "保留指定应用与路径", scheme.tertiary, actions.whitelist)
+                    HomeTool(Icons.Rounded.InstallMobile, "安装包", "查找并清理安装文件", actions.apkScan),
+                    HomeTool(Icons.Rounded.FolderCopy, "文件归类", "整理散落的文件", actions.organize),
+                    HomeTool(Icons.Rounded.CleaningServices, "深度清理", "查看应用占用与残留", actions.deep),
+                    HomeTool(Icons.Rounded.Shield, "白名单", "保留指定应用与路径", actions.whitelist)
                 )
-                BoxWithConstraints(Modifier.fillMaxWidth()) {
-                    val columns = if (maxWidth.value / LocalDensity.current.fontScale < 220f) 1 else 2
-                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                        tools.chunked(columns).forEach { group ->
-                            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                                group.forEach { tool -> HomeToolCard(tool, Modifier.weight(1f)) }
+                VideoCard {
+                    BoxWithConstraints(Modifier.fillMaxWidth().padding(8.dp)) {
+                        val columns = if (maxWidth.value / LocalDensity.current.fontScale >= 300f) 4 else 2
+                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            tools.chunked(columns).forEach { group ->
+                                Row(Modifier.fillMaxWidth()) {
+                                    group.forEach { tool -> HomeToolCell(tool, Modifier.weight(1f)) }
+                                }
                             }
                         }
                     }
@@ -136,38 +93,32 @@ fun VideoHomeScreenMiuix(
             }
         }
         item(key = "activity") {
-            Column(horizontal, verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                Text("清理与计划", Modifier.padding(top = 8.dp, bottom = 2.dp),
+            Column(inset, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("自动清理与记录", Modifier.padding(top = 8.dp, bottom = 2.dp),
                     style = MaterialTheme.typography.titleMedium)
                 VideoCard {
-                    Row(Modifier.fillMaxWidth().padding(20.dp),
+                    VideoListRow(Icons.Rounded.CalendarMonth, "自动清理",
+                        if (scheduler.enabled) taskCountdownLabel(next, now, scheduler) else "设置清理时间与保留规则",
+                        value = if (scheduler.enabled) "已开启" else "未开启", onClick = onOpenPlan)
+                    VideoDivider(start = 20)
+                    Row(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
                         horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                         HomeMetric("累计释放", Formatter.formatFileSize(context, state.lifetimeReleased), Modifier.weight(1f))
                         HomeMetric("完成清理", "${state.lifetimeRuns} 次", Modifier.weight(1f))
                     }
-                    HorizontalDivider(Modifier.padding(horizontal = 20.dp),
-                        color = scheme.onSurface.copy(alpha = .055f))
-                    Row(Modifier.fillMaxWidth().clickable(role = Role.Button, onClick = onOpenPlan)
-                        .padding(20.dp), verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        HomeIcon(Icons.Rounded.CalendarMonth, scheme.primary)
-                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                            Text("自动清理", style = MaterialTheme.typography.titleMedium)
-                            Text(if (scheduler.enabled) taskCountdownLabel(nextTask, nowEpoch, scheduler)
-                                else "设置清理时间与保留规则",
-                                style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant)
-                            Text(if (scheduler.enabled) "已开启" else "未开启",
-                                style = MaterialTheme.typography.labelSmall,
-                                color = if (scheduler.enabled) BaiZeTokens.colors.success else scheme.onSurfaceVariant)
-                        }
-                        Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp),
-                            tint = scheme.onSurfaceVariant.copy(alpha = .55f))
-                    }
                     if (state.lastTaskTime.isNotBlank()) {
                         Text("上次清理 ${state.lastTaskTime} · 释放 ${Formatter.formatFileSize(context, state.lastReleased)}",
-                            modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, bottom = 18.dp),
+                            Modifier.padding(start = 20.dp, end = 20.dp, bottom = 18.dp),
                             style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant)
                     }
+                }
+            }
+        }
+        // Retain the existing rule-clean action, but do not compete with scan-first flow.
+        if (!state.running && state.ready && !state.scanCompleted) {
+            item(key = "rule-clean") {
+                TextButton(onClick = actions.clean, modifier = inset.heightIn(min = 48.dp)) {
+                    Text("按现有规则清理", style = MaterialTheme.typography.labelMedium, color = scheme.onSurfaceVariant)
                 }
             }
         }
@@ -190,7 +141,7 @@ private fun HomeSpaceCard(state: DashboardUiState, actions: DashboardActions, mo
         state.storageTotal > 0 -> Formatter.formatFileSize(context, state.storageFree)
         else -> "—"
     }
-    val valueLabel = when {
+    val label = when {
         state.running -> "当前任务"
         state.scanCompleted && state.scanFiles > 0 -> "本次可清理"
         state.scanCompleted && state.scanErrors > 0 -> "扫描有异常"
@@ -209,13 +160,8 @@ private fun HomeSpaceCard(state: DashboardUiState, actions: DashboardActions, mo
     }
     val accent = if (state.scanCompleted && state.scanErrors > 0 && !state.running)
         BaiZeTokens.colors.warning else scheme.primary
-    val shape = RoundedCornerShape(28.dp)
-    val cardColor = BaiZeTokens.colors.surfaceRaised
-    Surface(modifier = modifier.glassSurface(cardColor, shape, scheme.surface.luminance() < .3f),
-        shape = shape, color = Color.Transparent, contentColor = scheme.onSurface) {
-        BoxWithConstraints(Modifier.fillMaxWidth()
-            .background(Brush.linearGradient(listOf(scheme.primaryContainer.copy(alpha = .46f), Color.Transparent)))
-            .padding(22.dp)) {
+    VideoCard(modifier, containerColor = lerp(BaiZeTokens.colors.surfaceRaised, scheme.primary, .035f)) {
+        BoxWithConstraints(Modifier.fillMaxWidth().padding(20.dp)) {
             val compact = maxWidth.value / LocalDensity.current.fontScale < 220f
             Column(Modifier.fillMaxWidth()) {
                 if (compact) {
@@ -229,53 +175,40 @@ private fun HomeSpaceCard(state: DashboardUiState, actions: DashboardActions, mo
                         HomeServiceStatus(state)
                     }
                 }
-                Spacer(Modifier.height(18.dp))
-                Text(value, color = scheme.onSurface, style = BaiZeTokens.type.hero.copy(
-                    fontSize = if (value.length > 9) 36.sp else 42.sp,
-                    lineHeight = if (value.length > 9) 43.sp else 50.sp,
+                Spacer(Modifier.height(14.dp))
+                Text(value, style = BaiZeTokens.type.hero.copy(
+                    fontSize = if (value.length > 9) 34.sp else 40.sp,
+                    lineHeight = if (value.length > 9) 42.sp else 48.sp,
                     fontWeight = FontWeight.SemiBold, letterSpacing = (-1.2).sp),
                     maxLines = 2, overflow = TextOverflow.Ellipsis)
-                Spacer(Modifier.height(2.dp))
                 Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Text(valueLabel, Modifier.weight(1f), color = scheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.bodyMedium)
-                    when {
-                        state.running -> Text("${state.taskProgressFiles} 个文件",
-                            style = MaterialTheme.typography.labelSmall, color = accent)
-                        !state.scanCompleted && state.storageTotal > 0 -> Text(
-                            "${(state.storagePercent.coerceIn(0f, 1f) * 100).roundToInt()}% 已使用",
+                    Text(label, Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium, color = scheme.onSurfaceVariant)
+                    if (!state.running && !state.scanCompleted && state.storageTotal > 0) {
+                        Text("${(state.storagePercent.coerceIn(0f, 1f) * 100).roundToInt()}% 已使用",
                             style = MaterialTheme.typography.labelSmall, color = scheme.primary)
                     }
                 }
                 Spacer(Modifier.height(16.dp))
-                when {
-                    state.running -> {
-                        if (state.taskProgressTotal > 0) LinearProgressIndicator(
-                            progress = { progress }, modifier = Modifier.fillMaxWidth().height(6.dp),
-                            color = accent, trackColor = accent.copy(alpha = .10f))
-                        else LinearProgressIndicator(modifier = Modifier.fillMaxWidth().height(6.dp),
-                            color = accent, trackColor = accent.copy(alpha = .10f))
-                        Spacer(Modifier.height(8.dp))
+                if (state.running || (!state.scanCompleted && state.storageTotal > 0)) {
+                    if (state.running && state.taskProgressTotal <= 0) {
+                        LinearProgressIndicator(Modifier.fillMaxWidth().height(6.dp), color = accent,
+                            trackColor = accent.copy(alpha = .10f))
+                    } else {
+                        LinearProgressIndicator(progress = { if (state.running) progress else state.storagePercent.coerceIn(0f, 1f) },
+                            modifier = Modifier.fillMaxWidth().height(6.dp), color = accent, trackColor = accent.copy(alpha = .10f))
                     }
-                    !state.scanCompleted && state.storageTotal > 0 -> {
-                        StorageSegments(state.storagePercent)
-                        Spacer(Modifier.height(8.dp))
-                    }
+                    Spacer(Modifier.height(10.dp))
                 }
-                Text(description, Modifier.padding(top = 4.dp), style = MaterialTheme.typography.bodySmall,
+                Text(description, style = MaterialTheme.typography.bodySmall,
                     color = if (state.scanCompleted && state.scanErrors > 0) accent else scheme.onSurfaceVariant)
                 Spacer(Modifier.height(18.dp))
                 HomePrimaryAction(state, actions)
-                if (!state.running && (state.ready || state.scanCompleted)) {
-                    if (compact) {
-                        Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                            HomeSecondaryActions(state, actions)
-                        }
-                    } else {
-                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
-                            HomeSecondaryActions(state, actions)
-                        }
+                if (!state.running && state.scanCompleted) {
+                    if (compact) Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                        HomeSecondaryActions(state, actions)
+                    } else Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                        HomeSecondaryActions(state, actions)
                     }
                 }
             }
@@ -285,15 +218,13 @@ private fun HomeSpaceCard(state: DashboardUiState, actions: DashboardActions, mo
 
 @Composable
 private fun HomeServiceStatus(state: DashboardUiState) {
-    VideoStatusPill(
-        when {
-            state.running -> "任务进行中"
-            state.connectionFailed -> "连接异常"
-            state.ready -> "服务已就绪"
-            state.connecting -> "正在连接"
-            else -> "等待连接"
-        }, positive = state.ready && !state.running && !state.connectionFailed
-    )
+    VideoStatusPill(when {
+        state.running -> "任务进行中"
+        state.connectionFailed -> "连接异常"
+        state.ready -> "服务已就绪"
+        state.connecting -> "正在连接"
+        else -> "等待连接"
+    }, positive = state.ready && !state.running && !state.connectionFailed)
 }
 
 @Composable
@@ -323,89 +254,38 @@ private fun HomePrimaryAction(state: DashboardUiState, actions: DashboardActions
 
 @Composable
 private fun HomeSecondaryActions(state: DashboardUiState, actions: DashboardActions) {
-    if (!state.scanCompleted || state.scanFiles > 0) {
-        TextButton(onClick = if (state.scanCompleted) actions.scan else actions.clean,
-            modifier = Modifier.heightIn(min = 44.dp)) {
-            Text(if (state.scanCompleted) "重新扫描" else "按现有规则清理",
-                style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        }
+    if (state.scanFiles > 0) TextButton(onClick = actions.scan, modifier = Modifier.heightIn(min = 48.dp)) {
+        Text("重新扫描", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
-    if (state.scanCompleted) TextButton(onClick = actions.dismissScan, modifier = Modifier.heightIn(min = 44.dp)) {
-        Text("收起结果", style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant)
+    TextButton(onClick = actions.dismissScan, modifier = Modifier.heightIn(min = 48.dp)) {
+        Text("收起结果", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
-/** The single continuous ratio is divided visually, without implying invented storage categories. */
-@Composable
-private fun StorageSegments(usedFraction: Float) {
-    val fraction = usedFraction.coerceIn(0f, 1f)
-    val primary = MaterialTheme.colorScheme.primary
-    val secondary = MaterialTheme.colorScheme.tertiary
-    val track = primary.copy(alpha = .09f)
-    Canvas(Modifier.fillMaxWidth().height(8.dp).semantics {
-        contentDescription = "存储空间已使用 ${(fraction * 100).roundToInt()}%"
-    }) {
-        val count = 24
-        val gap = 3.dp.toPx()
-        val segment = (size.width - gap * (count - 1)) / count
-        val radius = CornerRadius(2.dp.toPx())
-        repeat(count) { index ->
-            drawRoundRect(track, topLeft = Offset(index * (segment + gap), 0f),
-                size = Size(segment, size.height), cornerRadius = radius)
-        }
-        clipRect(right = size.width * fraction) {
-            val fill = Brush.horizontalGradient(listOf(primary, lerp(primary, secondary, .55f)))
-            repeat(count) { index ->
-                drawRoundRect(fill, topLeft = Offset(index * (segment + gap), 0f),
-                    size = Size(segment, size.height), cornerRadius = radius)
-            }
-        }
-    }
-}
+private data class HomeTool(val icon: ImageVector, val title: String, val description: String, val onClick: () -> Unit)
 
 @Composable
-private fun HomeToolCard(tool: HomeTool, modifier: Modifier) {
-    val scheme = MaterialTheme.colorScheme
-    VideoCard(modifier) {
-        Column(Modifier.fillMaxWidth().clickable(role = Role.Button, onClick = tool.onClick)
-            .heightIn(min = 132.dp).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                HomeIcon(tool.icon, tool.color)
-                Spacer(Modifier.weight(1f))
-                Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp),
-                    tint = scheme.onSurfaceVariant.copy(alpha = .38f))
-            }
-            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
-                Text(tool.title, style = MaterialTheme.typography.titleMedium, color = scheme.onSurface)
-                Text(tool.description, style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant, minLines = 2)
-            }
+private fun HomeToolCell(tool: HomeTool, modifier: Modifier) {
+    val tint = MaterialTheme.colorScheme.primary
+    Column(modifier.clip(RoundedCornerShape(18.dp))
+        .clickable(role = Role.Button, onClickLabel = tool.description, onClick = tool.onClick)
+        .padding(horizontal = 4.dp, vertical = 14.dp),
+        horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Box(Modifier.size(40.dp).clip(RoundedCornerShape(14.dp))
+            .background(Brush.verticalGradient(listOf(tint.copy(alpha = .12f), tint.copy(alpha = .04f)))),
+            contentAlignment = Alignment.Center) {
+            Icon(tool.icon, null, Modifier.size(22.dp), tint = tint)
         }
+        Text(tool.title, style = MaterialTheme.typography.labelLarge, textAlign = TextAlign.Center,
+            maxLines = 2, overflow = TextOverflow.Ellipsis)
     }
 }
-
-@Composable
-private fun HomeIcon(icon: ImageVector, tint: Color) {
-    Box(Modifier.size(38.dp).clip(RoundedCornerShape(13.dp))
-        .background(Brush.verticalGradient(listOf(tint.copy(alpha = .12f), tint.copy(alpha = .04f)))),
-        contentAlignment = Alignment.Center) {
-        Icon(icon, null, Modifier.size(21.dp), tint = tint)
-    }
-}
-
-private data class HomeTool(
-    val icon: ImageVector,
-    val title: String,
-    val description: String,
-    val color: Color,
-    val onClick: () -> Unit
-)
 
 @Composable
 private fun HomeMetric(label: String, value: String, modifier: Modifier) {
     Column(modifier, verticalArrangement = Arrangement.spacedBy(5.dp)) {
         Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
         Text(value, style = BaiZeTokens.type.display.copy(fontSize = 23.sp, lineHeight = 29.sp),
-            color = MaterialTheme.colorScheme.onSurface, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            maxLines = 2, overflow = TextOverflow.Ellipsis)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/VideoHomeScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/home/miuix/VideoHomeScreenMiuix.kt
@@ -20,13 +20,10 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.CalendarMonth
-import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.CleaningServices
 import androidx.compose.material.icons.rounded.FolderCopy
@@ -36,30 +33,33 @@ import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.Shield
 import androidx.compose.material.icons.rounded.Stop
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.xgl34222220.baize.DashboardActions
@@ -74,12 +74,11 @@ import io.github.xgl34222220.baize.ui.miuix.VideoCard
 import io.github.xgl34222220.baize.ui.miuix.VideoIconButton
 import io.github.xgl34222220.baize.ui.miuix.VideoStatusPill
 import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
+import io.github.xgl34222220.baize.ui.miuix.glassSurface
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
-import kotlin.math.cos
 import kotlin.math.roundToInt
-import kotlin.math.sin
 
-/** The dial reports real storage or task state; it never invents a cleanliness score. */
+/** Storage, task progress and scan results each retain their real meaning in the same primary card. */
 @Composable
 fun VideoHomeScreenMiuix(
     state: DashboardUiState,
@@ -93,7 +92,7 @@ fun VideoHomeScreenMiuix(
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val nowEpoch = rememberHomeNowEpoch()
     val nextTask = scheduler.homeTaskItems().nextTask(nowEpoch)
-    val horizontal = Modifier.padding(horizontal = 20.dp).fillMaxWidth()
+    val horizontal = Modifier.padding(horizontal = BaiZeTokens.spacing.pageHorizontal).fillMaxWidth()
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -106,159 +105,81 @@ fun VideoHomeScreenMiuix(
             })
         }
         item(key = "space") {
-            Column(horizontal, horizontalAlignment = Alignment.CenterHorizontally) {
-                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    Text("空间概览", style = MaterialTheme.typography.labelLarge, color = scheme.onSurfaceVariant)
-                    Spacer(Modifier.weight(1f))
-                    VideoStatusPill(
-                        when {
-                            state.running -> "任务进行中"
-                            state.connectionFailed -> "连接异常"
-                            state.ready -> "服务已就绪"
-                            state.connecting -> "正在连接"
-                            else -> "等待连接"
-                        },
-                        positive = state.ready && !state.running && !state.connectionFailed
-                    )
-                }
-                Spacer(Modifier.height(4.dp))
-                StorageDial(state)
-                Spacer(Modifier.height(6.dp))
-                val description = when {
-                    state.running -> state.taskPhase.ifBlank { "正在处理文件" }
-                    state.scanCompleted && state.scanFiles > 0 -> "发现 ${state.scanFiles} 个可清理文件" +
-                        if (state.scanErrors > 0) " · ${state.scanErrors} 处未完成" else ""
-                    state.scanCompleted && state.scanErrors > 0 -> "${state.scanErrors} 处扫描异常，请查看记录后重试"
-                    state.scanCompleted -> "本次扫描未发现可清理文件"
-                    !state.ready -> state.serviceText
-                    state.storageTotal > 0 -> "已用 ${Formatter.formatFileSize(context, state.storageUsed)} · 共 ${Formatter.formatFileSize(context, state.storageTotal)}"
-                    else -> "扫描缓存、安装包与应用残留"
-                }
-                Text(description, style = MaterialTheme.typography.bodySmall,
-                    color = scheme.onSurfaceVariant, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                Spacer(Modifier.height(14.dp))
-                val label = when {
-                    state.running -> "停止当前任务"
-                    state.scanCompleted && state.scanFiles > 0 -> "清理扫描结果"
-                    state.scanCompleted -> "重新扫描"
-                    state.connecting -> "正在连接…"
-                    !state.ready -> "连接 Root 服务"
-                    else -> "开始扫描"
-                }
-                val action = when {
-                    state.running -> actions.stop
-                    state.scanCompleted && state.scanFiles > 0 -> actions.cleanScan
-                    state.scanCompleted -> actions.scan
-                    !state.ready -> actions.reconnect
-                    else -> actions.scan
-                }
-                GlassActionButton(
-                    label, action, Modifier.fillMaxWidth(),
-                    icon = when {
-                        state.running -> Icons.Rounded.Stop
-                        state.scanCompleted && state.scanFiles > 0 -> Icons.Rounded.CleaningServices
-                        !state.ready && !state.scanCompleted -> Icons.Rounded.Security
-                        else -> Icons.Rounded.Search
-                    },
-                    enabled = state.running || !state.connecting || state.scanCompleted
-                )
-                if (!state.running && (state.ready || state.scanCompleted)) {
-                    Row(horizontalArrangement = Arrangement.Center) {
-                        if (!state.scanCompleted || state.scanFiles > 0) {
-                            TextButton(onClick = if (state.scanCompleted) actions.scan else actions.clean,
-                                modifier = Modifier.heightIn(min = 44.dp)) {
-                                Text(if (state.scanCompleted) "重新扫描" else "按现有规则清理",
-                                    style = MaterialTheme.typography.labelMedium, color = scheme.onSurfaceVariant)
-                            }
-                        }
-                        if (state.scanCompleted) TextButton(onClick = actions.dismissScan,
-                            modifier = Modifier.heightIn(min = 44.dp)) {
-                            Text("收起结果", style = MaterialTheme.typography.labelMedium, color = scheme.onSurfaceVariant)
-                        }
-                    }
-                }
-            }
+            HomeSpaceCard(state, actions, horizontal)
         }
         item(key = "shortcuts") {
-            Column(horizontal.padding(vertical = 2.dp)) {
+            Column(horizontal, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                    Text("常用工具", Modifier.weight(1f), style = MaterialTheme.typography.titleMedium)
+                    TextButton(onClick = onOpenClean, contentPadding = PaddingValues(start = 10.dp),
+                        modifier = Modifier.heightIn(min = 44.dp)) {
+                        Text("全部工具", style = MaterialTheme.typography.labelMedium)
+                        Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp))
+                    }
+                }
+                val tools = listOf(
+                    HomeTool(Icons.Rounded.InstallMobile, "安装包", "查找并清理安装文件", scheme.primary, actions.apkScan),
+                    HomeTool(Icons.Rounded.FolderCopy, "文件归类", "整理散落的文件", scheme.tertiary, actions.organize),
+                    HomeTool(Icons.Rounded.CleaningServices, "深度清理", "查看应用占用与残留", scheme.primary, actions.deep),
+                    HomeTool(Icons.Rounded.Shield, "白名单", "保留指定应用与路径", scheme.tertiary, actions.whitelist)
+                )
                 BoxWithConstraints(Modifier.fillMaxWidth()) {
-                    val compact = maxWidth < 300.dp && LocalDensity.current.fontScale > 1.1f
-                    val tools = listOf(
-                        HomeTool(Icons.Rounded.InstallMobile, "安装包", scheme.primary, actions.apkScan),
-                        HomeTool(Icons.Rounded.FolderCopy, "文件归类", Color(0xFF209B91), actions.organize),
-                        HomeTool(Icons.Rounded.CleaningServices, "深度清理", Color(0xFF8874D3), actions.deep),
-                        HomeTool(Icons.Rounded.Shield, "白名单", Color(0xFFBE8A42), actions.whitelist)
-                    )
-                    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        tools.chunked(if (compact) 2 else 4).forEach { group ->
-                            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(if (compact) 8.dp else 2.dp)) {
-                                group.forEach { tool ->
-                                    HomeShortcut(tool.icon, tool.title, tool.color, tool.onClick, Modifier.weight(1f), compact)
-                                }
+                    val columns = if (maxWidth.value / LocalDensity.current.fontScale < 220f) 1 else 2
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        tools.chunked(columns).forEach { group ->
+                            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                                group.forEach { tool -> HomeToolCard(tool, Modifier.weight(1f)) }
                             }
                         }
                     }
                 }
             }
         }
-        item(key = "metrics") {
-            Row(horizontal.padding(horizontal = 4.dp, vertical = 6.dp), verticalAlignment = Alignment.CenterVertically) {
-                HomeMetric("累计释放", Formatter.formatFileSize(context, state.lifetimeReleased), Modifier.weight(1f))
-                Box(Modifier.width(1.dp).height(30.dp).background(scheme.onSurface.copy(alpha = .08f)))
-                HomeMetric("完成清理", "${state.lifetimeRuns} 次", Modifier.weight(1f).padding(start = 18.dp))
-            }
-        }
-        item(key = "plan") {
-            VideoCard(horizontal) {
-                Row(Modifier.fillMaxWidth().clickable(role = Role.Button, onClick = onOpenPlan)
-                    .padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Rounded.CalendarMonth, null, Modifier.size(22.dp), tint = scheme.primary)
-                    Spacer(Modifier.width(12.dp))
-                    Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                            Text("自动清理", Modifier.weight(1f), fontSize = 15.sp, lineHeight = 21.sp, fontWeight = FontWeight.Medium)
-                            Text(if (scheduler.enabled) "已开启" else "未开启", style = MaterialTheme.typography.labelSmall,
+        item(key = "activity") {
+            Column(horizontal, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("清理与计划", Modifier.padding(top = 8.dp, bottom = 2.dp),
+                    style = MaterialTheme.typography.titleMedium)
+                VideoCard {
+                    Row(Modifier.fillMaxWidth().padding(20.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        HomeMetric("累计释放", Formatter.formatFileSize(context, state.lifetimeReleased), Modifier.weight(1f))
+                        HomeMetric("完成清理", "${state.lifetimeRuns} 次", Modifier.weight(1f))
+                    }
+                    HorizontalDivider(Modifier.padding(horizontal = 20.dp),
+                        color = scheme.onSurface.copy(alpha = .055f))
+                    Row(Modifier.fillMaxWidth().clickable(role = Role.Button, onClick = onOpenPlan)
+                        .padding(20.dp), verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        HomeIcon(Icons.Rounded.CalendarMonth, scheme.primary)
+                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Text("自动清理", style = MaterialTheme.typography.titleMedium)
+                            Text(if (scheduler.enabled) taskCountdownLabel(nextTask, nowEpoch, scheduler)
+                                else "设置清理时间与保留规则",
+                                style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant)
+                            Text(if (scheduler.enabled) "已开启" else "未开启",
+                                style = MaterialTheme.typography.labelSmall,
                                 color = if (scheduler.enabled) BaiZeTokens.colors.success else scheme.onSurfaceVariant)
                         }
-                        Text(if (scheduler.enabled) taskCountdownLabel(nextTask, nowEpoch, scheduler) else "设置清理时间与保留规则",
-                            style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant,
-                            maxLines = 3, overflow = TextOverflow.Ellipsis)
+                        Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp),
+                            tint = scheme.onSurfaceVariant.copy(alpha = .55f))
                     }
-                    Spacer(Modifier.width(6.dp))
-                    Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp), tint = scheme.onSurfaceVariant.copy(alpha = .55f))
+                    if (state.lastTaskTime.isNotBlank()) {
+                        Text("上次清理 ${state.lastTaskTime} · 释放 ${Formatter.formatFileSize(context, state.lastReleased)}",
+                            modifier = Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, bottom = 18.dp),
+                            style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant)
+                    }
                 }
-            }
-        }
-        if (state.lastTaskTime.isNotBlank()) item(key = "last-task") {
-            Text("上次清理 ${state.lastTaskTime} · 释放 ${Formatter.formatFileSize(context, state.lastReleased)}",
-                modifier = horizontal.padding(horizontal = 4.dp), style = MaterialTheme.typography.bodySmall,
-                color = scheme.onSurfaceVariant)
-        }
-        item(key = "all-tools") {
-            TextButton(onClick = onOpenClean, modifier = horizontal.heightIn(min = 48.dp)) {
-                Text("查看全部清理工具", style = MaterialTheme.typography.labelLarge)
-                Spacer(Modifier.width(4.dp))
-                Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp))
             }
         }
     }
 }
 
 @Composable
-private fun StorageDial(state: DashboardUiState) {
+private fun HomeSpaceCard(state: DashboardUiState, actions: DashboardActions, modifier: Modifier) {
     val scheme = MaterialTheme.colorScheme
     val context = LocalContext.current
-    val dark = scheme.background.luminance() < .5f
-    val accent = if (state.scanCompleted && state.scanErrors > 0 && !state.running)
-        BaiZeTokens.colors.warning else scheme.primary
-    val progress = when {
-        state.running && state.taskProgressTotal > 0 -> state.taskProgressCurrent.toFloat() / state.taskProgressTotal
-        state.running -> 0f
-        state.scanCompleted && state.scanErrors == 0L -> 1f
-        state.storageTotal > 0 -> state.storagePercent
-        else -> 0f
-    }.coerceIn(0f, 1f)
+    val progress = if (state.taskProgressTotal > 0)
+        (state.taskProgressCurrent.toFloat() / state.taskProgressTotal).coerceIn(0f, 1f) else 0f
     val value = when {
         state.running && state.taskProgressTotal > 0 -> "${(progress * 100).roundToInt()}%"
         state.running -> "处理中"
@@ -269,95 +190,222 @@ private fun StorageDial(state: DashboardUiState) {
         state.storageTotal > 0 -> Formatter.formatFileSize(context, state.storageFree)
         else -> "—"
     }
-    val label = when {
+    val valueLabel = when {
         state.running -> "当前任务"
         state.scanCompleted && state.scanFiles > 0 -> "本次可清理"
         state.scanCompleted && state.scanErrors > 0 -> "扫描有异常"
         state.scanCompleted -> "暂无待清理文件"
         else -> "可用空间"
     }
-    val diameter = 184.dp + (16 * (LocalDensity.current.fontScale - 1f).coerceIn(0f, .5f)).dp
-    val discTop = if (dark) Color(0xFF263546) else Color.White
-    val discBottom = if (dark) Color(0xFF131D2C) else Color(0xFFE4EEF7)
-    Box(Modifier.size(diameter), contentAlignment = Alignment.Center) {
-        Box(Modifier.fillMaxSize(.79f)
-            .shadow(if (dark) 8.dp else 12.dp, CircleShape, clip = false,
-                ambientColor = Color(0xFF5C87B0).copy(alpha = .16f),
-                spotColor = Color(0xFF5C87B0).copy(alpha = .18f))
-            .background(Brush.linearGradient(listOf(discTop, discBottom)), CircleShape))
-        Canvas(Modifier.fillMaxSize()) {
-            val stroke = 4.dp.toPx()
-            val inset = 9.dp.toPx()
-            val arcSize = Size(size.width - inset * 2, size.height - inset * 2)
-            drawArc(accent.copy(alpha = if (dark) .14f else .10f), 135f, 270f, false,
-                topLeft = Offset(inset, inset), size = arcSize, style = Stroke(stroke, cap = StrokeCap.Round))
-            if (progress > 0f) drawArc(
-                brush = Brush.sweepGradient(listOf(accent, lerp(accent, Color(0xFF42C4C0), .45f), accent)),
-                startAngle = 135f, sweepAngle = 270f * progress, useCenter = false,
-                topLeft = Offset(inset, inset), size = arcSize, style = Stroke(stroke, cap = StrokeCap.Round)
-            )
-            val radius = size.minDimension * .5f - inset - 10.dp.toPx()
-            repeat(31) { index ->
-                val angle = Math.toRadians((135 + index * 9).toDouble())
-                val a = Offset(center.x + cos(angle).toFloat() * radius, center.y + sin(angle).toFloat() * radius)
-                val length = if (index % 5 == 0) 4.dp.toPx() else 2.dp.toPx()
-                val b = Offset(center.x + cos(angle).toFloat() * (radius - length), center.y + sin(angle).toFloat() * (radius - length))
-                drawLine(accent.copy(alpha = if (index % 5 == 0) .28f else .13f), a, b, 1.dp.toPx(), StrokeCap.Round)
-            }
-            drawCircle(Brush.linearGradient(listOf(Color.White.copy(alpha = if (dark) .15f else .95f), Color.White.copy(alpha = .02f))),
-                radius = size.minDimension * .39f, style = Stroke(1.dp.toPx()))
-        }
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(5.dp)) {
-            if (state.scanCompleted && state.scanFiles == 0L && state.scanErrors == 0L && !state.running) {
-                Icon(Icons.Rounded.Check, null, Modifier.size(24.dp), tint = BaiZeTokens.colors.success)
-            }
-            Text(label, style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant)
-            Text(value, Modifier.fillMaxWidth(.80f), color = scheme.onSurface,
-                fontSize = if (value.length > 8) 22.sp else 28.sp,
-                lineHeight = 34.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.6).sp,
-                textAlign = TextAlign.Center, maxLines = 2)
-            if (!state.running && !state.scanCompleted && state.storageTotal > 0) {
-                Text("${(state.storagePercent.coerceIn(0f, 1f) * 100).roundToInt()}% 已使用",
-                    style = MaterialTheme.typography.labelSmall, color = accent)
-            } else if (state.running) {
-                Text("${state.taskProgressFiles} 个文件", style = MaterialTheme.typography.labelSmall, color = accent)
+    val description = when {
+        state.running -> state.taskPhase.ifBlank { "正在处理文件" }
+        state.scanCompleted && state.scanFiles > 0 -> "发现 ${state.scanFiles} 个可清理文件" +
+            if (state.scanErrors > 0) " · ${state.scanErrors} 处未完成" else ""
+        state.scanCompleted && state.scanErrors > 0 -> "${state.scanErrors} 处扫描异常，请查看记录后重试"
+        state.scanCompleted -> "本次扫描未发现可清理文件"
+        !state.ready -> state.serviceText
+        state.storageTotal > 0 -> "已用 ${Formatter.formatFileSize(context, state.storageUsed)} · 共 ${Formatter.formatFileSize(context, state.storageTotal)}"
+        else -> "扫描缓存、安装包与应用残留"
+    }
+    val accent = if (state.scanCompleted && state.scanErrors > 0 && !state.running)
+        BaiZeTokens.colors.warning else scheme.primary
+    val shape = RoundedCornerShape(28.dp)
+    val cardColor = BaiZeTokens.colors.surfaceRaised
+    Surface(modifier = modifier.glassSurface(cardColor, shape, scheme.surface.luminance() < .3f),
+        shape = shape, color = Color.Transparent, contentColor = scheme.onSurface) {
+        BoxWithConstraints(Modifier.fillMaxWidth()
+            .background(Brush.linearGradient(listOf(scheme.primaryContainer.copy(alpha = .46f), Color.Transparent)))
+            .padding(22.dp)) {
+            val compact = maxWidth.value / LocalDensity.current.fontScale < 220f
+            Column(Modifier.fillMaxWidth()) {
+                if (compact) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("空间概览", style = MaterialTheme.typography.titleMedium)
+                        HomeServiceStatus(state)
+                    }
+                } else {
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text("空间概览", Modifier.weight(1f), style = MaterialTheme.typography.titleMedium)
+                        HomeServiceStatus(state)
+                    }
+                }
+                Spacer(Modifier.height(18.dp))
+                Text(value, color = scheme.onSurface, style = BaiZeTokens.type.hero.copy(
+                    fontSize = if (value.length > 9) 36.sp else 42.sp,
+                    lineHeight = if (value.length > 9) 43.sp else 50.sp,
+                    fontWeight = FontWeight.SemiBold, letterSpacing = (-1.2).sp),
+                    maxLines = 2, overflow = TextOverflow.Ellipsis)
+                Spacer(Modifier.height(2.dp))
+                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(valueLabel, Modifier.weight(1f), color = scheme.onSurfaceVariant,
+                        style = MaterialTheme.typography.bodyMedium)
+                    when {
+                        state.running -> Text("${state.taskProgressFiles} 个文件",
+                            style = MaterialTheme.typography.labelSmall, color = accent)
+                        !state.scanCompleted && state.storageTotal > 0 -> Text(
+                            "${(state.storagePercent.coerceIn(0f, 1f) * 100).roundToInt()}% 已使用",
+                            style = MaterialTheme.typography.labelSmall, color = scheme.primary)
+                    }
+                }
+                Spacer(Modifier.height(16.dp))
+                when {
+                    state.running -> {
+                        if (state.taskProgressTotal > 0) LinearProgressIndicator(
+                            progress = { progress }, modifier = Modifier.fillMaxWidth().height(6.dp),
+                            color = accent, trackColor = accent.copy(alpha = .10f))
+                        else LinearProgressIndicator(modifier = Modifier.fillMaxWidth().height(6.dp),
+                            color = accent, trackColor = accent.copy(alpha = .10f))
+                        Spacer(Modifier.height(8.dp))
+                    }
+                    !state.scanCompleted && state.storageTotal > 0 -> {
+                        StorageSegments(state.storagePercent)
+                        Spacer(Modifier.height(8.dp))
+                    }
+                }
+                Text(description, Modifier.padding(top = 4.dp), style = MaterialTheme.typography.bodySmall,
+                    color = if (state.scanCompleted && state.scanErrors > 0) accent else scheme.onSurfaceVariant)
+                Spacer(Modifier.height(18.dp))
+                HomePrimaryAction(state, actions)
+                if (!state.running && (state.ready || state.scanCompleted)) {
+                    if (compact) {
+                        Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
+                            HomeSecondaryActions(state, actions)
+                        }
+                    } else {
+                        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
+                            HomeSecondaryActions(state, actions)
+                        }
+                    }
+                }
             }
         }
     }
 }
 
 @Composable
-private fun HomeShortcut(icon: ImageVector, title: String, color: Color, onClick: () -> Unit, modifier: Modifier, compact: Boolean = false) {
-    val dark = MaterialTheme.colorScheme.background.luminance() < .5f
-    val tint = if (dark) lerp(color, Color.White, .25f) else color
-    if (compact) {
-        Row(modifier.clip(RoundedCornerShape(14.dp)).clickable(role = Role.Button, onClick = onClick)
-            .heightIn(min = 56.dp).padding(horizontal = 4.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Box(Modifier.size(32.dp).background(tint.copy(alpha = .08f), RoundedCornerShape(11.dp)),
-                contentAlignment = Alignment.Center) { Icon(icon, null, Modifier.size(20.dp), tint = tint) }
-            Text(title, Modifier.weight(1f), style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurface, maxLines = 2)
+private fun HomeServiceStatus(state: DashboardUiState) {
+    VideoStatusPill(
+        when {
+            state.running -> "任务进行中"
+            state.connectionFailed -> "连接异常"
+            state.ready -> "服务已就绪"
+            state.connecting -> "正在连接"
+            else -> "等待连接"
+        }, positive = state.ready && !state.running && !state.connectionFailed
+    )
+}
+
+@Composable
+private fun HomePrimaryAction(state: DashboardUiState, actions: DashboardActions) {
+    val label = when {
+        state.running -> "停止当前任务"
+        state.scanCompleted && state.scanFiles > 0 -> "清理扫描结果"
+        state.scanCompleted -> "重新扫描"
+        state.connecting -> "正在连接…"
+        !state.ready -> "连接 Root 服务"
+        else -> "开始扫描"
+    }
+    val action = when {
+        state.running -> actions.stop
+        state.scanCompleted && state.scanFiles > 0 -> actions.cleanScan
+        state.scanCompleted -> actions.scan
+        !state.ready -> actions.reconnect
+        else -> actions.scan
+    }
+    GlassActionButton(label, action, Modifier.fillMaxWidth(), icon = when {
+        state.running -> Icons.Rounded.Stop
+        state.scanCompleted && state.scanFiles > 0 -> Icons.Rounded.CleaningServices
+        !state.ready && !state.scanCompleted -> Icons.Rounded.Security
+        else -> Icons.Rounded.Search
+    }, enabled = state.running || !state.connecting || state.scanCompleted)
+}
+
+@Composable
+private fun HomeSecondaryActions(state: DashboardUiState, actions: DashboardActions) {
+    if (!state.scanCompleted || state.scanFiles > 0) {
+        TextButton(onClick = if (state.scanCompleted) actions.scan else actions.clean,
+            modifier = Modifier.heightIn(min = 44.dp)) {
+            Text(if (state.scanCompleted) "重新扫描" else "按现有规则清理",
+                style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
-    } else Column(modifier.clip(RoundedCornerShape(16.dp)).clickable(role = Role.Button, onClick = onClick)
-        .padding(vertical = 8.dp), horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(7.dp)) {
-        Box(Modifier.size(38.dp).background(Brush.verticalGradient(listOf(tint.copy(alpha = .11f), tint.copy(alpha = .035f))),
-            RoundedCornerShape(12.dp)), contentAlignment = Alignment.Center) {
-            Icon(icon, null, Modifier.size(22.dp), tint = tint)
-        }
-        Text(title, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+    if (state.scanCompleted) TextButton(onClick = actions.dismissScan, modifier = Modifier.heightIn(min = 44.dp)) {
+        Text("收起结果", style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
-private data class HomeTool(val icon: ImageVector, val title: String, val color: Color, val onClick: () -> Unit)
+/** The single continuous ratio is divided visually, without implying invented storage categories. */
+@Composable
+private fun StorageSegments(usedFraction: Float) {
+    val fraction = usedFraction.coerceIn(0f, 1f)
+    val primary = MaterialTheme.colorScheme.primary
+    val secondary = MaterialTheme.colorScheme.tertiary
+    val track = primary.copy(alpha = .09f)
+    Canvas(Modifier.fillMaxWidth().height(8.dp).semantics {
+        contentDescription = "存储空间已使用 ${(fraction * 100).roundToInt()}%"
+    }) {
+        val count = 24
+        val gap = 3.dp.toPx()
+        val segment = (size.width - gap * (count - 1)) / count
+        val radius = CornerRadius(2.dp.toPx())
+        repeat(count) { index ->
+            drawRoundRect(track, topLeft = Offset(index * (segment + gap), 0f),
+                size = Size(segment, size.height), cornerRadius = radius)
+        }
+        clipRect(right = size.width * fraction) {
+            val fill = Brush.horizontalGradient(listOf(primary, lerp(primary, secondary, .55f)))
+            repeat(count) { index ->
+                drawRoundRect(fill, topLeft = Offset(index * (segment + gap), 0f),
+                    size = Size(segment, size.height), cornerRadius = radius)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeToolCard(tool: HomeTool, modifier: Modifier) {
+    val scheme = MaterialTheme.colorScheme
+    VideoCard(modifier) {
+        Column(Modifier.fillMaxWidth().clickable(role = Role.Button, onClick = tool.onClick)
+            .heightIn(min = 132.dp).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                HomeIcon(tool.icon, tool.color)
+                Spacer(Modifier.weight(1f))
+                Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp),
+                    tint = scheme.onSurfaceVariant.copy(alpha = .38f))
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(tool.title, style = MaterialTheme.typography.titleMedium, color = scheme.onSurface)
+                Text(tool.description, style = MaterialTheme.typography.bodySmall, color = scheme.onSurfaceVariant, minLines = 2)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HomeIcon(icon: ImageVector, tint: Color) {
+    Box(Modifier.size(38.dp).clip(RoundedCornerShape(13.dp))
+        .background(Brush.verticalGradient(listOf(tint.copy(alpha = .12f), tint.copy(alpha = .04f)))),
+        contentAlignment = Alignment.Center) {
+        Icon(icon, null, Modifier.size(21.dp), tint = tint)
+    }
+}
+
+private data class HomeTool(
+    val icon: ImageVector,
+    val title: String,
+    val description: String,
+    val color: Color,
+    val onClick: () -> Unit
+)
 
 @Composable
 private fun HomeMetric(label: String, value: String, modifier: Modifier) {
-    Column(modifier, verticalArrangement = Arrangement.spacedBy(3.dp)) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(5.dp)) {
         Text(label, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodySmall)
-        Text(value, fontSize = 20.sp, lineHeight = 26.sp, fontWeight = FontWeight.Medium,
-            maxLines = 2)
+        Text(value, style = BaiZeTokens.type.display.copy(fontSize = 23.sp, lineHeight = 29.sp),
+            color = MaterialTheme.colorScheme.onSurface, maxLines = 2, overflow = TextOverflow.Ellipsis)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/GlassComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/GlassComponents.kt
@@ -43,11 +43,11 @@ internal fun Modifier.glassSurface(
     dark: Boolean
 ): Modifier = this
     .shadow(
-        elevation = 8.dp,
+        elevation = 12.dp,
         shape = shape,
         clip = false,
-        ambientColor = Color(0xFF244064).copy(alpha = if (dark) .10f else .045f),
-        spotColor = Color(0xFF244064).copy(alpha = if (dark) .14f else .065f)
+        ambientColor = Color(0xFF1E3558).copy(alpha = if (dark) .10f else .055f),
+        spotColor = Color(0xFF1E3558).copy(alpha = if (dark) .16f else .085f)
     )
     .shadow(
         elevation = 1.dp,
@@ -59,12 +59,12 @@ internal fun Modifier.glassSurface(
     .clip(shape)
     .background(
         Brush.verticalGradient(
-            0f to lerp(color, Color.White, if (dark) .035f else .45f),
-            .10f to lerp(color, Color.White, if (dark) .012f else .12f),
-            1f to color
+            0f to lerp(color, Color.White, if (dark) .045f else .32f),
+            .20f to color,
+            1f to lerp(color, if (dark) Color.Black else Color(0xFFCEDBED), .025f)
         )
     )
-    .insetTopLight(if (dark) .055f else .32f)
+    .insetTopLight(if (dark) .055f else .22f)
 
 /** A six-dp internal reflection, clipped by the parent shape rather than drawn as a border. */
 private fun Modifier.insetTopLight(alpha: Float): Modifier = drawWithCache {
@@ -79,7 +79,7 @@ private fun Modifier.insetTopLight(alpha: Float): Modifier = drawWithCache {
     }
 }
 
-/** Shared 48dp action. Motion only follows the user's press and honours disabled state. */
+/** Shared action; its reflection and press response match the floating navigation. */
 @Composable
 fun GlassActionButton(
     label: String,
@@ -91,7 +91,7 @@ fun GlassActionButton(
 ) {
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.surface.luminance() < .3f
-    val shape = RoundedCornerShape(16.dp)
+    val shape = RoundedCornerShape(18.dp)
     val interactionSource = remember { MutableInteractionSource() }
     val pressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
@@ -120,7 +120,7 @@ fun GlassActionButton(
     Row(
         modifier = modifier
             .graphicsLayer { scaleX = scale; scaleY = scale }
-            .heightIn(min = 48.dp)
+            .heightIn(min = 50.dp)
             .shadow(
                 elevation = if (enabled) 6.dp else 0.dp,
                 shape = shape,
@@ -137,7 +137,7 @@ fun GlassActionButton(
             )
             .clip(shape)
             .background(Brush.verticalGradient(listOf(upper, base, lower)))
-            .insetTopLight(if (!enabled) .08f else if (dark) .10f else if (secondary) .45f else .18f)
+            .insetTopLight(if (!enabled) .06f else if (dark) .08f else if (secondary) .30f else .09f)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/LuoShuComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/LuoShuComponents.kt
@@ -1,0 +1,116 @@
+package io.github.xgl34222220.baize.ui.miuix
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+/** Adapted from LuoShu's ACTIVE compact layout, icon system and settings hub at fe4df5f.
+ * Not HomeScreenMiuix.kt: that legacy screen is no longer selected by HomeRoute.
+ * These components are only used by the MIUIX routes. See docs/UI-LUOSHU-BASELINE.md.
+ */
+@Composable
+internal fun LuoShuPageHeader(title: String, onBack: (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {}) {
+    Row(Modifier.fillMaxWidth().statusBarsPadding().heightIn(min = 64.dp).padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (onBack != null) LuoShuHeaderButton(Icons.AutoMirrored.Rounded.ArrowBack, "返回", onBack)
+        Text(title, Modifier.weight(1f), fontSize = if (onBack == null) 26.sp else 22.sp,
+            lineHeight = if (onBack == null) 34.sp else 30.sp,
+            fontWeight = if (onBack == null) FontWeight.Bold else FontWeight.SemiBold,
+            maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp), content = actions)
+    }
+}
+
+@Composable
+internal fun LuoShuHeaderButton(icon: ImageVector, label: String, onClick: () -> Unit) {
+    Box(Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+        Surface(Modifier.size(44.dp), shape = CircleShape, color = BaiZeTokens.colors.surfaceRaised,
+            contentColor = MaterialTheme.colorScheme.primary, shadowElevation = 1.dp) {
+            IconButton(onClick = onClick, modifier = Modifier.fillMaxSize()) {
+                Icon(icon, label, Modifier.size(21.dp))
+            }
+        }
+    }
+}
+
+@Composable
+internal fun LuoShuSection(title: String, subtitle: String = "") {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+        if (subtitle.isNotBlank()) Text(subtitle, style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+internal fun LuoShuGroup(modifier: Modifier = Modifier, content: @Composable ColumnScope.() -> Unit) {
+    Surface(modifier.fillMaxWidth(), shape = RoundedCornerShape(24.dp),
+        color = BaiZeTokens.colors.surfaceRaised, tonalElevation = 0.dp) {
+        Column(content = content)
+    }
+}
+
+@Composable
+internal fun LuoShuGroupDivider() {
+    HorizontalDivider(Modifier.padding(start = 74.dp, end = 18.dp),
+        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = .20f))
+}
+
+@Composable
+internal fun LuoShuNavigationRow(icon: ImageVector, title: String, subtitle: String,
+    onClick: () -> Unit) {
+    Surface(onClick = onClick, modifier = Modifier.fillMaxWidth(), color = Color.Transparent) {
+        Row(Modifier.fillMaxWidth().heightIn(min = 80.dp).padding(horizontal = 16.dp, vertical = 15.dp),
+            verticalAlignment = Alignment.CenterVertically) {
+            Surface(Modifier.size(42.dp), shape = RoundedCornerShape(13.dp),
+                color = MaterialTheme.colorScheme.primary.copy(alpha = .10f)) {
+                Box(contentAlignment = Alignment.Center) {
+                    Icon(icon, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
+                }
+            }
+            Spacer(Modifier.width(14.dp))
+            Column(Modifier.weight(1f)) {
+                Text(title, fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.Medium)
+                Text(subtitle, fontSize = 12.sp, lineHeight = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            }
+            Spacer(Modifier.width(8.dp))
+            Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .66f))
+        }
+    }
+}
+
+@Composable
+internal fun LuoShuShortcut(title: String, subtitle: String, icon: ImageVector,
+    onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Surface(onClick = onClick, modifier = modifier, shape = RoundedCornerShape(24.dp),
+        color = BaiZeTokens.colors.surfaceRaised, shadowElevation = 1.dp) {
+        Column(Modifier.padding(18.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Surface(shape = RoundedCornerShape(15.dp), color = BaiZeTokens.colors.surfaceOverlay) {
+                Box(Modifier.size(44.dp), contentAlignment = Alignment.Center) {
+                    Icon(icon, null, Modifier.size(22.dp), tint = MaterialTheme.colorScheme.primary)
+                }
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(title, style = MaterialTheme.typography.titleMedium)
+                Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/LuoShuLiquidDock.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/LuoShuLiquidDock.kt
@@ -111,7 +111,8 @@ internal fun LuoShuLiquidDock(
         .fillMaxWidth().height(itemHeight + 12.dp + if (floating) 0.dp else bottomInset)) {
         Box(Modifier.fillMaxSize().testTag("dock-shell-${mode.name.lowercase()}")
             .shadow(if (floating) 18.dp else 5.dp, shape, clip = false)
-            .then(if (floating) Modifier.squircleClip(31.dp) else Modifier.clip(shape))
+            // Squircle clipping also uses RuntimeShader; gate it with the refractive layer.
+            .then(if (floating && mode == DockRendering.LIQUID) Modifier.squircleClip(31.dp) else Modifier.clip(shape))
             .then(if (shellBackdrop != null) Modifier.layerBackdrop(shellBackdrop) else Modifier)
             .then(effect)
             .border(if (mode == DockRendering.LIQUID) .45.dp else .7.dp,
@@ -172,7 +173,7 @@ internal fun LuoShuLiquidDock(
             Box(Modifier.offset(x = x + 4.dp - if (direction < 0f) extra else 0.dp)
                 .width((itemWidth - 8.dp + extra).coerceAtLeast(1.dp)).height(itemHeight)
                 .shadow(if (shellBackdrop != null) 4.dp else 3.dp, indicatorShape, clip = false)
-                .squircleClip(23.dp).then(lens)
+                .then(if (shellBackdrop != null) Modifier.squircleClip(23.dp) else Modifier.clip(indicatorShape)).then(lens)
                 .border(1.dp, Color.White.copy(alpha = if (dark) .18f else .46f), indicatorShape))
             Row(Modifier.fillMaxWidth().selectableGroup()) {
                 items.forEachIndexed { index, item ->

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/LuoShuLiquidDock.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/LuoShuLiquidDock.kt
@@ -1,0 +1,206 @@
+package io.github.xgl34222220.baize.ui.miuix
+
+// Visual/optical parameters ported from LuoShu@fe4df5f LuoShuAppShell.kt.
+// Only the four BaiZe destinations and capability/accessibility fallback differ.
+import android.os.Build
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.*
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.chrisbanes.haze.*
+import dev.chrisbanes.haze.materials.ExperimentalHazeMaterialsApi
+import dev.chrisbanes.haze.materials.HazeMaterials
+import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.glass.liquidGlassLens
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+import top.yukonga.miuix.kmp.blur.*
+import top.yukonga.miuix.kmp.blur.highlight.Highlight
+import top.yukonga.miuix.kmp.squircle.squircleClip
+
+internal enum class DockRendering { LIQUID, HAZE, OPAQUE }
+internal fun dockRendering(sdk: Int, hardware: Boolean, effects: Boolean,
+    backdropAvailable: Boolean, hazeAvailable: Boolean): DockRendering = when {
+    !hardware || !effects -> DockRendering.OPAQUE
+    sdk >= 33 && backdropAvailable -> DockRendering.LIQUID
+    sdk >= 31 && hazeAvailable -> DockRendering.HAZE
+    else -> DockRendering.OPAQUE
+}
+
+@OptIn(ExperimentalHazeMaterialsApi::class)
+@Composable
+internal fun LuoShuLiquidDock(
+    selectedIndex: Int,
+    items: List<MiuixLiquidNavItem>,
+    onSelected: (Int) -> Unit,
+    hazeState: HazeState?,
+    backdrop: LayerBackdrop?,
+    effectsEnabled: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    if (items.isEmpty()) return
+    val appearance = LocalAppearanceSettings.current
+    val scheme = MaterialTheme.colorScheme
+    val tokens = BaiZeTokens.colors
+    val dark = scheme.background.luminance() < .5f
+    val amoled = dark && appearance.amoledBlack
+    val floating = appearance.floatingDock
+    val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+    val itemHeight = 60.dp + (16f * (LocalDensity.current.fontScale - 1f).coerceIn(0f, 1f)).dp
+    val shape = if (floating) RoundedCornerShape(31.dp) else RoundedCornerShape(topStart = 31.dp, topEnd = 31.dp)
+    val mode = dockRendering(Build.VERSION.SDK_INT, LocalView.current.isHardwareAccelerated,
+        effectsEnabled && appearance.glassEnabled && appearance.blurEnabled && !amoled,
+        backdrop != null, hazeState?.blurEnabled == true)
+    val glass = mode != DockRendering.OPAQUE
+    // Do not initialise the runtime backdrop on devices taking the API 26-32 fallback.
+    val shellBackdrop = if (mode == DockRendering.LIQUID) rememberLayerBackdrop() else null
+    val shellTint = if (dark) scheme.surface.copy(alpha = .39f) else Color.White.copy(alpha = .40f)
+    val effect = when (mode) {
+        DockRendering.LIQUID -> Modifier.drawBackdrop(
+            backdrop = requireNotNull(backdrop), shape = { shape },
+            effects = {
+                padding = maxOf(padding, 30.dp.toPx())
+                colorControls(brightness = if (dark) -.015f else .025f, contrast = 1.05f, saturation = 1.40f)
+                blur(9.dp.toPx(), 9.dp.toPx())
+                liquidGlassLens(17.dp.toPx(), 13.dp.toPx(), depthEffect = true, chromaticAberration = .045f)
+            },
+            highlight = {
+                (if (dark) Highlight.GlassStrokeSmallDark else Highlight.GlassStrokeSmallLight)
+                    .copy(alpha = if (dark) .72f else .86f)
+            },
+            onDrawSurface = {
+                drawRect(shellTint)
+                drawRect(Brush.radialGradient(
+                    listOf(Color.White.copy(alpha = if (dark) .06f else .20f), Color.Transparent),
+                    center = Offset(size.width * .16f, 0f), radius = size.width * .70f))
+            },
+        )
+        DockRendering.HAZE -> Modifier.hazeEffect(state = requireNotNull(hazeState), style = HazeMaterials.ultraThin()) {
+            blurRadius = 30.dp
+            noiseFactor = .018f
+            fallbackTint = HazeTint(tokens.surfaceOverlay)
+        }.background(Brush.verticalGradient(if (dark)
+            listOf(Color.White.copy(alpha = .10f), Color.White.copy(alpha = .035f)) else
+            listOf(Color.White.copy(alpha = .22f), Color.White.copy(alpha = .09f))))
+        // No transparent imitation without an actual blur: background text must not ghost.
+        DockRendering.OPAQUE -> Modifier.background(if (amoled) Color.Black else tokens.surfaceOverlay.copy(alpha = 1f))
+    }
+    Box(modifier.testTag("luoshu-dock")
+        .then(if (floating) Modifier.padding(horizontal = 20.dp).padding(bottom = bottomInset + 12.dp) else Modifier)
+        .fillMaxWidth().height(itemHeight + 12.dp + if (floating) 0.dp else bottomInset)) {
+        Box(Modifier.fillMaxSize().testTag("dock-shell-${mode.name.lowercase()}")
+            .shadow(if (floating) 18.dp else 5.dp, shape, clip = false)
+            .then(if (floating) Modifier.squircleClip(31.dp) else Modifier.clip(shape))
+            .then(if (shellBackdrop != null) Modifier.layerBackdrop(shellBackdrop) else Modifier)
+            .then(effect)
+            .border(if (mode == DockRendering.LIQUID) .45.dp else .7.dp,
+                if (glass) Color.White.copy(alpha = if (dark) .11f else .32f)
+                else Color.White.copy(alpha = if (dark) .10f else .50f), shape))
+        BoxWithConstraints(Modifier.fillMaxSize()
+            .padding(start = 6.dp, top = 6.dp, end = 6.dp, bottom = if (floating) 6.dp else bottomInset + 6.dp)) {
+            val itemWidth = maxWidth / items.size.toFloat()
+            val target = selectedIndex.coerceIn(items.indices)
+            val stretch = remember { Animatable(0f) }
+            var direction by remember { mutableFloatStateOf(0f) }
+            var previous by remember { mutableIntStateOf(target) }
+            LaunchedEffect(target, glass) {
+                if (target != previous) {
+                    direction = if (target > previous) 1f else -1f
+                    previous = target
+                    if (glass) {
+                        stretch.snapTo(1f)
+                        stretch.animateTo(0f, spring(dampingRatio = .55f, stiffness = Spring.StiffnessMediumLow))
+                    }
+                }
+                if (!glass) stretch.snapTo(0f)
+            }
+            val x by animateDpAsState(itemWidth * target,
+                spring(dampingRatio = if (glass) .68f else .84f,
+                    stiffness = if (glass) 310f else Spring.StiffnessMediumLow), label = "luoshuDockIndicator")
+            val extra = if (glass) 13.dp * stretch.value else 0.dp
+            val indicatorShape = RoundedCornerShape(23.dp)
+            val indicatorColor = scheme.primary.copy(alpha = if (dark) .28f else .16f)
+            val lens = if (shellBackdrop != null) Modifier.drawBackdrop(
+                backdrop = shellBackdrop, shape = { indicatorShape },
+                effects = {
+                    val amount = stretch.value
+                    padding = maxOf(padding, 22.dp.toPx())
+                    colorControls(brightness = .015f, contrast = 1.06f, saturation = 1.34f)
+                    blur(3.dp.toPx(), 3.dp.toPx())
+                    liquidGlassLens((13.dp + 4.dp * amount).toPx(), (14.dp + 5.dp * amount).toPx(),
+                        depthEffect = true, chromaticAberration = .08f + .10f * amount)
+                },
+                highlight = {
+                    (if (dark) Highlight.GlassStrokeSmallDark else Highlight.GlassStrokeSmallLight).copy(alpha = .88f)
+                },
+                layerBlock = { scaleY = 1f - .045f * stretch.value },
+                onDrawSurface = {
+                    drawRect(indicatorColor)
+                    drawRect(Brush.linearGradient(listOf(Color.White.copy(alpha = if (dark) .055f else .16f), Color.Transparent)))
+                },
+            ) else Modifier.drawBehind {
+                val radius = CornerRadius(size.height / 2f)
+                drawRoundRect(Brush.verticalGradient(if (glass) listOf(
+                    indicatorColor.copy(alpha = (indicatorColor.alpha * 1.18f).coerceAtMost(1f)),
+                    indicatorColor.copy(alpha = indicatorColor.alpha * .72f)) else listOf(indicatorColor, indicatorColor)), cornerRadius = radius)
+                if (glass) drawRoundRect(Brush.radialGradient(
+                    listOf(Color.White.copy(alpha = if (dark) .10f else .24f), Color.Transparent),
+                    center = Offset(size.width * .27f, 0f), radius = size.width * .74f), cornerRadius = radius)
+            }
+            // Record ONLY the shell above. Labels stay outside both shader/capture layers.
+            Box(Modifier.offset(x = x + 4.dp - if (direction < 0f) extra else 0.dp)
+                .width((itemWidth - 8.dp + extra).coerceAtLeast(1.dp)).height(itemHeight)
+                .shadow(if (shellBackdrop != null) 4.dp else 3.dp, indicatorShape, clip = false)
+                .squircleClip(23.dp).then(lens)
+                .border(1.dp, Color.White.copy(alpha = if (dark) .18f else .46f), indicatorShape))
+            Row(Modifier.fillMaxWidth().selectableGroup()) {
+                items.forEachIndexed { index, item ->
+                    val selected = index == target
+                    val interactions = remember(item.title) { MutableInteractionSource() }
+                    val pressed by interactions.collectIsPressedAsState()
+                    val base = if (selected) scheme.primary else scheme.onSurfaceVariant.copy(alpha = .90f)
+                    val color by animateColorAsState(if (pressed) base.copy(alpha = .62f) else base, tween(170), label = "dockColor$index")
+                    val scale by animateFloatAsState(when {
+                        pressed -> .92f; selected && glass -> 1.035f; else -> 1f
+                    }, spring(dampingRatio = .66f, stiffness = 520f), label = "dockScale$index")
+                    Column(Modifier.width(itemWidth).height(itemHeight).testTag("dock-tab-$index")
+                        .graphicsLayer { scaleX = scale; scaleY = scale }
+                        .clip(indicatorShape)
+                        .selectable(selected, role = Role.Tab, interactionSource = interactions, indication = null,
+                            onClick = { if (!selected) onSelected(index) }),
+                        horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+                        val opticalScale = when (index) { 0, 3 -> .94f; 2 -> .96f; else -> 1f }
+                        Box(Modifier.size(22.dp), contentAlignment = Alignment.Center) {
+                            Icon(item.icon, null, Modifier.fillMaxSize().scale(opticalScale), tint = color)
+                        }
+                        Spacer(Modifier.height(3.dp))
+                        Text(item.title, color = color, fontSize = 12.sp, lineHeight = 17.sp,
+                            fontWeight = if (selected) FontWeight.Bold else FontWeight.Medium,
+                            maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/MiuixLiquidComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/MiuixLiquidComponents.kt
@@ -105,13 +105,12 @@ fun MiuixLiquidDock(
     val activeHaze = hazeState.takeIf { hardwareBlur && glassActive && settings.blurEnabled && it?.blurEnabled == true }
     val bottomInset = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
     val itemHeight = 60.dp + (16 * (LocalDensity.current.fontScale - 1f).coerceIn(0f, 1f)).dp
-    val shape = if (floating) RoundedCornerShape(31.dp)
+    val shape = if (floating) RoundedCornerShape(32.dp)
         else RoundedCornerShape(topStart = 28.dp, topEnd = 28.dp)
     val surface = if (amoled) Color.Black else BaiZeTokens.colors.surfaceRaised
     val gapColor = if (amoled) Color.Black else BaiZeTokens.colors.surfaceBase
     val glassTint = if (dark) Color(0xFF131B27) else Color.White
-    val shellTint = glassTint.copy(alpha = if (dark) .42f else .34f)
-    val glassEdge = if (dark) Color.White.copy(alpha = .13f) else Color.White.copy(alpha = .70f)
+    val shellTint = glassTint.copy(alpha = if (dark) .48f else .42f)
     val shellEffect = activeHaze?.let { state ->
         Modifier.hazeEffect(state = state, style = HazeMaterials.ultraThin()) {
             backgroundColor = surface
@@ -120,7 +119,7 @@ fun MiuixLiquidDock(
             blurRadius = 26.dp
             noiseFactor = .012f
         }
-    } ?: Modifier.background(surface)
+    } ?: Modifier.background(surface.copy(alpha = if (glassActive) .88f else 1f))
 
     Box(
         modifier = modifier
@@ -140,9 +139,9 @@ fun MiuixLiquidDock(
         Box(
             Modifier.fillMaxSize()
                 .shadow(
-                    if (floating) 18.dp else 3.dp, shape, clip = false,
-                    ambientColor = Color.Black.copy(alpha = if (dark) .28f else .08f),
-                    spotColor = Color(0xFF173B6B).copy(alpha = if (dark) .24f else .16f)
+                    if (floating) 24.dp else 3.dp, shape, clip = false,
+                    ambientColor = Color.Black.copy(alpha = if (dark) .28f else .10f),
+                    spotColor = Color(0xFF173B6B).copy(alpha = if (dark) .24f else .20f)
                 )
                 .clip(shape)
                 .then(shellEffect)
@@ -161,7 +160,6 @@ fun MiuixLiquidDock(
                         }
                     }
                 }
-                .then(if (glassActive) Modifier.border(.7.dp, glassEdge, shape) else Modifier)
         )
 
         BoxWithConstraints(
@@ -189,8 +187,8 @@ fun MiuixLiquidDock(
                 label = "miuixDockIndicator"
             )
             val lensExtra = if (glassActive) 8.dp * stretch.value else 0.dp
-            val lensShape = RoundedCornerShape(25.dp)
-            val lensTint = scheme.primary.copy(alpha = if (dark) .19f else .09f)
+            val lensShape = RoundedCornerShape(26.dp)
+            val lensTint = scheme.primary.copy(alpha = if (dark) .16f else .07f)
             val lensEffect = activeHaze?.let { state ->
                 Modifier.hazeEffect(state = state, style = HazeMaterials.ultraThin()) {
                     backgroundColor = surface
@@ -202,17 +200,17 @@ fun MiuixLiquidDock(
                     blurRadius = 12.dp
                     noiseFactor = .005f
                 }
-            } ?: Modifier.background(
-                if (amoled) scheme.primary.copy(alpha = .24f)
-                else scheme.primary.copy(alpha = if (dark) .19f else .105f)
-            )
+            } ?: if (glassActive) Modifier.background(Brush.verticalGradient(listOf(
+                if (dark) Color.White.copy(alpha = .075f) else Color.White.copy(alpha = .88f),
+                scheme.primary.copy(alpha = if (dark) .16f else .12f)
+            ))) else Modifier.background(scheme.primary.copy(alpha = if (dark) .24f else .105f))
             Box(
                 modifier = Modifier
                     .offset(x = indicatorX + 4.dp - if (direction < 0) lensExtra else 0.dp)
                     .width(itemWidth - 8.dp + lensExtra)
                     .height(itemHeight)
                     .graphicsLayer { scaleY = 1f - .035f * stretch.value }
-                    .shadow(if (glassActive) 3.dp else 0.dp, lensShape, clip = false,
+                    .shadow(if (glassActive) 5.dp else 0.dp, lensShape, clip = false,
                         ambientColor = Color.Black.copy(alpha = .06f), spotColor = scheme.primary.copy(alpha = .12f))
                     .clip(lensShape)
                     .then(lensEffect)
@@ -225,8 +223,6 @@ fun MiuixLiquidDock(
                             )
                         )
                     )
-                    .then(if (glassActive) Modifier.border(.7.dp,
-                        Color.White.copy(alpha = if (dark) .16f else .55f), lensShape) else Modifier)
             )
 
             Row(Modifier.fillMaxWidth().selectableGroup()) {
@@ -235,7 +231,7 @@ fun MiuixLiquidDock(
                     val interactions = remember(item.title) { MutableInteractionSource() }
                     val pressed by interactions.collectIsPressedAsState()
                     val contentColor by animateColorAsState(
-                        targetValue = if (active) scheme.primary else scheme.onSurfaceVariant.copy(alpha = .86f),
+                        targetValue = if (active) scheme.primary else scheme.onSurfaceVariant,
                         animationSpec = tween(180), label = "miuixDockContentColor"
                     )
                     val pressScale by animateFloatAsState(
@@ -256,7 +252,7 @@ fun MiuixLiquidDock(
                     ) {
                         Icon(
                             imageVector = item.icon, contentDescription = null,
-                            modifier = Modifier.size(if (index == 0 || index == items.lastIndex) 23.dp else 24.dp),
+                            modifier = Modifier.size(22.dp),
                             tint = contentColor
                         )
                         Spacer(Modifier.height(3.dp))

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
@@ -73,7 +73,7 @@ fun VideoTopBar(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().statusBarsPadding()
-            .heightIn(min = 60.dp).padding(horizontal = 20.dp, vertical = 6.dp),
+            .heightIn(min = 72.dp).padding(horizontal = 24.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -147,9 +147,9 @@ fun VideoTabs(labels: List<String>, selectedIndex: Int, onSelected: (Int) -> Uni
 
 @Composable
 fun VideoSectionTitle(title: String, subtitle: String? = null, modifier: Modifier = Modifier) {
-    Column(modifier.padding(horizontal = 22.dp, vertical = 4.dp),
+    Column(modifier.padding(horizontal = 24.dp, vertical = 6.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        Text(title, style = MaterialTheme.typography.titleMedium,
+        Text(title, style = MaterialTheme.typography.titleMedium.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold),
             color = MaterialTheme.colorScheme.onSurface)
         if (!subtitle.isNullOrBlank()) {
             Text(subtitle, color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -185,8 +185,8 @@ fun VideoCard(
 fun VideoLeadingIcon(icon: ImageVector, primary: Boolean = true, modifier: Modifier = Modifier,
     color: Color? = null) {
     val tint = color ?: if (primary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-    Box(modifier.size(38.dp).clip(RoundedCornerShape(12.dp))
-        .background(if (primary || color != null) tint.copy(alpha = .065f) else Color.Transparent),
+    Box(modifier.size(40.dp).clip(RoundedCornerShape(14.dp))
+        .background(if (primary || color != null) tint.copy(alpha = .08f) else Color.Transparent),
         contentAlignment = Alignment.Center) {
         Icon(icon, null, Modifier.size(22.dp), tint = tint)
     }
@@ -204,9 +204,9 @@ fun VideoListRow(
     trailing: (@Composable () -> Unit)? = null
 ) {
     Row(
-        modifier = modifier.fillMaxWidth().heightIn(min = 68.dp)
+        modifier = modifier.fillMaxWidth().heightIn(min = 72.dp)
             .then(if (onClick != null) Modifier.clickable(enabled = enabled, role = Role.Button, onClick = onClick) else Modifier)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         VideoLeadingIcon(icon, primary = enabled)
@@ -250,7 +250,7 @@ fun VideoSwitchRow(icon: ImageVector, title: String, subtitle: String, checked: 
 @Composable
 fun VideoDivider(start: Int = 66) {
     HorizontalDivider(Modifier.padding(start = start.dp, end = 18.dp),
-        color = MaterialTheme.colorScheme.onSurface.copy(alpha = .055f))
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = .045f))
 }
 
 @Composable

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
@@ -73,7 +73,7 @@ fun VideoTopBar(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().statusBarsPadding()
-            .heightIn(min = 72.dp).padding(horizontal = 24.dp, vertical = 12.dp),
+            .heightIn(min = 72.dp).padding(horizontal = 20.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -91,8 +91,9 @@ fun VideoIconButton(icon: ImageVector, description: String, onClick: () -> Unit,
     val scheme = MaterialTheme.colorScheme
     val color = if (primary) scheme.primaryContainer else BaiZeTokens.colors.surfaceRaised
     Surface(
-        modifier = Modifier.size(44.dp).glassSurface(color, CircleShape, scheme.surface.luminance() < .3f)
-            .clickable(role = Role.Button, onClickLabel = description, onClick = onClick),
+        modifier = Modifier.size(48.dp)
+            .clip(CircleShape).clickable(role = Role.Button, onClickLabel = description, onClick = onClick)
+            .padding(2.dp).glassSurface(color, CircleShape, scheme.surface.luminance() < .3f),
         shape = CircleShape,
         color = Color.Transparent,
         contentColor = if (primary) scheme.primary else scheme.onSurface
@@ -108,6 +109,7 @@ fun VideoTabs(labels: List<String>, selectedIndex: Int, onSelected: (Int) -> Uni
     if (labels.isEmpty()) return
     val scheme = MaterialTheme.colorScheme
     val dark = scheme.surface.luminance() < .3f
+    val currentIndex = selectedIndex.coerceIn(labels.indices)
     Box(
         modifier = modifier.fillMaxWidth().padding(horizontal = 20.dp)
             .clip(RoundedCornerShape(16.dp))
@@ -119,7 +121,7 @@ fun VideoTabs(labels: List<String>, selectedIndex: Int, onSelected: (Int) -> Uni
             BoxWithConstraints(Modifier.fillMaxSize()) {
                 val segmentWidth = maxWidth / labels.size
                 val offset by animateDpAsState(
-                    targetValue = segmentWidth * selectedIndex.coerceIn(labels.indices),
+                    targetValue = segmentWidth * currentIndex,
                     animationSpec = tween(200), label = "segmentSelection"
                 )
                 Box(Modifier.offset(x = offset).width(segmentWidth).fillMaxHeight()
@@ -128,9 +130,9 @@ fun VideoTabs(labels: List<String>, selectedIndex: Int, onSelected: (Int) -> Uni
         }
         Row(Modifier.fillMaxWidth().padding(4.dp)) {
             labels.forEachIndexed { index, label ->
-                val selected = index == selectedIndex
+                val selected = index == currentIndex
                 Box(
-                    modifier = Modifier.weight(1f).heightIn(min = 44.dp)
+                    modifier = Modifier.weight(1f).heightIn(min = 48.dp)
                         .clip(RoundedCornerShape(12.dp))
                         .selectable(selected, role = Role.Tab) { onSelected(index) }
                         .padding(horizontal = 8.dp, vertical = 11.dp),
@@ -147,7 +149,7 @@ fun VideoTabs(labels: List<String>, selectedIndex: Int, onSelected: (Int) -> Uni
 
 @Composable
 fun VideoSectionTitle(title: String, subtitle: String? = null, modifier: Modifier = Modifier) {
-    Column(modifier.padding(horizontal = 24.dp, vertical = 6.dp),
+    Column(modifier.padding(horizontal = 20.dp, vertical = 6.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(title, style = MaterialTheme.typography.titleMedium.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.SemiBold),
             color = MaterialTheme.colorScheme.onSurface)
@@ -217,7 +219,7 @@ fun VideoListRow(
                 maxLines = 2, overflow = TextOverflow.Ellipsis)
             if (subtitle.isNotBlank()) {
                 Text(subtitle, style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = if (enabled) 1f else .5f),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 2, overflow = TextOverflow.Ellipsis)
             }
         }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/miuix/VideoStyleComponents.kt
@@ -64,7 +64,7 @@ fun ProvideVideoSkin(skin: VideoSkin, content: @Composable () -> Unit) {
 }
 
 @Composable
-@Suppress("UNUSED_PARAMETER") // Existing call sites may still supply their old descriptive tagline.
+@Suppress("UNUSED_PARAMETER")
 fun VideoTopBar(
     title: String,
     subtitle: String? = null,
@@ -73,7 +73,7 @@ fun VideoTopBar(
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().statusBarsPadding()
-            .heightIn(min = 72.dp).padding(horizontal = 20.dp, vertical = 12.dp),
+            .heightIn(min = 64.dp).padding(horizontal = 20.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -96,10 +96,10 @@ fun VideoIconButton(icon: ImageVector, description: String, onClick: () -> Unit,
             .padding(2.dp).glassSurface(color, CircleShape, scheme.surface.luminance() < .3f),
         shape = CircleShape,
         color = Color.Transparent,
-        contentColor = if (primary) scheme.primary else scheme.onSurface
+        contentColor = if (LocalVideoSkin.current == VideoSkin.MIUIX || primary) scheme.primary else scheme.onSurface
     ) {
         Box(contentAlignment = Alignment.Center) {
-            Icon(icon, description, Modifier.size(22.dp))
+            Icon(icon, description, Modifier.size(21.dp))
         }
     }
 }
@@ -116,7 +116,6 @@ fun VideoTabs(labels: List<String>, selectedIndex: Int, onSelected: (Int) -> Uni
             .background(BaiZeTokens.colors.surfaceOverlay.copy(alpha = .62f))
             .selectableGroup()
     ) {
-        // This layer follows the measured row, including larger accessibility text.
         Box(Modifier.matchParentSize().padding(4.dp)) {
             BoxWithConstraints(Modifier.fillMaxSize()) {
                 val segmentWidth = maxWidth / labels.size
@@ -177,8 +176,10 @@ fun VideoCard(
         }
     } else {
         CompositionLocalProvider(LocalContentColor provides scheme.onSurface) {
-            Column(modifier.glassSurface(color, shape, scheme.surface.luminance() < .3f)
-                .padding(contentPadding.dp), content = content)
+            Surface(modifier = modifier, shape = shape, color = color,
+                contentColor = scheme.onSurface, shadowElevation = 1.dp, tonalElevation = 0.dp) {
+                Column(Modifier.padding(contentPadding.dp), content = content)
+            }
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
@@ -23,6 +23,7 @@ fun SettingsRoute(
     scheduler: SchedulerUiState,
     appearance: AppearanceSettings,
     dashboardActions: DashboardActions,
+    onDetailChanged: (Boolean) -> Unit = {},
     onOpenDetails: () -> Unit
 ) {
     var draft by remember { mutableStateOf(scheduler.copy(saving = false)) }
@@ -77,7 +78,7 @@ fun SettingsRoute(
         UiStyle.MIUIX -> VideoSkin.MIUIX
     }
     ProvideVideoSkin(skin) {
-        if (style == UiStyle.MIUIX) LuoShuSettingsHub(state, actions)
+        if (style == UiStyle.MIUIX) LuoShuSettingsHub(state, actions, onDetailChanged)
         else VideoSettingsScreenMiuix(state, actions)
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/SettingsRoute.kt
@@ -14,6 +14,7 @@ import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.miuix.ProvideVideoSkin
 import io.github.xgl34222220.baize.ui.miuix.VideoSkin
 import io.github.xgl34222220.baize.ui.settings.miuix.VideoSettingsScreenMiuix
+import io.github.xgl34222220.baize.ui.settings.miuix.LuoShuSettingsHub
 
 @Composable
 fun SettingsRoute(
@@ -76,7 +77,8 @@ fun SettingsRoute(
         UiStyle.MIUIX -> VideoSkin.MIUIX
     }
     ProvideVideoSkin(skin) {
-        VideoSettingsScreenMiuix(state, actions)
+        if (style == UiStyle.MIUIX) LuoShuSettingsHub(state, actions)
+        else VideoSettingsScreenMiuix(state, actions)
     }
 }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/LuoShuSettingsHub.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/LuoShuSettingsHub.kt
@@ -5,6 +5,8 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -29,11 +31,22 @@ import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 /** LuoShu SettingsHubScreen structure: overview -> navigation groups -> separate detail page. */
 @Composable
-fun LuoShuSettingsHub(state: SettingsUiState, actions: SettingsUiActions) {
+fun LuoShuSettingsHub(state: SettingsUiState, actions: SettingsUiActions, onDetailChanged: (Boolean) -> Unit = {}) {
     var section by rememberSaveable { mutableStateOf("") }
+    val notify by rememberUpdatedState(onDetailChanged)
+    LaunchedEffect(section) { notify(section.isNotEmpty()) }
+    DisposableEffect(Unit) { onDispose { notify(false) } }
     BackHandler(enabled = section.isNotEmpty()) { section = "" }
     AnimatedContent(targetState = section,
-        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(140)) }, label = "settingsHub") { target ->
+        transitionSpec = {
+            if (targetState.isNotEmpty()) {
+                (fadeIn(tween(250)) + slideInHorizontally(tween(340)) { it }) togetherWith
+                    (fadeOut(tween(210), targetAlpha = .52f) + slideOutHorizontally(tween(340)) { -it / 7 })
+            } else {
+                (fadeIn(tween(230)) + slideInHorizontally(tween(340)) { -it / 7 }) togetherWith
+                    (fadeOut(tween(210)) + slideOutHorizontally(tween(340)) { it })
+            }
+        }, label = "settingsHub") { target ->
         when (target) {
             "tasks" -> TaskSettings(state, actions, { section = "" })
             "service" -> ServiceDetails(state, actions, { section = "" })
@@ -43,8 +56,8 @@ fun LuoShuSettingsHub(state: SettingsUiState, actions: SettingsUiActions) {
 }
 
 @Composable
-private fun pagePadding(): PaddingValues = PaddingValues(start = 20.dp, end = 20.dp,
-    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + 118.dp)
+private fun pagePadding(detail: Boolean = false): PaddingValues = PaddingValues(start = 20.dp, end = 20.dp,
+    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + if (detail) 32.dp else 118.dp)
 
 @Composable
 private fun SettingsHome(state: SettingsUiState, actions: SettingsUiActions, open: (String) -> Unit) {
@@ -127,7 +140,7 @@ private fun TaskSettings(state: SettingsUiState, actions: SettingsUiActions, bac
             actions.onUpdateScheduler(if (edit == "battery") s.copy(minBattery = it) else s.copy(maxFileMb = it))
             edit = ""
         })
-    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(detail = true), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         item {
             LuoShuPageHeader("自动任务设置", back) {
                 TextButton(onClick = { actions.onSaveScheduler(s) }, enabled = !s.saving) { Text(if (s.saving) "保存中" else "保存") }
@@ -185,7 +198,7 @@ private fun TaskSettings(state: SettingsUiState, actions: SettingsUiActions, bac
 
 @Composable
 private fun ServiceDetails(state: SettingsUiState, actions: SettingsUiActions, back: () -> Unit) {
-    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(detail = true), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         item { LuoShuPageHeader("连接与诊断", back) }
         item {
             LuoShuGroup {

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/LuoShuSettingsHub.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/LuoShuSettingsHub.kt
@@ -1,0 +1,206 @@
+package io.github.xgl34222220.baize.ui.settings.miuix
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.xgl34222220.baize.BuildConfig
+import io.github.xgl34222220.baize.ui.clean.IntValueDialog
+import io.github.xgl34222220.baize.ui.components.DetailStatusText
+import io.github.xgl34222220.baize.ui.miuix.*
+import io.github.xgl34222220.baize.ui.settings.SettingsUiActions
+import io.github.xgl34222220.baize.ui.settings.SettingsUiState
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+/** LuoShu SettingsHubScreen structure: overview -> navigation groups -> separate detail page. */
+@Composable
+fun LuoShuSettingsHub(state: SettingsUiState, actions: SettingsUiActions) {
+    var section by rememberSaveable { mutableStateOf("") }
+    BackHandler(enabled = section.isNotEmpty()) { section = "" }
+    AnimatedContent(targetState = section,
+        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(140)) }, label = "settingsHub") { target ->
+        when (target) {
+            "tasks" -> TaskSettings(state, actions, { section = "" })
+            "service" -> ServiceDetails(state, actions, { section = "" })
+            else -> SettingsHome(state, actions, { section = it })
+        }
+    }
+}
+
+@Composable
+private fun pagePadding(): PaddingValues = PaddingValues(start = 20.dp, end = 20.dp,
+    bottom = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() + 118.dp)
+
+@Composable
+private fun SettingsHome(state: SettingsUiState, actions: SettingsUiActions, open: (String) -> Unit) {
+    val scheme = MaterialTheme.colorScheme
+    val colors = BaiZeTokens.colors
+    val statusColor = if (state.ready) colors.success else colors.warning
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        item { LuoShuPageHeader("设置") }
+        item {
+            Surface(onClick = { open("service") }, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(28.dp),
+                color = colors.surfaceRaised, shadowElevation = 1.dp) {
+                Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(18.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Surface(Modifier.size(52.dp), shape = RoundedCornerShape(18.dp), color = scheme.primary.copy(alpha = .10f)) {
+                            Box(contentAlignment = Alignment.Center) {
+                                Text("泽", color = scheme.primary, fontSize = 25.sp, fontWeight = FontWeight.SemiBold)
+                            }
+                        }
+                        Spacer(Modifier.width(14.dp))
+                        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                            Text("白泽状态", fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                            Text(state.connectionLabel, fontSize = 12.sp, lineHeight = 18.sp, color = statusColor)
+                        }
+                        Icon(Icons.Rounded.ChevronRight, null, Modifier.size(22.dp), tint = scheme.onSurfaceVariant)
+                    }
+                    Surface(shape = RoundedCornerShape(16.dp), color = scheme.primary.copy(alpha = .045f)) {
+                        Column(Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+                            verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                            Text("自动清理", fontSize = 12.sp, color = scheme.onSurfaceVariant)
+                            Text(if (state.scheduler.enabled) "自动计划已开启" else "自动计划已暂停",
+                                fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.Medium)
+                            if (!state.ready && state.serviceText.isNotBlank()) {
+                                DetailStatusText(state.serviceText)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        item { LuoShuSection("你的白泽", "调整喜欢的样子，回看每次清理") }
+        item {
+            LuoShuGroup {
+                LuoShuNavigationRow(Icons.Rounded.Palette, "外观与主题", "颜色、深色模式与界面效果", actions.onOpenAppearance)
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.History, "清理记录", "结果明细、保留项目与任务记录", actions.onOpenAudit)
+            }
+        }
+        item { LuoShuSection("管理与维护") }
+        item {
+            LuoShuGroup {
+                LuoShuNavigationRow(Icons.Rounded.CalendarMonth, "自动任务设置", "执行条件、文件上限与完成通知", { open("tasks") })
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.Shield, "应用白名单", "已保护 ${state.whitelistCount} 个应用", actions.onOpenWhitelist)
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.PlayArrow, "断点续清", "继续已保存的扫描任务", actions.onOpenResumableScan)
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.Security, "连接与诊断", "服务详情、重新连接与异常信息", { open("service") })
+            }
+        }
+        item {
+            Column(Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("白泽 · ${BuildConfig.VERSION_NAME}", color = scheme.onSurfaceVariant, fontSize = 12.sp)
+                Text("清理有据，保留有度", color = scheme.onSurfaceVariant, fontSize = 12.sp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TaskSettings(state: SettingsUiState, actions: SettingsUiActions, back: () -> Unit) {
+    val s = state.scheduler
+    var edit by rememberSaveable { mutableStateOf("") }
+    if (edit.isNotEmpty()) IntValueDialog(
+        title = if (edit == "battery") "最低执行电量" else "单文件自动清理上限",
+        description = if (edit == "battery") "电量不足时等待，不改变清理内容。" else "大于上限的文件会保留，可在手动扫描中检查。",
+        initialValue = if (edit == "battery") s.minBattery else s.maxFileMb,
+        range = if (edit == "battery") 0..100 else 16..2048,
+        suffix = if (edit == "battery") "%" else "MB", onDismiss = { edit = "" }, onConfirm = {
+            actions.onUpdateScheduler(if (edit == "battery") s.copy(minBattery = it) else s.copy(maxFileMb = it))
+            edit = ""
+        })
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        item {
+            LuoShuPageHeader("自动任务设置", back) {
+                TextButton(onClick = { actions.onSaveScheduler(s) }, enabled = !s.saving) { Text(if (s.saving) "保存中" else "保存") }
+            }
+        }
+        item { LuoShuSection("清理执行条件", "条件满足后，才会运行自动任务") }
+        item {
+            LuoShuGroup {
+                VideoSwitchRow(Icons.Rounded.DarkMode, "仅息屏时执行", "使用手机时暂缓清理", s.screenOffOnly,
+                    { actions.onUpdateScheduler(s.copy(screenOffOnly = it)) })
+                LuoShuGroupDivider()
+                VideoSwitchRow(Icons.Rounded.BatterySaver, "仅充电时执行", "连接电源后开始", s.chargingOnly,
+                    { actions.onUpdateScheduler(s.copy(chargingOnly = it)) })
+                LuoShuGroupDivider()
+                VideoSwitchRow(Icons.Rounded.SettingsSuggest, "仅空闲时执行", "设备空闲后开始", s.idleOnly,
+                    { actions.onUpdateScheduler(s.copy(idleOnly = it)) })
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.BatterySaver, "最低执行电量", "${s.minBattery}% · 电量不足时等待", { edit = "battery" })
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.Security, "单文件清理上限", "${s.maxFileMb} MB · 大于上限的文件会保留", { edit = "limit" })
+            }
+        }
+        item { LuoShuSection("文件归类") }
+        item {
+            LuoShuGroup {
+                VideoSwitchRow(Icons.Rounded.DarkMode, "归类时等待息屏", "避免打断前台使用", s.organizeScreenOffOnly,
+                    { actions.onUpdateScheduler(s.copy(organizeScreenOffOnly = it)) })
+                LuoShuGroupDivider()
+                VideoSwitchRow(Icons.Rounded.BatterySaver, "归类时等待充电", "连接电源后整理", s.organizeChargingOnly,
+                    { actions.onUpdateScheduler(s.copy(organizeChargingOnly = it)) })
+                LuoShuGroupDivider()
+                VideoSwitchRow(Icons.Rounded.SettingsSuggest, "归类时等待空闲", "设备空闲后整理", s.organizeIdleOnly,
+                    { actions.onUpdateScheduler(s.copy(organizeIdleOnly = it)) })
+            }
+        }
+        item { LuoShuSection("任务通知") }
+        item {
+            LuoShuGroup {
+                VideoSwitchRow(Icons.Rounded.Notifications, "任务完成通知", "自动任务结束后显示结果", s.notifyOnComplete,
+                    { actions.onUpdateScheduler(s.copy(notifyOnComplete = it)) })
+                LuoShuGroupDivider()
+                VideoSwitchRow(Icons.Rounded.Notifications, "零结果也通知", "没有可清理内容时也提醒", s.notifyZero,
+                    { actions.onUpdateScheduler(s.copy(notifyZero = it)) })
+            }
+        }
+        item {
+            Button(onClick = { actions.onSaveScheduler(s) }, enabled = !s.saving,
+                modifier = Modifier.fillMaxWidth().heightIn(min = 50.dp), shape = RoundedCornerShape(18.dp)) {
+                Text(if (s.saving) "正在保存…" else "保存任务设置")
+            }
+        }
+        item { Text("执行条件与通知保存后生效。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant) }
+    }
+}
+
+@Composable
+private fun ServiceDetails(state: SettingsUiState, actions: SettingsUiActions, back: () -> Unit) {
+    LazyColumn(Modifier.fillMaxSize(), contentPadding = pagePadding(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        item { LuoShuPageHeader("连接与诊断", back) }
+        item {
+            LuoShuGroup {
+                Column(Modifier.padding(20.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("清理服务 · ${state.connectionLabel}", style = MaterialTheme.typography.titleMedium)
+                    DetailStatusText(listOf(state.serviceText, state.schedulerText).filter { it.isNotBlank() }.distinct().joinToString("\n"))
+                }
+            }
+        }
+        item {
+            LuoShuGroup {
+                LuoShuNavigationRow(Icons.Rounded.Refresh, "重新连接服务", "重新获取服务连接", actions.onReconnect)
+                LuoShuGroupDivider()
+                LuoShuNavigationRow(Icons.Rounded.BugReport, "崩溃与诊断信息", "查看异常与故障记录", actions.onOpenCrashDiagnostics)
+            }
+        }
+    }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/VideoSettingsScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/VideoSettingsScreenMiuix.kt
@@ -1,32 +1,22 @@
 package io.github.xgl34222220.baize.ui.settings.miuix
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.BatterySaver
 import androidx.compose.material.icons.rounded.BugReport
-import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.DarkMode
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
@@ -49,11 +39,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -62,7 +49,6 @@ import io.github.xgl34222220.baize.ui.components.DetailStatusText
 import io.github.xgl34222220.baize.ui.miuix.GlassActionButton
 import io.github.xgl34222220.baize.ui.miuix.VideoCard
 import io.github.xgl34222220.baize.ui.miuix.VideoDivider
-import io.github.xgl34222220.baize.ui.miuix.VideoLeadingIcon
 import io.github.xgl34222220.baize.ui.miuix.VideoListRow
 import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
 import io.github.xgl34222220.baize.ui.miuix.VideoStatusPill
@@ -106,69 +92,58 @@ fun VideoSettingsScreenMiuix(state: SettingsUiState, actions: SettingsUiActions)
         }
         item { ServiceOverview(state) }
         item {
-            BoxWithConstraints(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
-                if (maxWidth < 320.dp || LocalDensity.current.fontScale > 1.2f) {
-                    VideoCard(Modifier.fillMaxWidth()) {
-                        VideoListRow(Icons.Rounded.DarkMode, "界面与主题", state.appearance.themeMode.label,
-                            onClick = actions.onOpenAppearance)
-                        VideoDivider()
-                        VideoListRow(Icons.Rounded.Security, "应用白名单", "已保护 ${state.whitelistCount} 个应用",
-                            onClick = actions.onOpenWhitelist)
-                    }
-                } else {
-                    Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                        SettingsShortcut(Icons.Rounded.DarkMode, "界面与主题", state.appearance.themeMode.label,
-                            actions.onOpenAppearance, Modifier.weight(1f).fillMaxHeight())
-                        SettingsShortcut(Icons.Rounded.Security, "应用白名单", "已保护 ${state.whitelistCount} 个应用",
-                            actions.onOpenWhitelist, Modifier.weight(1f).fillMaxHeight())
-                    }
-                }
+            VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+                VideoListRow(Icons.Rounded.DarkMode, "界面与主题", state.appearance.themeMode.label,
+                    onClick = actions.onOpenAppearance)
+                VideoDivider()
+                VideoListRow(Icons.Rounded.Security, "应用白名单", "已保护 ${state.whitelistCount} 个应用",
+                    onClick = actions.onOpenWhitelist)
             }
         }
         item { VideoSectionTitle("自动任务", "按你的使用习惯运行") }
         item {
-            SettingsGroup(
-                Icons.Rounded.SettingsSuggest, "清理执行条件",
-                "${conditionSummary(scheduler.screenOffOnly, scheduler.chargingOnly, scheduler.idleOnly)} · 电量 ≥ ${scheduler.minBattery}%",
-                showExecution, { showExecution = !showExecution }
-            ) {
-                VideoSwitchRow(Icons.Rounded.DarkMode, "仅息屏时执行", "使用手机时暂缓清理", scheduler.screenOffOnly,
-                    { actions.onUpdateScheduler(scheduler.copy(screenOffOnly = it)) })
+            VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+                SettingsGroup(
+                    Icons.Rounded.SettingsSuggest, "清理执行条件",
+                    "${conditionSummary(scheduler.screenOffOnly, scheduler.chargingOnly, scheduler.idleOnly)} · 电量 ≥ ${scheduler.minBattery}%",
+                    showExecution, { showExecution = !showExecution }
+                ) {
+                    VideoSwitchRow(Icons.Rounded.DarkMode, "仅息屏时执行", "使用手机时暂缓清理", scheduler.screenOffOnly,
+                        { actions.onUpdateScheduler(scheduler.copy(screenOffOnly = it)) })
+                    VideoDivider()
+                    VideoSwitchRow(Icons.Rounded.BatterySaver, "仅充电时执行", "连接电源后开始", scheduler.chargingOnly,
+                        { actions.onUpdateScheduler(scheduler.copy(chargingOnly = it)) })
+                    VideoDivider()
+                    VideoSwitchRow(Icons.Rounded.SettingsSuggest, "仅空闲时执行", "设备空闲后开始", scheduler.idleOnly,
+                        { actions.onUpdateScheduler(scheduler.copy(idleOnly = it)) })
+                    VideoDivider()
+                    VideoListRow(Icons.Rounded.BatterySaver, "最低执行电量", "电量不足时等待", value = "${scheduler.minBattery}%", onClick = { editBattery = true })
+                    VideoDivider()
+                    VideoListRow(Icons.Rounded.Security, "单文件清理上限", "大于上限的文件会保留", value = "${scheduler.maxFileMb} MB", onClick = { editFileLimit = true })
+                }
                 VideoDivider()
-                VideoSwitchRow(Icons.Rounded.BatterySaver, "仅充电时执行", "连接电源后开始", scheduler.chargingOnly,
-                    { actions.onUpdateScheduler(scheduler.copy(chargingOnly = it)) })
+                SettingsGroup(Icons.Rounded.FolderCopy, "归类执行条件",
+                    conditionSummary(scheduler.organizeScreenOffOnly, scheduler.organizeChargingOnly, scheduler.organizeIdleOnly),
+                    showOrganizer, { showOrganizer = !showOrganizer }) {
+                    VideoSwitchRow(Icons.Rounded.DarkMode, "归类时等待息屏", "避免打断前台使用", scheduler.organizeScreenOffOnly,
+                        { actions.onUpdateScheduler(scheduler.copy(organizeScreenOffOnly = it)) })
+                    VideoDivider()
+                    VideoSwitchRow(Icons.Rounded.BatterySaver, "归类时等待充电", "连接电源后整理", scheduler.organizeChargingOnly,
+                        { actions.onUpdateScheduler(scheduler.copy(organizeChargingOnly = it)) })
+                    VideoDivider()
+                    VideoSwitchRow(Icons.Rounded.SettingsSuggest, "归类时等待空闲", "设备空闲后整理", scheduler.organizeIdleOnly,
+                        { actions.onUpdateScheduler(scheduler.copy(organizeIdleOnly = it)) })
+                }
                 VideoDivider()
-                VideoSwitchRow(Icons.Rounded.SettingsSuggest, "仅空闲时执行", "设备空闲后开始", scheduler.idleOnly,
-                    { actions.onUpdateScheduler(scheduler.copy(idleOnly = it)) })
-                VideoDivider()
-                VideoListRow(Icons.Rounded.BatterySaver, "最低执行电量", "电量不足时等待", value = "${scheduler.minBattery}%", onClick = { editBattery = true })
-                VideoDivider()
-                VideoListRow(Icons.Rounded.Security, "单文件清理上限", "大于上限的文件会保留", value = "${scheduler.maxFileMb} MB", onClick = { editFileLimit = true })
-            }
-        }
-        item {
-            SettingsGroup(Icons.Rounded.FolderCopy, "归类执行条件",
-                conditionSummary(scheduler.organizeScreenOffOnly, scheduler.organizeChargingOnly, scheduler.organizeIdleOnly),
-                showOrganizer, { showOrganizer = !showOrganizer }) {
-                VideoSwitchRow(Icons.Rounded.DarkMode, "归类时等待息屏", "避免打断前台使用", scheduler.organizeScreenOffOnly,
-                    { actions.onUpdateScheduler(scheduler.copy(organizeScreenOffOnly = it)) })
-                VideoDivider()
-                VideoSwitchRow(Icons.Rounded.BatterySaver, "归类时等待充电", "连接电源后整理", scheduler.organizeChargingOnly,
-                    { actions.onUpdateScheduler(scheduler.copy(organizeChargingOnly = it)) })
-                VideoDivider()
-                VideoSwitchRow(Icons.Rounded.SettingsSuggest, "归类时等待空闲", "设备空闲后整理", scheduler.organizeIdleOnly,
-                    { actions.onUpdateScheduler(scheduler.copy(organizeIdleOnly = it)) })
-            }
-        }
-        item {
-            SettingsGroup(Icons.Rounded.Notifications, "任务通知",
-                if (!scheduler.notifyOnComplete) "已关闭" else if (scheduler.notifyZero) "每次任务完成后提醒" else "有清理结果时提醒",
-                showNotifications, { showNotifications = !showNotifications }) {
-                VideoSwitchRow(Icons.Rounded.Notifications, "任务完成通知", "自动任务结束后显示结果", scheduler.notifyOnComplete,
-                    { actions.onUpdateScheduler(scheduler.copy(notifyOnComplete = it)) })
-                VideoDivider()
-                VideoSwitchRow(Icons.Rounded.Notifications, "零结果也通知", "没有可清理内容时也提醒", scheduler.notifyZero,
-                    { actions.onUpdateScheduler(scheduler.copy(notifyZero = it)) })
+                SettingsGroup(Icons.Rounded.Notifications, "任务通知",
+                    if (!scheduler.notifyOnComplete) "已关闭" else if (scheduler.notifyZero) "每次任务完成后提醒" else "有清理结果时提醒",
+                    showNotifications, { showNotifications = !showNotifications }) {
+                    VideoSwitchRow(Icons.Rounded.Notifications, "任务完成通知", "自动任务结束后显示结果", scheduler.notifyOnComplete,
+                        { actions.onUpdateScheduler(scheduler.copy(notifyOnComplete = it)) })
+                    VideoDivider()
+                    VideoSwitchRow(Icons.Rounded.Notifications, "零结果也通知", "没有可清理内容时也提醒", scheduler.notifyZero,
+                        { actions.onUpdateScheduler(scheduler.copy(notifyZero = it)) })
+                }
             }
         }
         item {
@@ -199,52 +174,27 @@ fun VideoSettingsScreenMiuix(state: SettingsUiState, actions: SettingsUiActions)
 private fun ServiceOverview(state: SettingsUiState) {
     var expanded by rememberSaveable { mutableStateOf(false) }
     VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(),
-        containerColor = lerp(BaiZeTokens.colors.surfaceRaised, MaterialTheme.colorScheme.primary, .035f),
-        contentPadding = 20) {
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                Text("清理服务", fontSize = 22.sp, lineHeight = 29.sp, fontWeight = FontWeight.SemiBold)
-                Text(if (state.scheduler.enabled) "自动计划已开启" else "自动计划已暂停",
-                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            VideoStatusPill(when {
-                state.running -> "执行中"
-                state.ready -> "已就绪"
-                state.connected -> "准备中"
-                else -> "待连接"
-            }, state.ready || state.running)
-        }
-        Spacer(Modifier.height(14.dp))
-        Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.primary.copy(alpha = .04f))
-            .heightIn(min = 44.dp).clickable(role = Role.Button) { expanded = !expanded }
-            .padding(horizontal = 14.dp, vertical = 11.dp),
-            verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(if (expanded) "收起服务详情" else "查看服务详情", Modifier.weight(1f),
-                style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
-            Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, null,
-                Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
-        }
+        containerColor = lerp(BaiZeTokens.colors.surfaceRaised, MaterialTheme.colorScheme.primary, .035f)) {
+        VideoListRow(Icons.Rounded.Security, "清理服务",
+            if (state.scheduler.enabled) "自动计划已开启" else "自动计划已暂停",
+            onClick = { expanded = !expanded }, trailing = {
+                Row(verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    VideoStatusPill(when {
+                        state.running -> "执行中"
+                        state.ready -> "已就绪"
+                        state.connected -> "准备中"
+                        else -> "待连接"
+                    }, state.ready || state.running)
+                    Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        if (expanded) "收起服务详情" else "查看服务详情",
+                        Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            })
         AnimatedVisibility(expanded || (!state.ready && !state.running)) {
             DetailStatusText(listOf(state.serviceText, state.schedulerText).filter { it.isNotBlank() }.distinct().joinToString("\n"),
-                Modifier.padding(top = 12.dp))
+                Modifier.padding(start = 20.dp, end = 20.dp, bottom = 18.dp))
         }
-    }
-}
-
-@Composable
-private fun SettingsShortcut(icon: ImageVector, title: String, subtitle: String, onClick: () -> Unit, modifier: Modifier) {
-    VideoCard(modifier.clip(RoundedCornerShape(24.dp)).clickable(role = Role.Button, onClick = onClick), contentPadding = 18) {
-        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-            VideoLeadingIcon(icon)
-            Spacer(Modifier.weight(1f))
-            Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .45f))
-        }
-        Spacer(Modifier.height(16.dp))
-        Text(title, fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold)
-        Spacer(Modifier.height(4.dp))
-        Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }
 
@@ -253,15 +203,14 @@ private fun SettingsGroup(
     icon: ImageVector, title: String, summary: String, expanded: Boolean,
     onToggle: () -> Unit, content: @Composable ColumnScope.() -> Unit
 ) {
-    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+    Column {
         VideoListRow(icon, title, summary, onClick = onToggle, trailing = {
             Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
                 contentDescription = if (expanded) "收起$title" else "展开$title",
                 modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
         })
         AnimatedVisibility(expanded) {
-            Column(Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
-                .clip(RoundedCornerShape(16.dp)).background(BaiZeTokens.colors.surfaceOverlay.copy(alpha = .45f)), content = content)
+            Column(Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp), content = content)
         }
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/VideoSettingsScreenMiuix.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/settings/miuix/VideoSettingsScreenMiuix.kt
@@ -1,21 +1,35 @@
 package io.github.xgl34222220.baize.ui.settings.miuix
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.BatterySaver
 import androidx.compose.material.icons.rounded.BugReport
+import androidx.compose.material.icons.rounded.ChevronRight
 import androidx.compose.material.icons.rounded.DarkMode
+import androidx.compose.material.icons.rounded.ExpandLess
+import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material.icons.rounded.FolderCopy
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.PlayArrow
@@ -23,6 +37,7 @@ import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Rule
 import androidx.compose.material.icons.rounded.Security
 import androidx.compose.material.icons.rounded.SettingsSuggest
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -34,13 +49,20 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.xgl34222220.baize.ui.clean.IntValueDialog
 import io.github.xgl34222220.baize.ui.components.DetailStatusText
+import io.github.xgl34222220.baize.ui.miuix.GlassActionButton
 import io.github.xgl34222220.baize.ui.miuix.VideoCard
 import io.github.xgl34222220.baize.ui.miuix.VideoDivider
+import io.github.xgl34222220.baize.ui.miuix.VideoLeadingIcon
 import io.github.xgl34222220.baize.ui.miuix.VideoListRow
 import io.github.xgl34222220.baize.ui.miuix.VideoSectionTitle
 import io.github.xgl34222220.baize.ui.miuix.VideoStatusPill
@@ -48,6 +70,7 @@ import io.github.xgl34222220.baize.ui.miuix.VideoSwitchRow
 import io.github.xgl34222220.baize.ui.miuix.VideoTopBar
 import io.github.xgl34222220.baize.ui.settings.SettingsUiActions
 import io.github.xgl34222220.baize.ui.settings.SettingsUiState
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 
 @Composable
 fun VideoSettingsScreenMiuix(state: SettingsUiState, actions: SettingsUiActions) {
@@ -72,106 +95,173 @@ fun VideoSettingsScreenMiuix(state: SettingsUiState, actions: SettingsUiActions)
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = bottomInset + 112.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         item {
             VideoTopBar(title = "设置", actions = {
                 TextButton(onClick = { actions.onSaveScheduler(scheduler) }, enabled = !scheduler.saving) {
-                    Text(if (scheduler.saving) "保存中" else "保存", fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                    Text(if (scheduler.saving) "保存中" else "保存", fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
                 }
             })
         }
+        item { ServiceOverview(state) }
         item {
-            Column(Modifier.padding(horizontal = 24.dp, vertical = 4.dp)) {
-                Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                    Text("清理服务", Modifier.weight(1f), fontSize = 16.sp, lineHeight = 22.sp,
-                        fontWeight = FontWeight.Medium)
-                    VideoStatusPill(when { state.running -> "执行中"; state.ready -> "已就绪"; state.connected -> "准备中"; else -> "待连接" }, state.ready || state.running)
-                }
-                DetailStatusText(listOf(state.serviceText, state.schedulerText).filter { it.isNotBlank() }.distinct().joinToString("\n"),
-                    Modifier.padding(top = 8.dp, bottom = 4.dp))
-            }
-        }
-        item { VideoSectionTitle("常用设置") }
-        item {
-            VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(), contentPadding = 0) {
-                VideoListRow(Icons.Rounded.DarkMode, "界面与主题", "${state.appearance.uiStyle.label} · ${state.appearance.themeMode.label} · ${if (state.appearance.monetEnabled) "壁纸配色" else state.appearance.accent.label}", onClick = actions.onOpenAppearance)
-                VideoDivider()
-                VideoListRow(Icons.Rounded.Security, "应用白名单", "跳过重要应用", value = "${state.whitelistCount} 个", onClick = actions.onOpenWhitelist)
-                VideoDivider()
-                VideoListRow(Icons.Rounded.Rule, "清理结果与保护", "查看清理明细与保留项", onClick = actions.onOpenAudit)
-            }
-        }
-        item { VideoSectionTitle("自动任务") }
-        item {
-            VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(), contentPadding = 0) {
-                VideoListRow(Icons.Rounded.SettingsSuggest, "清理执行条件",
-                    conditionSummary(scheduler.screenOffOnly, scheduler.chargingOnly, scheduler.idleOnly),
-                    value = if (showExecution) "收起" else "调整", onClick = { showExecution = !showExecution })
-                AnimatedVisibility(showExecution) {
-                    Column {
+            BoxWithConstraints(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+                if (maxWidth < 320.dp || LocalDensity.current.fontScale > 1.2f) {
+                    VideoCard(Modifier.fillMaxWidth()) {
+                        VideoListRow(Icons.Rounded.DarkMode, "界面与主题", state.appearance.themeMode.label,
+                            onClick = actions.onOpenAppearance)
                         VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.DarkMode, "仅息屏时执行", "使用手机时暂缓后台清理", scheduler.screenOffOnly,
-                            { actions.onUpdateScheduler(scheduler.copy(screenOffOnly = it)) })
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.BatterySaver, "仅充电时执行", "连接电源后再开始任务", scheduler.chargingOnly,
-                            { actions.onUpdateScheduler(scheduler.copy(chargingOnly = it)) })
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.SettingsSuggest, "仅空闲时执行", "设备空闲后再清理", scheduler.idleOnly,
-                            { actions.onUpdateScheduler(scheduler.copy(idleOnly = it)) })
+                        VideoListRow(Icons.Rounded.Security, "应用白名单", "已保护 ${state.whitelistCount} 个应用",
+                            onClick = actions.onOpenWhitelist)
+                    }
+                } else {
+                    Row(Modifier.fillMaxWidth().height(IntrinsicSize.Min), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        SettingsShortcut(Icons.Rounded.DarkMode, "界面与主题", state.appearance.themeMode.label,
+                            actions.onOpenAppearance, Modifier.weight(1f).fillMaxHeight())
+                        SettingsShortcut(Icons.Rounded.Security, "应用白名单", "已保护 ${state.whitelistCount} 个应用",
+                            actions.onOpenWhitelist, Modifier.weight(1f).fillMaxHeight())
                     }
                 }
+            }
+        }
+        item { VideoSectionTitle("自动任务", "按你的使用习惯运行") }
+        item {
+            SettingsGroup(
+                Icons.Rounded.SettingsSuggest, "清理执行条件",
+                "${conditionSummary(scheduler.screenOffOnly, scheduler.chargingOnly, scheduler.idleOnly)} · 电量 ≥ ${scheduler.minBattery}%",
+                showExecution, { showExecution = !showExecution }
+            ) {
+                VideoSwitchRow(Icons.Rounded.DarkMode, "仅息屏时执行", "使用手机时暂缓清理", scheduler.screenOffOnly,
+                    { actions.onUpdateScheduler(scheduler.copy(screenOffOnly = it)) })
+                VideoDivider()
+                VideoSwitchRow(Icons.Rounded.BatterySaver, "仅充电时执行", "连接电源后开始", scheduler.chargingOnly,
+                    { actions.onUpdateScheduler(scheduler.copy(chargingOnly = it)) })
+                VideoDivider()
+                VideoSwitchRow(Icons.Rounded.SettingsSuggest, "仅空闲时执行", "设备空闲后开始", scheduler.idleOnly,
+                    { actions.onUpdateScheduler(scheduler.copy(idleOnly = it)) })
                 VideoDivider()
                 VideoListRow(Icons.Rounded.BatterySaver, "最低执行电量", "电量不足时等待", value = "${scheduler.minBattery}%", onClick = { editBattery = true })
                 VideoDivider()
-                VideoListRow(Icons.Rounded.Security, "单文件清理上限", "大于上限的文件不会自动清理", value = "${scheduler.maxFileMb} MB", onClick = { editFileLimit = true })
+                VideoListRow(Icons.Rounded.Security, "单文件清理上限", "大于上限的文件会保留", value = "${scheduler.maxFileMb} MB", onClick = { editFileLimit = true })
+            }
+        }
+        item {
+            SettingsGroup(Icons.Rounded.FolderCopy, "归类执行条件",
+                conditionSummary(scheduler.organizeScreenOffOnly, scheduler.organizeChargingOnly, scheduler.organizeIdleOnly),
+                showOrganizer, { showOrganizer = !showOrganizer }) {
+                VideoSwitchRow(Icons.Rounded.DarkMode, "归类时等待息屏", "避免打断前台使用", scheduler.organizeScreenOffOnly,
+                    { actions.onUpdateScheduler(scheduler.copy(organizeScreenOffOnly = it)) })
                 VideoDivider()
-                VideoListRow(Icons.Rounded.FolderCopy, "归类执行条件",
-                    conditionSummary(scheduler.organizeScreenOffOnly, scheduler.organizeChargingOnly, scheduler.organizeIdleOnly),
-                    value = if (showOrganizer) "收起" else "调整", onClick = { showOrganizer = !showOrganizer })
-                AnimatedVisibility(showOrganizer) {
-                    Column {
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.DarkMode, "归类时等待息屏", "避免移动文件打断前台使用", scheduler.organizeScreenOffOnly,
-                            { actions.onUpdateScheduler(scheduler.copy(organizeScreenOffOnly = it)) })
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.BatterySaver, "归类时等待充电", "接通电源后整理文件", scheduler.organizeChargingOnly,
-                            { actions.onUpdateScheduler(scheduler.copy(organizeChargingOnly = it)) })
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.SettingsSuggest, "归类时等待空闲", "设备空闲后再整理文件", scheduler.organizeIdleOnly,
-                            { actions.onUpdateScheduler(scheduler.copy(organizeIdleOnly = it)) })
-                    }
-                }
+                VideoSwitchRow(Icons.Rounded.BatterySaver, "归类时等待充电", "连接电源后整理", scheduler.organizeChargingOnly,
+                    { actions.onUpdateScheduler(scheduler.copy(organizeChargingOnly = it)) })
                 VideoDivider()
-                VideoListRow(Icons.Rounded.Notifications, "任务通知",
-                    if (!scheduler.notifyOnComplete) "任务完成后不提醒" else if (scheduler.notifyZero) "每次任务完成后提醒" else "清理有结果时提醒",
-                    value = if (showNotifications) "收起" else "调整", onClick = { showNotifications = !showNotifications })
-                AnimatedVisibility(showNotifications) {
-                    Column {
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.Notifications, "任务完成通知", "自动任务结束后显示结果", scheduler.notifyOnComplete,
-                            { actions.onUpdateScheduler(scheduler.copy(notifyOnComplete = it)) })
-                        VideoDivider()
-                        VideoSwitchRow(Icons.Rounded.Notifications, "零结果也通知", "未发现可清理内容时也提醒", scheduler.notifyZero,
-                            { actions.onUpdateScheduler(scheduler.copy(notifyZero = it)) })
-                    }
-                }
+                VideoSwitchRow(Icons.Rounded.SettingsSuggest, "归类时等待空闲", "设备空闲后整理", scheduler.organizeIdleOnly,
+                    { actions.onUpdateScheduler(scheduler.copy(organizeIdleOnly = it)) })
+            }
+        }
+        item {
+            SettingsGroup(Icons.Rounded.Notifications, "任务通知",
+                if (!scheduler.notifyOnComplete) "已关闭" else if (scheduler.notifyZero) "每次任务完成后提醒" else "有清理结果时提醒",
+                showNotifications, { showNotifications = !showNotifications }) {
+                VideoSwitchRow(Icons.Rounded.Notifications, "任务完成通知", "自动任务结束后显示结果", scheduler.notifyOnComplete,
+                    { actions.onUpdateScheduler(scheduler.copy(notifyOnComplete = it)) })
+                VideoDivider()
+                VideoSwitchRow(Icons.Rounded.Notifications, "零结果也通知", "没有可清理内容时也提醒", scheduler.notifyZero,
+                    { actions.onUpdateScheduler(scheduler.copy(notifyZero = it)) })
             }
         }
         item {
             Column(Modifier.padding(horizontal = 20.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("执行条件与通知需保存后生效。", fontSize = 12.sp, lineHeight = 19.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                GlassActionButton(if (scheduler.saving) "正在保存…" else "保存任务设置",
+                    onClick = { actions.onSaveScheduler(scheduler) }, enabled = !scheduler.saving,
+                    secondary = true, modifier = Modifier.fillMaxWidth())
+                Text("执行条件与通知保存后生效。", Modifier.padding(horizontal = 4.dp),
+                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
-        item { VideoSectionTitle("恢复与诊断") }
+        item { VideoSectionTitle("记录与诊断") }
         item {
-            VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(), contentPadding = 0) {
-                VideoListRow(Icons.Rounded.PlayArrow, "断点续清", "从已保存的扫描结果继续处理", onClick = actions.onOpenResumableScan)
+            VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+                VideoListRow(Icons.Rounded.Rule, "清理结果与保护", "查看明细与保留项", onClick = actions.onOpenAudit)
                 VideoDivider()
-                VideoListRow(Icons.Rounded.Refresh, "重新连接服务", "授权变化或服务异常时使用", onClick = actions.onReconnect)
+                VideoListRow(Icons.Rounded.PlayArrow, "断点续清", "继续已保存的扫描任务", onClick = actions.onOpenResumableScan)
                 VideoDivider()
-                VideoListRow(Icons.Rounded.BugReport, "崩溃与诊断信息", "查看最近异常与故障记录", onClick = actions.onOpenCrashDiagnostics)
+                VideoListRow(Icons.Rounded.Refresh, "重新连接服务", "重新获取服务连接", onClick = actions.onReconnect)
+                VideoDivider()
+                VideoListRow(Icons.Rounded.BugReport, "崩溃与诊断信息", "查看异常与故障记录", onClick = actions.onOpenCrashDiagnostics)
             }
+        }
+    }
+}
+
+@Composable
+private fun ServiceOverview(state: SettingsUiState) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth(),
+        containerColor = lerp(BaiZeTokens.colors.surfaceRaised, MaterialTheme.colorScheme.primary, .035f),
+        contentPadding = 20) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text("清理服务", fontSize = 22.sp, lineHeight = 29.sp, fontWeight = FontWeight.SemiBold)
+                Text(if (state.scheduler.enabled) "自动计划已开启" else "自动计划已暂停",
+                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            VideoStatusPill(when {
+                state.running -> "执行中"
+                state.ready -> "已就绪"
+                state.connected -> "准备中"
+                else -> "待连接"
+            }, state.ready || state.running)
+        }
+        Spacer(Modifier.height(14.dp))
+        Row(Modifier.fillMaxWidth().clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.primary.copy(alpha = .04f))
+            .heightIn(min = 44.dp).clickable(role = Role.Button) { expanded = !expanded }
+            .padding(horizontal = 14.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(if (expanded) "收起服务详情" else "查看服务详情", Modifier.weight(1f),
+                style = MaterialTheme.typography.labelLarge, color = MaterialTheme.colorScheme.primary)
+            Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, null,
+                Modifier.size(18.dp), tint = MaterialTheme.colorScheme.primary)
+        }
+        AnimatedVisibility(expanded || (!state.ready && !state.running)) {
+            DetailStatusText(listOf(state.serviceText, state.schedulerText).filter { it.isNotBlank() }.distinct().joinToString("\n"),
+                Modifier.padding(top = 12.dp))
+        }
+    }
+}
+
+@Composable
+private fun SettingsShortcut(icon: ImageVector, title: String, subtitle: String, onClick: () -> Unit, modifier: Modifier) {
+    VideoCard(modifier.clip(RoundedCornerShape(24.dp)).clickable(role = Role.Button, onClick = onClick), contentPadding = 18) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            VideoLeadingIcon(icon)
+            Spacer(Modifier.weight(1f))
+            Icon(Icons.Rounded.ChevronRight, null, Modifier.size(16.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = .45f))
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(title, fontSize = 16.sp, lineHeight = 22.sp, fontWeight = FontWeight.SemiBold)
+        Spacer(Modifier.height(4.dp))
+        Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+@Composable
+private fun SettingsGroup(
+    icon: ImageVector, title: String, summary: String, expanded: Boolean,
+    onToggle: () -> Unit, content: @Composable ColumnScope.() -> Unit
+) {
+    VideoCard(Modifier.padding(horizontal = 20.dp).fillMaxWidth()) {
+        VideoListRow(icon, title, summary, onClick = onToggle, trailing = {
+            Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                contentDescription = if (expanded) "收起$title" else "展开$title",
+                modifier = Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
+        })
+        AnimatedVisibility(expanded) {
+            Column(Modifier.padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+                .clip(RoundedCornerShape(16.dp)).background(BaiZeTokens.colors.surfaceOverlay.copy(alpha = .45f)), content = content)
         }
     }
 }
@@ -180,5 +270,5 @@ private fun conditionSummary(screenOff: Boolean, charging: Boolean, idle: Boolea
     buildList {
         if (screenOff) add("息屏")
         if (charging) add("充电")
-        if (idle) add("系统空闲")
-    }.let { if (it.isEmpty()) "不限息屏、充电与空闲" else "等待${it.joinToString("、")}" }
+        if (idle) add("空闲")
+    }.let { if (it.isEmpty()) "随时执行" else "等待${it.joinToString("、")}" }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
@@ -35,13 +35,24 @@ private val MaterialShapes = Shapes(
     extraLarge = RoundedCornerShape(32.dp)
 )
 
-/** 12 / 16 / 24 / 32dp distinguish controls, insets, cards and floating surfaces. */
+/** Active LuoShu Miuix shape hierarchy; Material remains independent. */
 private val MiuixShapes = Shapes(
-    extraSmall = RoundedCornerShape(10.dp),
-    small = RoundedCornerShape(12.dp),
-    medium = RoundedCornerShape(16.dp),
+    extraSmall = RoundedCornerShape(7.dp),
+    small = RoundedCornerShape(11.dp),
+    medium = RoundedCornerShape(18.dp),
     large = RoundedCornerShape(24.dp),
-    extraLarge = RoundedCornerShape(32.dp)
+    extraLarge = RoundedCornerShape(30.dp)
+)
+
+private val LuoShuMiuixCorners = DefaultBaiZeCorners.copy(
+    small = RoundedCornerShape(11.dp), medium = RoundedCornerShape(18.dp),
+    extraLarge = RoundedCornerShape(30.dp)
+)
+private val LuoShuMiuixTypeScale = DefaultBaiZeTypeScale.copy(
+    title = TextStyle(fontSize = 17.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold),
+    headline = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
+    body = TextStyle(fontSize = 14.sp, lineHeight = 21.sp),
+    bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 23.sp)
 )
 
 private val SharedTypography = Typography(
@@ -60,6 +71,22 @@ private val SharedTypography = Typography(
     labelSmall = TextStyle(fontSize = 11.sp, lineHeight = 16.sp, fontWeight = FontWeight.Normal)
 )
 
+// Ported from LuoShu ui/theme/LuoShuTheme.kt at fe4df5f. Material keeps its own typography.
+private val LuoShuMiuixTypography = Typography(
+    displaySmall = TextStyle(fontSize = 34.sp, lineHeight = 39.sp, fontWeight = FontWeight.Bold),
+    headlineLarge = TextStyle(fontSize = 26.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
+    headlineMedium = TextStyle(fontSize = 26.sp, lineHeight = 34.sp, fontWeight = FontWeight.Bold),
+    headlineSmall = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
+    titleLarge = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold),
+    titleMedium = TextStyle(fontSize = 17.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold),
+    titleSmall = TextStyle(fontSize = 15.sp, lineHeight = 21.sp, fontWeight = FontWeight.SemiBold),
+    bodyLarge = TextStyle(fontSize = 15.sp, lineHeight = 23.sp),
+    bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 21.sp),
+    bodySmall = TextStyle(fontSize = 12.sp, lineHeight = 18.sp),
+    labelLarge = TextStyle(fontSize = 13.sp, fontWeight = FontWeight.Bold),
+    labelSmall = TextStyle(fontSize = 11.sp, lineHeight = 16.sp, fontWeight = FontWeight.Medium, letterSpacing = .2.sp)
+)
+
 /** Both appearances resolve surfaces from the selected palette, including Monet and AMOLED. */
 @Composable
 fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
@@ -71,13 +98,13 @@ fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
         withAmoled = amoled,
         style = settings.kolorStyle.toPaletteStyle(),
         shapes = if (settings.uiStyle == UiStyle.MATERIAL) MaterialShapes else MiuixShapes,
-        typography = SharedTypography,
+        typography = if (settings.uiStyle == UiStyle.MIUIX) LuoShuMiuixTypography else SharedTypography,
         animate = true
     ) {
         val generatedScheme = MaterialTheme.colorScheme
         // The default blue is deliberately crisp. Explicit Monet, alternate accents and
         // the neutral/vibrant palette options continue to use their generated colours.
-        val defaultBlue = !settings.monetEnabled &&
+        val defaultBlue = settings.uiStyle == UiStyle.MATERIAL && !settings.monetEnabled &&
             settings.seedArgb == AccentOptions.first().argb && settings.kolorStyle == KolorStyle.SOFT
         val scheme = if (defaultBlue) generatedScheme.copy(
             primary = if (dark) Color(0xFFA9CAFF) else Color(0xFF376BE6),
@@ -89,7 +116,25 @@ fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
             onSurfaceVariant = if (dark) Color(0xFFADB8CA) else Color(0xFF626F82)
         ) else generatedScheme
         val semantic = if (dark) DarkBaiZeColors else LightBaiZeColors
-        val colors = semantic.copy(
+        val colors = if (settings.uiStyle == UiStyle.MIUIX) semantic.copy(
+            surfaceBase = when {
+                amoled -> Color.Black
+                dark -> scheme.surfaceContainerLowest
+                else -> lerp(Color(0xFFF4F6FA), scheme.primaryContainer, .07f)
+            },
+            surfaceRaised = when {
+                amoled -> Color(0xFF111214)
+                dark -> scheme.surfaceContainerLow
+                else -> scheme.surfaceContainerLowest
+            },
+            surfaceOverlay = when {
+                amoled -> Color(0xFF1B1C20)
+                dark -> scheme.surfaceContainerHigh
+                else -> lerp(scheme.surfaceContainerLowest, scheme.primaryContainer, .20f)
+            },
+            success = if (dark) Color(0xFF69D9AD) else Color(0xFF187B58),
+            warning = if (dark) Color(0xFFF3C378) else Color(0xFF956319)
+        ) else semantic.copy(
             surfaceBase = when {
                 amoled -> Color.Black
                 dark -> lerp(DarkBaiZeColors.surfaceBase, scheme.primaryContainer, .03f)
@@ -110,9 +155,9 @@ fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
             CompositionLocalProvider(
                 LocalContentColor provides scheme.onSurface,
                 LocalBaiZeColors provides colors,
-                LocalBaiZeCorners provides DefaultBaiZeCorners,
+                LocalBaiZeCorners provides if (settings.uiStyle == UiStyle.MIUIX) LuoShuMiuixCorners else DefaultBaiZeCorners,
                 LocalBaiZeSpacing provides DefaultBaiZeSpacing,
-                LocalBaiZeTypeScale provides DefaultBaiZeTypeScale,
+                LocalBaiZeTypeScale provides if (settings.uiStyle == UiStyle.MIUIX) LuoShuMiuixTypeScale else DefaultBaiZeTypeScale,
                 content = content
             )
         }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
@@ -9,11 +9,9 @@ import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.lerp
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -166,14 +164,11 @@ fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
 
 @Composable
 private fun resolveSeedColor(settings: AppearanceSettings): Color {
-    val context = LocalContext.current
-    val configuration = LocalConfiguration.current
-    return remember(settings.monetEnabled, settings.seedArgb, configuration) {
-        if (settings.monetEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            Color(context.getColor(android.R.color.system_accent1_500))
-        } else {
-            Color(settings.seedArgb)
-        }
+    val resources = LocalResources.current
+    return if (settings.monetEnabled && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        Color(resources.getColor(android.R.color.system_accent1_500, null))
+    } else {
+        Color(settings.seedArgb)
     }
 }
 

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTheme.kt
@@ -26,35 +26,35 @@ import io.github.xgl34222220.baize.ui.appearance.KolorStyle
 import io.github.xgl34222220.baize.ui.appearance.ThemeMode
 import io.github.xgl34222220.baize.ui.appearance.UiStyle
 
-/** Material 3：标准化控件皮肤，与 MIUIX 共用同一圆角等级。 */
+/** Material controls and MIUIX surfaces share the same corner hierarchy. */
 private val MaterialShapes = Shapes(
     extraSmall = RoundedCornerShape(10.dp),
     small = RoundedCornerShape(12.dp),
     medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(18.dp),
-    extraLarge = RoundedCornerShape(24.dp)
+    large = RoundedCornerShape(24.dp),
+    extraLarge = RoundedCornerShape(32.dp)
 )
 
-/** MIUIX / HyperOS：12 / 16 / 18dp 区分控件、分组与浮层。 */
+/** 12 / 16 / 24 / 32dp distinguish controls, insets, cards and floating surfaces. */
 private val MiuixShapes = Shapes(
     extraSmall = RoundedCornerShape(10.dp),
     small = RoundedCornerShape(12.dp),
     medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(18.dp),
-    extraLarge = RoundedCornerShape(24.dp)
+    large = RoundedCornerShape(24.dp),
+    extraLarge = RoundedCornerShape(32.dp)
 )
 
 private val SharedTypography = Typography(
     displaySmall = TextStyle(fontSize = 34.sp, lineHeight = 40.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.7).sp),
-    headlineLarge = TextStyle(fontSize = 24.sp, lineHeight = 30.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.5).sp),
+    headlineLarge = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-.7).sp),
     headlineMedium = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.4).sp),
     headlineSmall = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.4).sp),
     titleLarge = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.4).sp),
-    titleMedium = TextStyle(fontSize = 14.5.sp, lineHeight = 20.sp, fontWeight = FontWeight.Medium),
+    titleMedium = TextStyle(fontSize = 15.sp, lineHeight = 22.sp, fontWeight = FontWeight.Medium),
     titleSmall = TextStyle(fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.Medium),
     bodyLarge = TextStyle(fontSize = 14.5.sp, lineHeight = 21.sp, fontWeight = FontWeight.Normal, letterSpacing = .15.sp),
     bodyMedium = TextStyle(fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.Normal, letterSpacing = .15.sp),
-    bodySmall = TextStyle(fontSize = 12.sp, lineHeight = 18.sp, fontWeight = FontWeight.Normal),
+    bodySmall = TextStyle(fontSize = 12.5.sp, lineHeight = 18.sp, fontWeight = FontWeight.Normal),
     labelLarge = TextStyle(fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.Medium),
     labelMedium = TextStyle(fontSize = 12.sp, lineHeight = 18.sp, fontWeight = FontWeight.Medium),
     labelSmall = TextStyle(fontSize = 11.sp, lineHeight = 16.sp, fontWeight = FontWeight.Normal)
@@ -80,11 +80,13 @@ fun BaiZeTheme(settings: AppearanceSettings, content: @Composable () -> Unit) {
         val defaultBlue = !settings.monetEnabled &&
             settings.seedArgb == AccentOptions.first().argb && settings.kolorStyle == KolorStyle.SOFT
         val scheme = if (defaultBlue) generatedScheme.copy(
-            primary = if (dark) Color(0xFFA9CAFF) else Color(0xFF2364DB),
+            primary = if (dark) Color(0xFFA9CAFF) else Color(0xFF376BE6),
             onPrimary = if (dark) Color(0xFF082C63) else Color.White,
             primaryContainer = if (dark) Color(0xFF1C3656) else Color(0xFFE5EEFF),
             onPrimaryContainer = if (dark) Color(0xFFDCE9FF) else Color(0xFF163C77),
-            surfaceTint = if (dark) Color(0xFFA9CAFF) else Color(0xFF2364DB)
+            surfaceTint = if (dark) Color(0xFFA9CAFF) else Color(0xFF376BE6),
+            onSurface = if (dark) Color(0xFFE8EDF5) else Color(0xFF202A3B),
+            onSurfaceVariant = if (dark) Color(0xFFADB8CA) else Color(0xFF626F82)
         ) else generatedScheme
         val semantic = if (dark) DarkBaiZeColors else LightBaiZeColors
         val colors = semantic.copy(

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTokens.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ui/theme/BaiZeTokens.kt
@@ -36,9 +36,9 @@ val LightBaiZeColors = BaiZeColors(
     warning = Color(0xFF956319),
     danger = Color(0xFFD83A3A),
     info = Color(0xFF245FD3),
-    surfaceBase = Color(0xFFF5F6F8),
+    surfaceBase = Color(0xFFF1F4F9),
     surfaceRaised = Color(0xFFFFFFFF),
-    surfaceOverlay = Color(0xFFEDEFF3)
+    surfaceOverlay = Color(0xFFE8EDF5)
 )
 
 /** 普通深色：避免纯黑压迫感，维持柔和层级。 */
@@ -47,9 +47,9 @@ val DarkBaiZeColors = BaiZeColors(
     warning = Color(0xFFE8B45D),
     danger = Color(0xFFFF8585),
     info = Color(0xFF8EAFFF),
-    surfaceBase = Color(0xFF111316),
-    surfaceRaised = Color(0xFF1B1E23),
-    surfaceOverlay = Color(0xFF262A30)
+    surfaceBase = Color(0xFF101319),
+    surfaceRaised = Color(0xFF1C222C),
+    surfaceOverlay = Color(0xFF293240)
 )
 
 /** AMOLED：页面纯黑，主体与次级容器保留极轻阶差。 */
@@ -76,8 +76,8 @@ data class BaiZeCorners(
 val DefaultBaiZeCorners = BaiZeCorners(
     small = RoundedCornerShape(12.dp),
     medium = RoundedCornerShape(16.dp),
-    large = RoundedCornerShape(18.dp),
-    extraLarge = RoundedCornerShape(24.dp),
+    large = RoundedCornerShape(24.dp),
+    extraLarge = RoundedCornerShape(32.dp),
     full = RoundedCornerShape(percent = 50)
 )
 
@@ -111,9 +111,9 @@ val DefaultBaiZeTypeScale = BaiZeTypeScale(
     caption = TextStyle(fontSize = 12.sp, lineHeight = 18.sp, fontWeight = FontWeight.Normal),
     body = TextStyle(fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.Normal, letterSpacing = .15.sp),
     bodyLarge = TextStyle(fontSize = 14.5.sp, lineHeight = 21.sp, fontWeight = FontWeight.Normal, letterSpacing = .15.sp),
-    title = TextStyle(fontSize = 14.5.sp, lineHeight = 20.sp, fontWeight = FontWeight.Medium),
-    headline = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.4).sp),
-    display = TextStyle(fontSize = 24.sp, lineHeight = 30.sp, fontWeight = FontWeight.Medium, letterSpacing = (-.5).sp),
+    title = TextStyle(fontSize = 15.sp, lineHeight = 22.sp, fontWeight = FontWeight.Medium),
+    headline = TextStyle(fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-.4).sp),
+    display = TextStyle(fontSize = 28.sp, lineHeight = 34.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-.7).sp),
     hero = TextStyle(
         fontSize = 34.sp,
         lineHeight = 40.sp,

--- a/v2/app/src/test/java/com/topjohnwu/superuser/internal/RootServiceRecoveryTest.java
+++ b/v2/app/src/test/java/com/topjohnwu/superuser/internal/RootServiceRecoveryTest.java
@@ -77,9 +77,11 @@ public class RootServiceRecoveryTest {
     @Before public void resetManager() {
         ReflectionHelpers.setStaticField(RootServiceManager.class, "mInstance", null);
         Utils.context = RuntimeEnvironment.getApplication();
+        // Resolve only the application shadow, not Shadows' removed framework overloads.
+        org.robolectric.shadows.ShadowApplication appShadow =
+                org.robolectric.shadow.api.Shadow.extract(RuntimeEnvironment.getApplication());
         // The production broadcaster is root; the shadow sender needs its guarded permission.
-        org.robolectric.Shadows.shadowOf((Application) RuntimeEnvironment.getApplication())
-                .grantPermissions(android.Manifest.permission.BROADCAST_PACKAGE_REMOVED);
+        appShadow.grantPermissions(android.Manifest.permission.BROADCAST_PACKAGE_REMOVED);
     }
 
     private Intent intent(String service, boolean daemon) {

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/LuoShuDockTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/LuoShuDockTest.kt
@@ -1,0 +1,143 @@
+package io.github.xgl34222220.baize
+
+import android.app.Application
+import android.graphics.Bitmap
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Home
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import io.github.xgl34222220.baize.ui.appearance.*
+import io.github.xgl34222220.baize.ui.miuix.*
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import java.io.File
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], application = Application::class, qualifiers = "zh-rCN-w393dp-h852dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class LuoShuDockTest {
+    @get:Rule val compose = createAndroidComposeRule<ComponentActivity>()
+
+    @Test fun capabilityPolicyNeverUsesShaderWithoutHardwareOrEffects() {
+        assertEquals(DockRendering.OPAQUE, dockRendering(26, true, true, false, true))
+        assertEquals(DockRendering.HAZE, dockRendering(32, true, true, false, true))
+        assertEquals(DockRendering.LIQUID, dockRendering(35, true, true, true, true))
+        assertEquals(DockRendering.OPAQUE, dockRendering(35, false, true, true, true))
+        assertEquals(DockRendering.OPAQUE, dockRendering(35, true, false, true, true))
+        assertEquals(DockRendering.OPAQUE, dockRendering(35, true, true, false, false))
+    }
+
+    @Test fun allTabsNavigateWithoutStartingCleanup() {
+        var cleanups = 0
+        render(actions = actions.copy(clean = { cleanups++ }, cleanScan = { cleanups++ }))
+        listOf(1, 2, 3, 0).forEach { index ->
+            compose.onNodeWithTag("dock-tab-$index").performClick()
+            compose.onNodeWithTag("dock-tab-$index").assertIsSelected()
+        }
+        assertEquals(0, cleanups)
+        save("dock-home-light")
+    }
+
+    @Test fun taskDetailsHideDockAndBackRestoresSelection() {
+        render(page = 3)
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("自动任务设置"))
+        compose.onNodeWithText("自动任务设置").performScrollTo().performClick()
+        compose.onNodeWithTag("luoshu-dock").assertDoesNotExist()
+        save("dock-hidden-task-details")
+        compose.onNodeWithContentDescription("返回").performClick()
+        compose.onNodeWithTag("luoshu-dock").assertIsDisplayed()
+        compose.onNodeWithTag("dock-tab-3").assertIsSelected()
+    }
+
+    @Test fun diagnosticsHideDockAndSystemBackRestoresIt() {
+        render(page = 3)
+        compose.onNodeWithText("白泽状态").performClick()
+        compose.onNodeWithTag("luoshu-dock").assertDoesNotExist()
+        compose.runOnIdle { compose.activity.onBackPressedDispatcher.onBackPressed() }
+        compose.onNodeWithTag("luoshu-dock").assertIsDisplayed()
+        compose.onNodeWithTag("dock-tab-3").assertIsSelected()
+    }
+
+    @Test fun darkFallbackRemainsReadable() {
+        render(dark = true)
+        compose.onNodeWithTag("dock-shell-opaque").assertIsDisplayed()
+        save("dock-home-dark")
+    }
+
+    @Test
+    @Config(sdk = [26])
+    fun oldAndroidCanRenderWithoutLoadingTheShader() {
+        render()
+        compose.onNodeWithTag("dock-shell-opaque").assertIsDisplayed()
+        compose.onNodeWithTag("dock-tab-1").performClick()
+        compose.onNodeWithTag("dock-tab-1").assertIsSelected()
+    }
+
+    @Test fun opaqueFallbackDoesNotExposeChangingBackgroundPixels() {
+        var background by mutableStateOf(Color.Red)
+        val appearance = AppearanceSettings(blurEnabled = false, monetEnabled = false, themeMode = ThemeMode.LIGHT)
+        compose.setContent {
+            BaiZeTheme(appearance) {
+                CompositionLocalProvider(LocalAppearanceSettings provides appearance) {
+                    Box(Modifier.fillMaxSize().background(background)) {
+                        LuoShuLiquidDock(0, List(4) { MiuixLiquidNavItem("项目$it", Icons.Rounded.Home) }, {},
+                            hazeState = null, backdrop = null, effectsEnabled = false,
+                            modifier = Modifier.align(Alignment.BottomCenter))
+                    }
+                }
+            }
+        }
+        compose.waitForIdle()
+        val bounds = compose.onNodeWithTag("dock-shell-opaque").fetchSemanticsNode().boundsInRoot
+        val before = compose.runOnIdle { captureActivityContent(compose.activity) }
+        compose.runOnIdle { background = Color.Blue }
+        compose.waitForIdle()
+        val after = compose.runOnIdle { captureActivityContent(compose.activity) }
+        for (y in bounds.top.toInt() + 12 until bounds.bottom.toInt() - 12) {
+            for (x in bounds.left.toInt() + 24 until bounds.right.toInt() - 24) {
+                assertEquals("Backdrop leaked through dock at $x,$y", before.getPixel(x, y), after.getPixel(x, y))
+            }
+        }
+    }
+
+    private fun render(page: Int = 0, dark: Boolean = false, actions: DashboardActions = this.actions) {
+        compose.setContent {
+            BaiZeMiuixApp(DashboardUiState(ready = true, connected = true,
+                storageTotal = 256L * 1024 * 1024 * 1024, storageUsed = 164L * 1024 * 1024 * 1024,
+                storageFree = 92L * 1024 * 1024 * 1024, storagePercent = .64f),
+                SchedulerUiState(), actions,
+                AppearanceSettings(monetEnabled = false, blurEnabled = false,
+                    themeMode = if (dark) ThemeMode.DARK else ThemeMode.LIGHT), initialPage = page)
+        }
+        compose.waitForIdle()
+    }
+
+    private fun save(name: String) {
+        val bitmap = compose.runOnIdle { captureActivityContent(compose.activity) }
+        val output = File("build/reports/ui-screenshots/$name.png")
+        output.parentFile?.mkdirs()
+        output.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+    }
+
+    private val actions = DashboardActions(
+        refresh = {}, clean = {}, organize = {}, scan = {}, apkScan = {}, cleanScan = {},
+        dismissScan = {}, stop = {}, deep = {}, corpses = {}, audit = {},
+        updateScheduler = {}, saveScheduler = {}, schedulerCommand = {}, clearHistory = {},
+        clearRawLog = {}, reviewProtected = {}, whitelist = {}, resumableScan = {},
+        theme = {}, reconnect = {}, resetScanPerformance = {}, crash = {},
+    )
+}

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/UiVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/UiVisualReviewTest.kt
@@ -76,8 +76,37 @@ class UiVisualReviewTest {
         compose.onNodeWithText("自动清理").performScrollTo().performClick()
         compose.waitForIdle()
         save("clean-plan")
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("安装包保留时间"))
         compose.onNodeWithText("安装包保留时间").performScrollTo().assertIsDisplayed()
         save("clean-plan-apk-retention")
+    }
+
+    @Test fun homePlanIsVisibleOnTheFirstScreen() {
+        render("home-plan-visible", 0)
+        compose.onNodeWithText("自动清理").assertIsDisplayed()
+    }
+
+    @Test fun groupedHomeToolsKeepTheirOwnActions() {
+        val calls = mutableListOf<String>()
+        render("home-tools", 0, actions = previewActions.copy(
+            apkScan = { calls += "apk" }, organize = { calls += "organize" },
+            deep = { calls += "deep" }, whitelist = { calls += "whitelist" }))
+        listOf("安装包", "文件归类", "深度清理", "白名单").forEach { title ->
+            compose.onNodeWithText(title).performScrollTo().performClick()
+        }
+        assertEquals(listOf("apk", "organize", "deep", "whitelist"), calls)
+    }
+
+    @Test fun disconnectedHomeOnlyReconnects() {
+        var reconnects = 0
+        var scans = 0
+        var cleans = 0
+        render("home-reconnect-action", 0, connected = false, actions = previewActions.copy(
+            reconnect = { reconnects++ }, scan = { scans++ }, clean = { cleans++ }, cleanScan = { cleans++ }))
+        compose.onNodeWithText("连接 Root 服务").performClick()
+        assertEquals(1, reconnects)
+        assertEquals(0, scans)
+        assertEquals(0, cleans)
     }
 
     private fun render(

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/UiVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/UiVisualReviewTest.kt
@@ -8,9 +8,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.unit.Density
 import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.ThemeMode
@@ -69,6 +72,7 @@ class UiVisualReviewTest {
 
     @Test fun homePlanOpensAutomaticPlan() {
         render("home-plan-entry", 0)
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("自动清理"))
         compose.onNodeWithText("自动清理").performScrollTo().performClick()
         compose.waitForIdle()
         save("clean-plan")

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/UiVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/UiVisualReviewTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasText
@@ -92,6 +93,7 @@ class UiVisualReviewTest {
             apkScan = { calls += "apk" }, organize = { calls += "organize" },
             deep = { calls += "deep" }, whitelist = { calls += "whitelist" }))
         listOf("安装包", "文件归类", "深度清理", "白名单").forEach { title ->
+            compose.onNode(hasScrollAction()).performScrollToNode(hasText(title))
             compose.onNodeWithText(title).performScrollTo().performClick()
         }
         assertEquals(listOf("apk", "organize", "deep", "whitelist"), calls)
@@ -107,6 +109,42 @@ class UiVisualReviewTest {
         assertEquals(1, reconnects)
         assertEquals(0, scans)
         assertEquals(0, cleans)
+    }
+
+    @Test fun settingsHubOpensTaskDetailsAndReturns() {
+        render("settings-hub", 3)
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("自动任务设置"))
+        compose.onNodeWithText("自动任务设置").performScrollTo().performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("清理执行条件").assertIsDisplayed()
+        save("settings-task-details")
+        compose.onNodeWithContentDescription("返回").performClick()
+        compose.waitForIdle()
+        compose.onNodeWithText("你的白泽").assertIsDisplayed()
+    }
+
+    @Test fun settingsAppearanceAndWhitelistKeepTheirActions() {
+        var appearance = 0
+        var whitelist = 0
+        render("settings-action-routing", 3, actions = previewActions.copy(theme = { appearance++ }, whitelist = { whitelist++ }))
+        compose.onNodeWithText("外观与主题").performScrollTo().performClick()
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("应用白名单"))
+        compose.onNodeWithText("应用白名单").performScrollTo().performClick()
+        assertEquals(1, appearance)
+        assertEquals(1, whitelist)
+    }
+
+    @Test fun taskSettingsSaveTheEditedDraft() {
+        var updated: SchedulerUiState? = null
+        var saved: SchedulerUiState? = null
+        render("settings-draft", 3, actions = previewActions.copy(
+            updateScheduler = { updated = it }, saveScheduler = { saved = it }))
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("自动任务设置"))
+        compose.onNodeWithText("自动任务设置").performScrollTo().performClick()
+        compose.onNodeWithContentDescription("仅息屏时执行").performClick()
+        compose.onNodeWithText("保存").performClick()
+        assertEquals(!SchedulerUiState().screenOffOnly, updated?.screenOffOnly)
+        assertEquals(updated?.screenOffOnly, saved?.screenOffOnly)
     }
 
     private fun render(

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
@@ -68,13 +68,16 @@ class WorkbenchVisualReviewTest {
         val medium = item(0).copy(id = "medium", title = "诊断日志", groupKey = "manual", groupTitle = "示例应用", risk = "medium")
         val high = item(1).copy(id = "high", title = "离线资源", groupKey = "manual", groupTitle = "示例应用", risk = "high")
         render(ready().copy(items = listOf(medium, high), selectedIds = emptySet(), policyTitle = "保守"))
-        compose.waitUntil(5_000) { compose.onAllNodesWithText("示例应用").fetchSemanticsNodes().isNotEmpty() }
+        // Wait for asynchronous grouping, then scroll the LazyColumn to the target.
+        // Offscreen rows are not required to be present in the semantics tree.
+        compose.waitUntil(5_000) { compose.onAllNodesWithText("这个分类下没有项目").fetchSemanticsNodes().isEmpty() }
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("示例应用"))
         compose.onNodeWithText("示例应用").performClick()
         compose.waitUntil(5_000) {
-            compose.onAllNodesWithContentDescription("选择诊断日志").fetchSemanticsNodes().size == 1 &&
-                compose.onAllNodesWithContentDescription("选择离线资源").fetchSemanticsNodes().size == 1
+            runCatching { compose.onNode(hasScrollAction()).performScrollToNode(hasContentDescription("选择诊断日志")) }.isSuccess
         }
         compose.onNodeWithContentDescription("选择诊断日志").assertIsEnabled().performClick()
+        compose.onNode(hasScrollAction()).performScrollToNode(hasContentDescription("选择离线资源"))
         compose.onNodeWithContentDescription("选择离线资源").assertIsEnabled().performClick()
         compose.onNodeWithText("清理已选 2 项").assertIsDisplayed().performClick()
         assertEquals(0, cleanRequests)

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchVisualReviewTest.kt
@@ -99,6 +99,21 @@ class WorkbenchVisualReviewTest {
         save("empty")
     }
 
+    @Test
+    @Config(qualifiers = "zh-rCN-w320dp-h740dp-mdpi")
+    fun emptyFailedScanKeepsDetailsAndRetryReachable() {
+        render(WorkbenchUiState(profileConnected = true, cacheConnected = true,
+            notice = WorkbenchNotice.ERROR,
+            phase = "安全扫描失败：服务结果未确认：Transaction failed on small parcel; remote process probably died"),
+            fontScale = 1.3f)
+        compose.onNodeWithText("清理服务通信失败，结果未确认").assertIsDisplayed()
+        compose.onNodeWithContentDescription("查看任务详情").assertIsDisplayed()
+        compose.onNodeWithText("重新扫描").assertIsDisplayed().performClick()
+        assertEquals(1, scanRequests)
+        assertEquals(0, cleanRequests)
+        save("empty-failure-narrow-large-font")
+    }
+
     private fun render(initial: WorkbenchUiState, dark: Boolean = false, fontScale: Float = 1f) {
         state = initial
         val appearance = AppearanceSettings(monetEnabled = false, themeMode = if (dark) ThemeMode.DARK else ThemeMode.LIGHT,

--- a/v2/build.gradle.kts
+++ b/v2/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    id("com.android.application") version "8.12.2" apply false
-    id("com.android.test") version "8.12.2" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.21" apply false
-    id("org.jetbrains.kotlin.plugin.compose") version "2.1.21" apply false
+    id("com.android.application") version "9.3.2" apply false
+    id("com.android.test") version "9.3.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.10" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.4.10" apply false
     // 静态检查。此前 42k 行 Kotlin 完全没有 lint 之外的把关。
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.jlleitschuh.gradle.ktlint") version "12.3.0"

--- a/v2/gradle.properties
+++ b/v2/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
+
+# Retain existing KGP/DSL integration while the UI shader stack uses AGP 9.3.
+android.builtInKotlin=false
+android.newDsl=false

--- a/v2/macrobenchmark/build.gradle.kts
+++ b/v2/macrobenchmark/build.gradle.kts
@@ -5,22 +5,21 @@ plugins {
 
 android {
     namespace = "io.github.xgl34222220.baize.macrobenchmark"
-    compileSdk = 36
+    compileSdk = 37
     targetProjectPath = ":app"
     defaultConfig {
         minSdk = 28
         targetSdk = 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+}
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
+kotlin {
+    compilerOptions { jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17) }
 }
 
 dependencies {

--- a/v2/tests/test-audit-center-contract.sh
+++ b/v2/tests/test-audit-center-contract.sh
@@ -55,7 +55,7 @@ for pattern in \
   'fragmentMinutes.coerceIn(5, 43_200)' \
   'deepMinutes.coerceIn(5, 43_200)' \
   'organizeMinutes.coerceIn(15, 43_200)'; do
-  grep -Fq "$pattern" "$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt"
+  grep -Fq "$pattern" "$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/DashboardUiModels.kt"
 done
 
 echo "audit center contract passed"

--- a/v2/tests/test-schedule-modes-contract.sh
+++ b/v2/tests/test-schedule-modes-contract.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 DEFAULTS="$ROOT/config/default.conf"
-APP_STATE="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/BaiZeMiuixApp.kt"
+APP_STATE="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/DashboardUiModels.kt"
 CONTRACT="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/CleanContract.kt"
 MATERIAL="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/material/CleanScreenMaterial.kt"
 MIUIX="$ROOT/v2/app/src/main/java/io/github/xgl34222220/baize/ui/clean/miuix/CleanScreenMiuix.kt"


### PR DESCRIPTION
## 已合并并替换正式版

按所有者“替换正式版”的要求，本 PR 已合并到 main。2026-09-13 03:01 UTC 已替换原有 **v3.0.0 正式 Release**（不是新预览版），内部构建号由 30000 提升到 **30001**；独立 APK、模块内置 APK、下载镜像、标签与 OTA 已同步。

- 正式源码：`9ecf0cf8cf863e1c4b6fceb7352b4f2a88f2c0c7`
- Release：https://github.com/xgl34222220-ops/BaiZe/releases/tag/v3.0.0
- 验证及发布流程：https://github.com/xgl34222220-ops/BaiZe/actions/runs/34733978879
- 下载镜像提交：`c57d2e17cadba38222f40dbab0208e1c0b790970`

## 已交付

固定参考 LuoShu@fe4df5f224dca9bc77517ffa539ba021ed4b1a8e 的实际 HomeScreenCompact、SettingsHubScreen、MiuixAppDock/AppDockLayout 和 LiquidGlassLens。

白泽 MIUIX 入口已接入同源首页、分组设置、独立详情页和折射底栏；保留首页、清理、记录、设置四个白泽入口。底栏沿用洛书的尺寸、外边距、连续圆角、背景采样、双层透镜、高光、拉伸与弹簧参数。自动任务和连接诊断详情隐藏底栏，返回恢复选中。

非硬件/关闭效果/旧系统采用不透明回退和非着色器裁剪；支持硬件时保留折射。Material 保留独立分支。清理规则、Root 服务实现和高风险确认边界未因本轮界面重构改变。

## 最终验证

- 247 项 JVM/界面测试全部通过，失败 0、错误 0、跳过 0。
- Release 构建、Debug/Release lint、macrobenchmark assemble 和完整核心回归通过；lint 仍有已报告的警告，不宣称零警告。
- 原正式签名校验通过：`9efa848001ccdc168ea96753d332b1713e2668ba6a2fa22d5bfd98de65db1f0f`。
- 下载回读与 SHA-256 校验通过，模块内置 APK 与独立 APK 字节一致；确认新折射实现及 Apache-2.0 许可证实际打包。
- 原 30000 构建的五个正式附件在替换前备份并校验，回退产物保留 30 天。

APK SHA-256：`570ece2a97e348d392ed45fd89b7ab452937af3cb58f923744f6260ef9021f76`

模块 SHA-256：`9e270d52b71c9865e28d505f009a5b72d9b2b3dd6681f90e63f918f81ea7ad12`

此前阻断发布的测试环境问题已修正：软件截图只对效果消费者提供软件绘制能力，未替换全局 View shadow、未跳过断言，也没有把软件截图冒充 GPU 验证。

## 真机边界

软件渲染/自动回归不等于 K80 至尊版、一加 15 的 GPU、触控和重启后服务实测。本轮尚未收到这两台设备的真机验收结果，不声称硬件表现已完成逐像素确认。