### PR TITLE
重构版 1.0.0：明确扫描状态、风险选择与双页白名单

### DIFF
--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchActivity.kt
@@ -1,8 +1,6 @@
 package io.github.xgl34222220.baize
 
 import io.github.xgl34222220.baize.root.RootServiceClients
-import io.github.xgl34222220.baize.ui.components.*
-import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
@@ -16,78 +14,12 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.Apps
-import androidx.compose.material.icons.rounded.ArrowBack
-import androidx.compose.material.icons.rounded.CheckCircle
-import androidx.compose.material.icons.rounded.CleaningServices
-import androidx.compose.material.icons.rounded.Deselect
-import androidx.compose.material.icons.rounded.ExpandLess
-import androidx.compose.material.icons.rounded.ExpandMore
-import androidx.compose.material.icons.rounded.Folder
-import androidx.compose.material.icons.rounded.Inventory2
-import androidx.compose.material.icons.rounded.Refresh
-import androidx.compose.material.icons.rounded.Rule
-import androidx.compose.material.icons.rounded.SelectAll
-import androidx.compose.material.icons.rounded.Shield
-import androidx.compose.material.icons.rounded.Stop
-import androidx.compose.material.icons.rounded.Warning
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.produceState
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -96,17 +28,18 @@ import io.github.xgl34222220.baize.root.BaiZeProfileRootService
 import io.github.xgl34222220.baize.root.BaiZeRootService
 import io.github.xgl34222220.baize.root.IBaiZeRootService
 import io.github.xgl34222220.baize.root.IProfileRootService
-import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.AppearanceViewModel
 import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
 import io.github.xgl34222220.baize.ui.appearance.ThemeMode
-import io.github.xgl34222220.baize.ui.appearance.UiStyle
 import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -143,28 +76,21 @@ class ScanWorkbenchActivity : ComponentActivity() {
             screenState = screenState.copy(profileConnected = true)
             maybeStartScan()
         }
-
         override fun onNullBinding(name: ComponentName?) {
             RootService.unbind(this)
             onServiceDisconnected(name)
             screenState = screenState.copy(notice = WorkbenchNotice.ERROR, phase = "Root 启动失败，请检查授权后重试")
         }
-
         override fun onServiceDisconnected(name: ComponentName?) {
             invalidateScanLoad()
             scanJob?.cancel()
             saveReview()
             profileService = null
             profileBound = false
-            screenState = screenState.copy(
-                profileConnected = false,
-                running = false,
-                notice = WorkbenchNotice.ERROR,
-                phase = "Root 详情引擎连接已断开"
-            )
+            screenState = screenState.copy(profileConnected = false, running = false,
+                notice = WorkbenchNotice.ERROR, phase = "Root 详情引擎连接已断开")
         }
     }
-
     private val cacheConnection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
             cacheService = RootServiceClients.cache(binder, applicationContext.cacheDir)
@@ -172,25 +98,19 @@ class ScanWorkbenchActivity : ComponentActivity() {
             screenState = screenState.copy(cacheConnected = true)
             maybeStartScan()
         }
-
         override fun onNullBinding(name: ComponentName?) {
             RootService.unbind(this)
             onServiceDisconnected(name)
             screenState = screenState.copy(notice = WorkbenchNotice.ERROR, phase = "Root 启动失败，请检查授权后重试")
         }
-
         override fun onServiceDisconnected(name: ComponentName?) {
             invalidateScanLoad()
             scanJob?.cancel()
             saveReview()
             cacheService = null
             cacheBound = false
-            screenState = screenState.copy(
-                cacheConnected = false,
-                running = false,
-                notice = WorkbenchNotice.ERROR,
-                phase = "Root 缓存引擎连接已断开"
-            )
+            screenState = screenState.copy(cacheConnected = false, running = false,
+                notice = WorkbenchNotice.ERROR, phase = "Root 缓存引擎连接已断开")
         }
     }
 
@@ -200,7 +120,6 @@ class ScanWorkbenchActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         window.statusBarColor = Color.TRANSPARENT
         window.navigationBarColor = Color.TRANSPARENT
-
         setContent {
             val appearance = appearanceViewModel.settings.collectAsStateWithLifecycle().value
             val systemDark = isSystemInDarkTheme()
@@ -217,22 +136,14 @@ class ScanWorkbenchActivity : ComponentActivity() {
             }
             BaiZeTheme(appearance) {
                 CompositionLocalProvider(LocalAppearanceSettings provides appearance) {
-                    ScanWorkbenchScreen(
-                        appearance = appearance,
-                        state = screenState,
-                        actions = WorkbenchActions(
-                            onBack = ::finish,
-                            onScan = ::runScan,
-                            onStop = ::stopTask,
-                            onClean = ::cleanSelection,
-                            onToggleItem = ::toggleItem,
-                            onToggleGroup = ::toggleGroup,
-                            onSelectAll = ::selectAllSafe,
-                            onClear = ::clearSelection,
-                            onProtect = ::protectItem,
-                            onQuarantine = ::quarantineItem
-                        )
-                    )
+                    ScanWorkbenchScreen(appearance, screenState, WorkbenchActions(
+                        onBack = ::finish, onScan = ::runScan, onStop = ::stopTask,
+                        onClean = ::cleanSelection, onToggleItem = ::toggleItem,
+                        onToggleGroup = ::toggleGroup, onSelectAll = ::selectAllSafe,
+                        onClear = ::clearSelection, onProtect = ::protectItem,
+                        onQuarantine = ::quarantineItem, onSelectMedium = ::selectAllMedium,
+                        onManageWhitelist = ::openWhitelist
+                    ))
                 }
             }
         }
@@ -247,7 +158,6 @@ class ScanWorkbenchActivity : ComponentActivity() {
         saveReview()
         super.onStop()
     }
-
     override fun onDestroy() {
         scanGeneration.invalidate()
         scanJob?.cancel()
@@ -264,21 +174,15 @@ class ScanWorkbenchActivity : ComponentActivity() {
         if (!profileBound) {
             profileBound = true
             runCatching {
-                RootService.bind(
-                    Intent(this, BaiZeProfileRootService::class.java)
-                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
-                    profileConnection
-                )
+                RootService.bind(Intent(this, BaiZeProfileRootService::class.java)
+                    .addCategory(RootService.CATEGORY_DAEMON_MODE), profileConnection)
             }.onFailure { profileBound = false; screenState = screenState.copy(notice = WorkbenchNotice.ERROR, phase = "详情引擎启动失败：${it.message.orEmpty()}") }
         }
         if (scanProfile == "safe" && !cacheBound) {
             cacheBound = true
             runCatching {
-                RootService.bind(
-                    Intent(this, BaiZeRootService::class.java)
-                        .addCategory(RootService.CATEGORY_DAEMON_MODE),
-                    cacheConnection
-                )
+                RootService.bind(Intent(this, BaiZeRootService::class.java)
+                    .addCategory(RootService.CATEGORY_DAEMON_MODE), cacheConnection)
             }.onFailure { cacheBound = false; screenState = screenState.copy(notice = WorkbenchNotice.ERROR, phase = "缓存引擎启动失败：${it.message.orEmpty()}") }
         }
     }
@@ -289,17 +193,13 @@ class ScanWorkbenchActivity : ComponentActivity() {
             if (screenState.notice != WorkbenchNotice.ERROR) {
                 screenState = screenState.copy(
                     notice = if (screenState.scanReady) WorkbenchNotice.INFO else WorkbenchNotice.WARNING,
-                    phase = if (screenState.scanReady) "已恢复上次扫描，可继续选择" else "已恢复上次结果，重新扫描后可清理"
-                )
+                    phase = if (screenState.scanReady) "已恢复上次扫描，可继续选择" else "已恢复上次结果，重新扫描后可清理")
             }
             return
         }
         if (autoScanStarted) return
         autoScanStarted = true
-        lifecycleScope.launch {
-            delay(180L)
-            runScan()
-        }
+        lifecycleScope.launch { delay(180L); runScan() }
     }
 
     private fun runScan() {
@@ -315,15 +215,11 @@ class ScanWorkbenchActivity : ComponentActivity() {
         cacheSnapshotId = ""
         profileSnapshotId = ""
         snapshotExpiresAtRealtime = 0L
-        screenState = screenState.copy(
-            running = true, loadingResults = false, scanReady = false,
-            notice = WorkbenchNotice.INFO,
-            phase = "正在并行扫描应用缓存与安全项目…",
+        screenState = screenState.copy(running = true, loadingResults = false, scanReady = false,
+            notice = WorkbenchNotice.INFO, phase = "正在并行扫描应用缓存与安全项目…",
             progressCurrent = 0L, progressTotal = 0L, currentPath = "",
-            items = emptyList(), selectedIds = emptySet(), resultText = "",
-            expiresAtRealtime = 0L
-        )
-        // Persist the invalidation even before the first page, including across rotation.
+            items = emptyList(), selectedIds = emptySet(), resultText = "", expiresAtRealtime = 0L)
+        // Persist invalidation before any result page, including across rotation.
         saveReview()
         startPolling()
         scanJob = lifecycleScope.launch {
@@ -366,22 +262,18 @@ class ScanWorkbenchActivity : ComponentActivity() {
                 val cacheId = cacheSnapshotId
                 val profileId = profileSnapshotId
                 snapshotExpiresAtRealtime = minOf(
-                    // Cache epochs have second precision and may predate the scan response.
                     if (cacheOk) cacheCompletedAt - cacheJson.optLong("elapsedMs", 0L).coerceAtLeast(0L) - 1_000L +
                         cacheJson.optLong("snapshotExpiresInMs", SNAPSHOT_TTL_MS).coerceIn(0L, SNAPSHOT_TTL_MS)
                     else Long.MAX_VALUE,
                     if (profileOk) profileCompletedAt + profileJson.optLong("snapshotExpiresInMs", SNAPSHOT_TTL_MS)
-                        .coerceIn(0L, SNAPSHOT_TTL_MS) else Long.MAX_VALUE
-                )
+                        .coerceIn(0L, SNAPSHOT_TTL_MS) else Long.MAX_VALUE)
                 val partial = profileJson.optBoolean("partial") || !profileOk || (scanProfile == "safe" && !cacheOk)
                 val warning = if (partial) "本轮扫描未覆盖全部范围；仅展示有效快照中的项目。" else ""
-                screenState = screenState.copy(
-                    loadingResults = true, notice = WorkbenchNotice.INFO, phase = "扫描结束，正在读取结果…",
+                screenState = screenState.copy(loadingResults = true, notice = WorkbenchNotice.INFO, phase = "扫描结束，正在读取结果…",
                     progressCurrent = 0L, progressTotal = 0L, currentPath = "",
                     policyTitle = policy.title, policyKey = policy.key, highRiskMode = policy.highRiskMode,
                     expiresAtRealtime = snapshotExpiresAtRealtime,
-                    resultText = warning + "读取期间仅供预览，全部读取完成后才可选择和清理。"
-                )
+                    resultText = warning + "读取期间仅供预览，全部读取完成后才可选择和清理。")
                 val results = ProgressiveScanResults<WorkbenchItem>({ it.id }) {
                     it.selectable && ReviewRiskPolicy.defaultSelected(it.risk, "", policy.autoRisk == "medium")
                 }
@@ -396,13 +288,11 @@ class ScanWorkbenchActivity : ComponentActivity() {
                         val expectedSources = (if (cacheOk) 1 else 0) + (if (profileOk) 1 else 0)
                         val total = if (counts.size == expectedSources) counts.values.sumOf { it.second.toLong() } else 0L
                         val newer = review != null && review.items.size > screenState.items.size
-                        screenState = screenState.copy(
-                            notice = WorkbenchNotice.INFO,
+                        screenState = screenState.copy(notice = WorkbenchNotice.INFO,
                             phase = "正在读取结果 · 已读取 $loaded 项" + if (total > 0) " / $total" else "",
                             progressCurrent = loaded, progressTotal = total,
                             items = if (newer) requireNotNull(review).items else screenState.items,
-                            selectedIds = if (newer) requireNotNull(review).selectedIds else screenState.selectedIds
-                        )
+                            selectedIds = if (newer) requireNotNull(review).selectedIds else screenState.selectedIds)
                     }
                 }
                 withContext(Dispatchers.IO) {
@@ -425,8 +315,7 @@ class ScanWorkbenchActivity : ComponentActivity() {
                 }
                 if (!scanGeneration.accepts(generation)) return@launch
                 val expired = SystemClock.elapsedRealtime() >= snapshotExpiresAtRealtime
-                screenState = screenState.copy(
-                    running = false, loadingResults = false,
+                screenState = screenState.copy(running = false, loadingResults = false,
                     scanReady = review.items.isNotEmpty() && !expired,
                     notice = if (expired || partial) WorkbenchNotice.WARNING else WorkbenchNotice.SUCCESS,
                     phase = when {
@@ -434,16 +323,14 @@ class ScanWorkbenchActivity : ComponentActivity() {
                         partial -> "本轮扫描未覆盖全部范围，已读取 ${review.items.size} 项"
                         review.items.isEmpty() -> "扫描完成，没有发现垃圾项目"
                         else -> "扫描完成，展开应用或分类后选择要清理的项目"
-                    },
-                    items = review.items, selectedIds = review.selectedIds,
+                    }, items = review.items, selectedIds = review.selectedIds,
                     resultText = warning + if (review.items.isEmpty()) {
                         if (partial) "未发现可展示项目，请重新扫描。" else "当前设备很干净"
                     } else if (policy == CleanupPolicy.CONSERVATIVE) {
                         "保守档默认只勾选低风险项目；中风险仍可手动选择"
                     } else {
                         "默认勾选低、中风险项目；高风险默认不选，可逐项选择。大小未统计的项目也会列出。"
-                    }
-                )
+                    })
                 scanGeneration.invalidate()
                 saveReview()
             } catch (cancelled: CancellationException) {
@@ -469,10 +356,8 @@ class ScanWorkbenchActivity : ComponentActivity() {
         screenState = screenState.copy(scanReady = false, loadingResults = false, expiresAtRealtime = 0L)
     }
 
-    private suspend fun loadCacheItems(
-        service: IBaiZeRootService, snapshotId: String,
-        onPage: suspend (List<WorkbenchItem>, ScanPageCursor) -> Unit
-    ) {
+    private suspend fun loadCacheItems(service: IBaiZeRootService, snapshotId: String,
+        onPage: suspend (List<WorkbenchItem>, ScanPageCursor) -> Unit) {
         val cursor = ScanPageCursor(snapshotId)
         while (!cursor.complete) {
             currentCoroutineContext().ensureActive()
@@ -491,33 +376,21 @@ class ScanWorkbenchActivity : ComponentActivity() {
                 val path = item.optString("path").trim()
                 if (packageName.isBlank() || path.isBlank()) continue
                 val appName = applicationLabel(packageName)
-                result += WorkbenchItem(
-                    id = "cache:${stableId("$packageName\u0000$category\u0000$path")}",
-                    source = "cache",
-                    profile = "cache",
-                    packageName = packageName,
-                    appName = appName,
-                    category = category,
-                    groupKey = "app:$packageName",
-                    groupTitle = appName,
-                    title = category,
-                    risk = "low",
-                    path = path,
+                result += WorkbenchItem(id = "cache:${stableId("$packageName\u0000$category\u0000$path")}",
+                    source = "cache", profile = "cache", packageName = packageName, appName = appName,
+                    category = category, groupKey = "app:$packageName", groupTitle = appName,
+                    title = category, risk = "low", path = path,
                     bytes = item.optLong("bytes", 0L).coerceAtLeast(0L),
                     files = item.optLong("files", 0L).coerceAtLeast(0L),
                     directories = item.optLong("directories", 0L).coerceAtLeast(0L),
-                    reason = "应用缓存快照命中 · 只删除扫描时记录的文件",
-                    selectable = true
-                )
+                    reason = "应用缓存快照命中 · 只删除扫描时记录的文件", selectable = true)
             }
             onPage(result, cursor)
         }
     }
 
-    private suspend fun loadProfileItems(
-        service: IProfileRootService, snapshotId: String,
-        onPage: suspend (List<WorkbenchItem>, ScanPageCursor) -> Unit
-    ) {
+    private suspend fun loadProfileItems(service: IProfileRootService, snapshotId: String,
+        onPage: suspend (List<WorkbenchItem>, ScanPageCursor) -> Unit) {
         val cursor = ScanPageCursor(snapshotId)
         while (!cursor.complete) {
             currentCoroutineContext().ensureActive()
@@ -541,27 +414,17 @@ class ScanWorkbenchActivity : ComponentActivity() {
                     else item.optString("appName").trim().ifBlank { label }
                 val candidateId = item.optString("id").ifBlank { stableId("$profile\u0000$category\u0000$path") }
                 val note = item.optString("note").trim()
-                result += WorkbenchItem(
-                    id = "profile:$candidateId",
-                    source = "profile",
-                    profile = profile,
-                    packageName = packageName,
-                    appName = appName,
-                    category = category,
+                result += WorkbenchItem(id = "profile:$candidateId", source = "profile", profile = profile,
+                    packageName = packageName, appName = appName, category = category,
                     groupKey = if (packageName.isNotBlank()) "app:$packageName" else "category:$profile:$label",
                     groupTitle = if (packageName.isNotBlank()) appName else label,
-                    title = File(path).name.ifBlank { label },
-                    risk = risk,
-                    path = path,
-                    bytes = item.optLong("bytes", -1L),
-                    files = item.optLong("files", -1L),
+                    title = File(path).name.ifBlank { label }, risk = risk, path = path,
+                    bytes = item.optLong("bytes", -1L), files = item.optLong("files", -1L),
                     directories = item.optLong("directories", -1L),
                     reason = item.optString("blockedReason").ifBlank {
                         if (risk == "high") "默认不清理；可能包含离线内容或应用数据，确认用途后勾选。$note"
                         else note.ifBlank { riskReason(risk, label, cleanupPolicy) }
-                    },
-                    selectable = ReviewRiskPolicy.selectable(risk, item.optString("blockedReason"))
-                )
+                    }, selectable = ReviewRiskPolicy.selectable(risk, item.optString("blockedReason")))
             }
             onPage(result, cursor)
         }
@@ -582,18 +445,12 @@ class ScanWorkbenchActivity : ComponentActivity() {
         }
         val cacheItems = selected.filter { it.source == "cache" }
         val profileItems = selected.filter { it.source == "profile" }
-        screenState = screenState.copy(
-            running = true,
-            notice = WorkbenchNotice.INFO,
-            phase = "正在校验并清理 ${selected.size} 个已勾选项目…",
-            progressCurrent = 0L,
-            progressTotal = selected.size.toLong(),
-            currentPath = ""
-        )
+        screenState = screenState.copy(running = true, notice = WorkbenchNotice.INFO,
+            phase = "正在校验并清理 ${selected.size} 个已勾选项目…", progressCurrent = 0L,
+            progressTotal = selected.size.toLong(), currentPath = "")
         startPolling()
         saveReview()
         val attempt = CleanupAttempt()
-
         lifecycleScope.launch {
             val response = runCatching {
                 withContext(Dispatchers.IO) {
@@ -610,7 +467,6 @@ class ScanWorkbenchActivity : ComponentActivity() {
                     val outcomes = HashMap<String, String>()
                     val actualApps = ArrayList<AppJunkUiItem>()
                     val actualJunk = ArrayList<GeneralJunkUiItem>()
-
                     if (cacheItems.isNotEmpty()) {
                         val cache = requireNotNull(cache)
                         val selection = JSONObject()
@@ -618,19 +474,11 @@ class ScanWorkbenchActivity : ComponentActivity() {
                         val prepared = JSONObject(attempt.authorize {
                             profile.prepareCacheSelection(cacheSnapshotId, selection.toString())
                         })
-                        if (!prepared.optBoolean("success")) {
-                            error(prepared.optString("message", prepared.optString("error", "无法裁剪缓存快照")))
-                        }
+                        if (!prepared.optBoolean("success")) error(prepared.optString("message", prepared.optString("error", "无法裁剪缓存快照")))
                         val selectedSnapshotId = prepared.optString("snapshotId")
-                        val cacheResult = JSONObject(
-                            attempt.mutate {
-                                cache.cleanSelected(
-                                    selectedSnapshotId,
-                                    JSONObject().put("__all_safe__", true).toString(),
-                                    packageWhitelist
-                                )
-                            }
-                        )
+                        val cacheResult = JSONObject(attempt.mutate {
+                            cache.cleanSelected(selectedSnapshotId, JSONObject().put("__all_safe__", true).toString(), packageWhitelist)
+                        })
                         bytes += cacheResult.optLong("deletedBytes", 0L).coerceAtLeast(0L)
                         files += cacheResult.optLong("deletedFiles", 0L).coerceAtLeast(0L)
                         failures += cacheResult.optInt("failures", if (cacheResult.optBoolean("success")) 0 else 1).coerceAtLeast(0)
@@ -648,27 +496,22 @@ class ScanWorkbenchActivity : ComponentActivity() {
                             val app = report.optJSONObject(index) ?: continue
                             val pkg = app.optString("packageName")
                             if (cacheItems.none { it.packageName == pkg }) continue
-                            actualApps += AppJunkUiItem(pkg, applicationLabel(pkg), "应用缓存",
-                                app.optLong("files"), app.optLong("bytes"), app.optLong("errors"))
+                            actualApps += AppJunkUiItem(pkg, applicationLabel(pkg), "应用缓存", app.optLong("files"), app.optLong("bytes"), app.optLong("errors"))
                         }
                     }
-
                     if (!cancelled && profileItems.isNotEmpty()) {
                         val selection = JSONObject()
                         profileItems.forEach { selection.put(it.id.removePrefix("profile:"), true) }
-                        val profileResult = JSONObject(
-                            attempt.mutate {
-                                profile.cleanProfileSelected(profileSnapshotId, selection.toString(), options)
-                            }
-                        )
+                        val profileResult = JSONObject(attempt.mutate {
+                            profile.cleanProfileSelected(profileSnapshotId, selection.toString(), options)
+                        })
                         bytes += profileResult.optLong("deletedBytes", 0L).coerceAtLeast(0L)
                         files += profileResult.optLong("deletedFiles", 0L).coerceAtLeast(0L)
                         failures += profileResult.optInt("failures", if (profileResult.optBoolean("success")) 0 else 1).coerceAtLeast(0)
                         cleanedCandidates += profileResult.optInt("cleanedCandidates", 0).coerceAtLeast(0)
                         cancelled = cancelled || profileResult.optBoolean("cancelled")
-                        incomplete = incomplete || !profileResult.optBoolean("success") || cancelled ||
-                            profileResult.optBoolean("timedOut") || profileResult.optInt("skippedCandidates") > 0 ||
-                            profileResult.optInt("failures") > 0
+                        incomplete = incomplete || !profileResult.optBoolean("success") || cancelled || profileResult.optBoolean("timedOut") ||
+                            profileResult.optInt("skippedCandidates") > 0 || profileResult.optInt("failures") > 0
                         messages += profileResult.optString("message", "安全项目处理完成")
                         val details = profileResult.optJSONArray("details") ?: JSONArray()
                         for (index in 0 until details.length()) {
@@ -695,19 +538,11 @@ class ScanWorkbenchActivity : ComponentActivity() {
                             }
                         }
                     }
-
                     runCatching {
-                        profile.recordNativeTask(
-                            JSONObject()
-                                .put("mode", "workbench-clean")
-                                .put("success", !incomplete && failures == 0 && !cancelled)
-                                .put("cancelled", cancelled)
-                                .put("bytes", bytes)
-                                .put("files", files)
-                                .put("errors", failures)
-                                .put("result", "工作台清理完成，处理 $cleanedCandidates 个候选")
-                                .toString()
-                        )
+                        profile.recordNativeTask(JSONObject().put("mode", "workbench-clean")
+                            .put("success", !incomplete && failures == 0 && !cancelled)
+                            .put("cancelled", cancelled).put("bytes", bytes).put("files", files).put("errors", failures)
+                            .put("result", "工作台清理完成，处理 $cleanedCandidates 个候选").toString())
                     }
                     val groupedApps = actualApps.groupBy { it.packageName }.values.map { entries ->
                         entries.first().copy(files = entries.sumOf { it.files }, bytes = entries.sumOf { it.bytes },
@@ -724,127 +559,93 @@ class ScanWorkbenchActivity : ComponentActivity() {
                 cacheSnapshotId = ""
                 profileSnapshotId = ""
                 snapshotExpiresAtRealtime = 0L
-                screenState = screenState.copy(
-                    running = false,
-                    scanReady = false,
-                    items = screenState.items.map { item -> item.copy(
-                        outcome = if (item.id in screenState.selectedIds) result.outcomes[item.id] ?: "未完成或未返回结果" else "未勾选，保留"
-                    ) },
-                    selectedIds = if (result.incomplete) screenState.selectedIds.filterTo(linkedSetOf()) {
-                        itWasNotCleaned(it, result.outcomes)
-                    } else emptySet(),
-                    notice = if (result.incomplete) WorkbenchNotice.WARNING else WorkbenchNotice.SUCCESS,
-                    expiresAtRealtime = 0L,
+                screenState = screenState.copy(running = false, scanReady = false,
+                    items = screenState.items.map { item -> item.copy(outcome =
+                        if (item.id in screenState.selectedIds) result.outcomes[item.id] ?: "未完成或未返回结果" else "未勾选，保留") },
+                    selectedIds = if (result.incomplete) screenState.selectedIds.filterTo(linkedSetOf()) { itWasNotCleaned(it, result.outcomes) } else emptySet(),
+                    notice = if (result.incomplete) WorkbenchNotice.WARNING else WorkbenchNotice.SUCCESS, expiresAtRealtime = 0L,
                     phase = if (result.cancelled) "清理已停止，结果与未完成勾选已保留"
-                        else if (result.incomplete) "部分项目未完成，重新扫描后可继续清理"
-                        else "已完成所选项目清理",
-                    resultText = "释放 ${formatBytes(result.bytes)} · 文件 ${result.files} · 候选 ${result.candidates}\n${result.messages.filter { it.isNotBlank() }.joinToString("\n")}"
-                )
+                        else if (result.incomplete) "部分项目未完成，重新扫描后可继续清理" else "已完成所选项目清理",
+                    resultText = "释放 ${formatBytes(result.bytes)} · 文件 ${result.files} · 候选 ${result.candidates}\n${result.messages.filter { it.isNotBlank() }.joinToString("\n")}")
             }.onFailure { error ->
-                val canRetry = !attempt.snapshotTouched && !attempt.cleanupSubmitted &&
-                    SystemClock.elapsedRealtime() < snapshotExpiresAtRealtime &&
+                val canRetry = !attempt.snapshotTouched && !attempt.cleanupSubmitted && SystemClock.elapsedRealtime() < snapshotExpiresAtRealtime &&
                     profileService != null && (cacheItems.isEmpty() || cacheService != null)
                 if (!canRetry) {
                     cacheSnapshotId = ""
                     profileSnapshotId = ""
                     snapshotExpiresAtRealtime = 0L
                 }
-                screenState = screenState.copy(
-                    running = false,
-                    scanReady = canRetry,
-                    notice = WorkbenchNotice.ERROR,
+                screenState = screenState.copy(running = false, scanReady = canRetry, notice = WorkbenchNotice.ERROR,
                     expiresAtRealtime = snapshotExpiresAtRealtime,
-                    // Keep the exact review and user choice. A lost reply must never look like an
-                    // empty scan, and must never trigger an automatic repeat of a deletion.
-                    phase = if (attempt.cleanupSubmitted) "清理结果未确认，列表与勾选已保留"
-                        else "清理未完成，列表与勾选已保留",
+                    // Never replay deletion after a lost response. Keep the exact user review.
+                    phase = if (attempt.cleanupSubmitted) "清理结果未确认，列表与勾选已保留" else "清理未完成，列表与勾选已保留",
                     resultText = (if (canRetry) "请求尚未执行，可重试。" else "请重新扫描后再清理，避免重复执行。") +
-                        "\n" + (error.message ?: error.javaClass.simpleName)
-                )
+                        "\n" + (error.message ?: error.javaClass.simpleName))
             }
             saveReview()
         }
     }
 
     private fun quarantineItem(item: WorkbenchItem) {
-    if (screenState.running || screenState.loadingResults || stopJob?.isActive == true || item !in screenState.items || item.source != "profile" || item.risk != "high" || !cleanupPolicy.canQuarantineHighRisk) return
-    if (!screenState.scanReady || SystemClock.elapsedRealtime() >= snapshotExpiresAtRealtime) {
-        screenState = screenState.copy(scanReady = false, notice = WorkbenchNotice.WARNING, phase = "扫描快照已过期，请重新扫描")
-        return
-    }
-    val service = profileService ?: return
-    screenState = screenState.copy(
-        running = true,
-        notice = WorkbenchNotice.INFO,
-        phase = "正在把 ${item.title} 移入隔离区…",
-        currentPath = item.path
-    )
-    startPolling()
-    val attempt = CleanupAttempt()
-    lifecycleScope.launch {
-        val result = runCatching {
-            withContext(Dispatchers.IO) {
-                val selection = JSONObject().put(item.id.removePrefix("profile:"), true)
-                val options = optionsJson(service)
-                JSONObject(attempt.mutate {
-                    service.quarantineProfileSelected(profileSnapshotId, selection.toString(), options)
-                })
-            }
+        if (screenState.running || screenState.loadingResults || stopJob?.isActive == true || item !in screenState.items || item.source != "profile" || item.risk != "high" || !cleanupPolicy.canQuarantineHighRisk) return
+        if (!screenState.scanReady || SystemClock.elapsedRealtime() >= snapshotExpiresAtRealtime) {
+            screenState = screenState.copy(scanReady = false, notice = WorkbenchNotice.WARNING, phase = "扫描快照已过期，请重新扫描")
+            return
         }
-        pollJob?.cancel()
-        result.onSuccess { json ->
-            if (json.optBoolean("success") && json.optInt("quarantinedCandidates") > 0) {
-                cacheSnapshotId = ""
-                profileSnapshotId = ""
-                snapshotExpiresAtRealtime = 0L
-                screenState = screenState.copy(
-                    running = false,
-                    scanReady = false,
-                    items = emptyList(),
-                    selectedIds = emptySet(),
-                    notice = WorkbenchNotice.SUCCESS,
-                    phase = json.optString("message", "高风险项目已移入隔离区"),
-                    resultText = "已隔离 ${json.optInt("quarantinedCandidates")} 项 · ${formatBytes(json.optLong("quarantinedBytes"))}"
-                )
-                Toast.makeText(this@ScanWorkbenchActivity, "已移入隔离区，可随时恢复", Toast.LENGTH_SHORT).show()
-                delay(180L)
-                runScan()
-            } else {
-                // The engine consumes its snapshot even when all requested entries were skipped.
-                // Keep the review visible, but don't retry a mutation with an uncertain snapshot.
+        val service = profileService ?: return
+        screenState = screenState.copy(running = true, notice = WorkbenchNotice.INFO,
+            phase = "正在把 ${item.title} 移入隔离区…", currentPath = item.path)
+        startPolling()
+        val attempt = CleanupAttempt()
+        lifecycleScope.launch {
+            val result = runCatching {
+                withContext(Dispatchers.IO) {
+                    val selection = JSONObject().put(item.id.removePrefix("profile:"), true)
+                    val options = optionsJson(service)
+                    JSONObject(attempt.mutate { service.quarantineProfileSelected(profileSnapshotId, selection.toString(), options) })
+                }
+            }
+            pollJob?.cancel()
+            result.onSuccess { json ->
+                if (json.optBoolean("success") && json.optInt("quarantinedCandidates") > 0) {
+                    cacheSnapshotId = ""
+                    profileSnapshotId = ""
+                    snapshotExpiresAtRealtime = 0L
+                    screenState = screenState.copy(running = false, scanReady = false, items = emptyList(), selectedIds = emptySet(),
+                        notice = WorkbenchNotice.SUCCESS, phase = json.optString("message", "高风险项目已移入隔离区"),
+                        resultText = "已隔离 ${json.optInt("quarantinedCandidates")} 项 · ${formatBytes(json.optLong("quarantinedBytes"))}")
+                    Toast.makeText(this@ScanWorkbenchActivity, "已移入隔离区，可随时恢复", Toast.LENGTH_SHORT).show()
+                    delay(180L)
+                    runScan()
+                } else {
+                    if (attempt.cleanupSubmitted) {
+                        cacheSnapshotId = ""
+                        profileSnapshotId = ""
+                        snapshotExpiresAtRealtime = 0L
+                    }
+                    screenState = screenState.copy(running = false,
+                        notice = if (json.optBoolean("cancelled") || json.optBoolean("success")) WorkbenchNotice.WARNING else WorkbenchNotice.ERROR,
+                        scanReady = !attempt.cleanupSubmitted && SystemClock.elapsedRealtime() < snapshotExpiresAtRealtime,
+                        expiresAtRealtime = snapshotExpiresAtRealtime,
+                        phase = json.optString("message", json.optString("error", "隔离未完成")),
+                        resultText = if (attempt.cleanupSubmitted) "列表与勾选已保留，请重新扫描后继续。" else "请求尚未执行。")
+                    saveReview()
+                }
+            }.onFailure {
                 if (attempt.cleanupSubmitted) {
                     cacheSnapshotId = ""
                     profileSnapshotId = ""
                     snapshotExpiresAtRealtime = 0L
                 }
-                screenState = screenState.copy(
-                    running = false,
-                    notice = if (json.optBoolean("cancelled") || json.optBoolean("success")) WorkbenchNotice.WARNING else WorkbenchNotice.ERROR,
+                screenState = screenState.copy(running = false, notice = WorkbenchNotice.ERROR,
                     scanReady = !attempt.cleanupSubmitted && SystemClock.elapsedRealtime() < snapshotExpiresAtRealtime,
-                    expiresAtRealtime = snapshotExpiresAtRealtime,
-                    phase = json.optString("message", json.optString("error", "隔离未完成")),
-                    resultText = if (attempt.cleanupSubmitted) "列表与勾选已保留，请重新扫描后继续。" else "请求尚未执行。"
-                )
+                    expiresAtRealtime = snapshotExpiresAtRealtime, phase = "隔离结果未确认，列表与勾选已保留",
+                    resultText = "${it.message ?: it.javaClass.simpleName}" +
+                        if (attempt.cleanupSubmitted) "\n请重新扫描后继续，避免重复执行。" else "\n请求尚未执行，可重试。")
                 saveReview()
             }
-        }.onFailure {
-            if (attempt.cleanupSubmitted) {
-                cacheSnapshotId = ""
-                profileSnapshotId = ""
-                snapshotExpiresAtRealtime = 0L
-            }
-            screenState = screenState.copy(
-                running = false, notice = WorkbenchNotice.ERROR,
-                scanReady = !attempt.cleanupSubmitted && SystemClock.elapsedRealtime() < snapshotExpiresAtRealtime,
-                expiresAtRealtime = snapshotExpiresAtRealtime,
-                phase = "隔离结果未确认，列表与勾选已保留",
-                resultText = "${it.message ?: it.javaClass.simpleName}" +
-                    if (attempt.cleanupSubmitted) "\n请重新扫描后继续，避免重复执行。" else "\n请求尚未执行，可重试。"
-            )
-            saveReview()
         }
     }
-}
 
     private fun protectItem(item: WorkbenchItem) {
         if (screenState.running || item !in screenState.items) return
@@ -859,9 +660,7 @@ class ScanWorkbenchActivity : ComponentActivity() {
                         for (index in 0 until current.length()) current.optString(index).trim().takeIf { it.isNotBlank() }?.let(packages::add)
                         packages += item.packageName
                         JSONObject(service.saveWhitelistPackages(JSONArray(packages.sorted()).toString()))
-                    } else {
-                        JSONObject(service.addWhitelistPath(item.path))
-                    }
+                    } else JSONObject(service.addWhitelistPath(item.path))
                 }
             }
             result.onSuccess { json ->
@@ -869,35 +668,41 @@ class ScanWorkbenchActivity : ComponentActivity() {
                     cacheSnapshotId = ""
                     profileSnapshotId = ""
                     snapshotExpiresAtRealtime = 0L
-                    screenState = screenState.copy(
-                        scanReady = false,
-                        items = emptyList(),
-                        selectedIds = emptySet(),
-                        notice = WorkbenchNotice.SUCCESS,
-                        phase = "已加入白名单，正在重新生成安全快照…"
-                    )
+                    screenState = screenState.copy(scanReady = false, items = emptyList(), selectedIds = emptySet(),
+                        notice = WorkbenchNotice.SUCCESS, phase = "已加入白名单，正在重新生成安全快照…")
                     Toast.makeText(this@ScanWorkbenchActivity, json.optString("message", "已加入白名单"), Toast.LENGTH_SHORT).show()
                     delay(180L)
                     runScan()
-                } else {
-                    screenState = screenState.copy(notice = WorkbenchNotice.ERROR, phase = "白名单保存失败：${json.optString("message", json.optString("error"))}")
-                }
-            }.onFailure {
-                screenState = screenState.copy(notice = WorkbenchNotice.ERROR, phase = "白名单保存失败：${it.message ?: it.javaClass.simpleName}")
-            }
+                } else screenState = screenState.copy(notice = WorkbenchNotice.ERROR,
+                    phase = "白名单保存失败：${json.optString("message", json.optString("error"))}")
+            }.onFailure { screenState = screenState.copy(notice = WorkbenchNotice.ERROR,
+                phase = "白名单保存失败：${it.message ?: it.javaClass.simpleName}") }
         }
     }
 
+    private fun openWhitelist() {
+        if (screenState.running || screenState.loadingResults) return
+        invalidateScanLoad()
+        screenState = screenState.copy(notice = WorkbenchNotice.INFO,
+            phase = "白名单管理后请重新扫描，旧记录不会直接用于删除")
+        saveReview()
+        startActivity(Intent(this, WhitelistActivity::class.java))
+    }
+
+    private fun selectionIsEditable(): Boolean {
+        val reason = reviewSelectionBlockReason(screenState, SystemClock.elapsedRealtime())
+        if (reason != null && !screenState.running) screenState = screenState.copy(phase = reason)
+        return reason == null
+    }
     private fun toggleItem(id: String) {
         val item = screenState.items.firstOrNull { it.id == id } ?: return
-        if (!item.selectable || screenState.running) return
+        if (!item.selectable || item.risk == "critical" || !selectionIsEditable()) return
         val selected = screenState.selectedIds.toMutableSet()
         if (!selected.add(id)) selected.remove(id)
         screenState = screenState.copy(selectedIds = selected)
     }
-
     private fun toggleGroup(groupKey: String) {
-        if (screenState.running) return
+        if (!selectionIsEditable()) return
         val group = screenState.items.filter { it.groupKey == groupKey && it.selectable && it.risk in setOf("low", "medium") }
         if (group.isEmpty()) return
         val selected = screenState.selectedIds.toMutableSet()
@@ -905,16 +710,14 @@ class ScanWorkbenchActivity : ComponentActivity() {
         group.forEach { if (shouldSelect) selected += it.id else selected -= it.id }
         screenState = screenState.copy(selectedIds = selected)
     }
-
-    private fun selectAllSafe() {
-        if (screenState.running) return
-        screenState = screenState.copy(
-            selectedIds = screenState.items.asSequence().filter { it.selectable && it.risk in setOf("low", "medium") }.mapTo(linkedSetOf()) { it.id }
-        )
+    private fun selectAllSafe() = selectRisks(setOf("low", "medium"))
+    private fun selectAllMedium() = selectRisks(setOf("medium"))
+    private fun selectRisks(risks: Set<String>) {
+        if (!selectionIsEditable()) return
+        screenState = screenState.copy(selectedIds = reviewRiskSelection(screenState.items, risks))
     }
-
     private fun clearSelection() {
-        if (!screenState.running) screenState = screenState.copy(selectedIds = emptySet())
+        if (selectionIsEditable()) screenState = screenState.copy(selectedIds = emptySet())
     }
 
     private fun stopTask() {
@@ -922,10 +725,7 @@ class ScanWorkbenchActivity : ComponentActivity() {
         val profile = profileService
         val cache = cacheService
         val stoppingScan = scanJob?.isActive == true
-        if (stoppingScan) {
-            invalidateScanLoad()
-            scanJob?.cancel()
-        }
+        if (stoppingScan) { invalidateScanLoad(); scanJob?.cancel() }
         val stoppingGeneration = if (stoppingScan) scanGeneration.start() else null
         screenState = screenState.copy(notice = WorkbenchNotice.INFO, phase = "正在安全停止当前任务…")
         stopJob = lifecycleScope.launch {
@@ -935,14 +735,12 @@ class ScanWorkbenchActivity : ComponentActivity() {
             }
             if (stoppingGeneration != null && scanGeneration.accepts(stoppingGeneration)) {
                 scanGeneration.invalidate()
-                screenState = screenState.copy(running = false, scanReady = false,
-                    notice = WorkbenchNotice.WARNING,
+                screenState = screenState.copy(running = false, scanReady = false, notice = WorkbenchNotice.WARNING,
                     phase = "扫描 / 结果读取已停止；已加载项目仅供查看，请重新扫描")
                 saveReview()
             }
         }
     }
-
     private fun startPolling() {
         pollJob?.cancel()
         pollJob = lifecycleScope.launch {
@@ -952,44 +750,30 @@ class ScanWorkbenchActivity : ComponentActivity() {
                     val cache = runCatching { cacheService?.getTaskState()?.let(::JSONObject) }.getOrNull()
                     listOfNotNull(profile, cache).firstOrNull { it.optBoolean("running") }
                 }
-                if (state != null) {
-                    screenState = screenState.copy(
-                        phase = state.optString("phase", screenState.phase),
-                        progressCurrent = state.optLong("progress_current", state.optLong("current", 0L)).coerceAtLeast(0L),
-                        progressTotal = state.optLong("progress_total", state.optLong("total", 0L)).coerceAtLeast(0L),
-                        currentPath = state.optString("current_path", state.optString("path")).takeLast(120)
-                    )
-                }
+                if (state != null) screenState = screenState.copy(phase = state.optString("phase", screenState.phase),
+                    progressCurrent = state.optLong("progress_current", state.optLong("current", 0L)).coerceAtLeast(0L),
+                    progressTotal = state.optLong("progress_total", state.optLong("total", 0L)).coerceAtLeast(0L),
+                    currentPath = state.optString("current_path", state.optString("path")).takeLast(120))
                 delay(350L)
             }
         }
     }
-
     private fun optionsJson(service: IProfileRootService, suppliedConfig: JSONObject? = null): String {
         val config = suppliedConfig ?: runCatching { JSONObject(service.getSchedulerConfig()) }.getOrDefault(JSONObject())
         val policy = CleanupPolicy.fromId(config.optInt("cleanup_policy", CleanupPolicy.BALANCED.id))
         val paths = runCatching { JSONArray(service.getWhitelistPaths()) }.getOrDefault(JSONArray())
         val packages = runCatching { JSONArray(service.getWhitelistPackages()) }.getOrDefault(JSONArray())
         val maxMb = config.optInt("max_file_mb", 256).coerceIn(16, 16_384)
-        return JSONObject()
-            .put("whitelistPackages", packages)
-            .put("whitelistPaths", paths)
+        return JSONObject().put("whitelistPackages", packages).put("whitelistPaths", paths)
             .put("maxFileBytes", maxMb * 1_024L * 1_024L)
             .put("fragmentDays", config.optInt("fragment_days", 7).coerceIn(0, 365))
-            .put("allowHighRisk", false)
-            .put("maxAutoRisk", policy.autoRisk)
-            .put("highRiskMode", policy.highRiskMode)
-            .put("cleanupPolicy", policy.key)
-            .put("includeReviewRules", true)
-            .toString()
+            .put("allowHighRisk", false).put("maxAutoRisk", policy.autoRisk)
+            .put("highRiskMode", policy.highRiskMode).put("cleanupPolicy", policy.key)
+            .put("includeReviewRules", true).toString()
     }
-
     private fun applicationLabel(packageName: String): String = labels.getOrPut(packageName) { runCatching {
         val info = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            packageManager.getApplicationInfo(
-                packageName,
-                android.content.pm.PackageManager.ApplicationInfoFlags.of(0)
-            )
+            packageManager.getApplicationInfo(packageName, android.content.pm.PackageManager.ApplicationInfoFlags.of(0))
         } else {
             @Suppress("DEPRECATION")
             packageManager.getApplicationInfo(packageName, 0)
@@ -1006,8 +790,8 @@ class ScanWorkbenchActivity : ComponentActivity() {
         ScanReviewStore.save(this, scanProfile) {
             JSONObject().put("cacheSnapshotId", cacheId).put("profileSnapshotId", profileId)
                 .put("expiresAt", expires).put("scanReady", state.scanReady && !state.running && !state.loadingResults)
-                .put("loadingResults", state.loadingResults)
-                .put("phase", state.phase).put("resultText", state.resultText).put("notice", state.notice.name)
+                .put("loadingResults", state.loadingResults).put("phase", state.phase)
+                .put("resultText", state.resultText).put("notice", state.notice.name)
                 .put("policyId", policyId).put("selected", JSONArray(state.selectedIds.toList()))
                 .put("items", JSONArray().apply { state.items.forEach { item -> put(JSONObject()
                     .put("id", item.id).put("source", item.source).put("profile", item.profile)
@@ -1015,11 +799,9 @@ class ScanWorkbenchActivity : ComponentActivity() {
                     .put("category", item.category).put("groupKey", item.groupKey).put("groupTitle", item.groupTitle)
                     .put("title", item.title).put("risk", item.risk).put("path", item.path)
                     .put("bytes", item.bytes).put("files", item.files).put("directories", item.directories)
-                    .put("reason", item.reason).put("selectable", item.selectable).put("outcome", item.outcome)
-                ) } })
+                    .put("reason", item.reason).put("selectable", item.selectable).put("outcome", item.outcome)) } })
         }
     }
-
     private suspend fun restoreReview(saved: JSONObject) {
         val array = saved.optJSONArray("items") ?: return
         val items = withContext(Dispatchers.Default) {
@@ -1040,12 +822,9 @@ class ScanWorkbenchActivity : ComponentActivity() {
         snapshotExpiresAtRealtime = SystemClock.elapsedRealtime() + remaining
         cleanupPolicy = CleanupPolicy.fromId(saved.optInt("policyId", CleanupPolicy.BALANCED.id))
         val selected = saved.optJSONArray("selected") ?: JSONArray()
-        val selectedIds = withContext(Dispatchers.Default) {
-            (0 until selected.length()).map { selected.optString(it) }.toSet()
-        }
+        val selectedIds = withContext(Dispatchers.Default) { (0 until selected.length()).map { selected.optString(it) }.toSet() }
         val incomplete = saved.optBoolean("loadingResults")
-        screenState = screenState.copy(items = items,
-            selectedIds = selectedIds,
+        screenState = screenState.copy(items = items, selectedIds = selectedIds,
             scanReady = saved.optBoolean("scanReady") && !incomplete && remaining > 0L,
             expiresAtRealtime = snapshotExpiresAtRealtime,
             phase = if (incomplete) "上次结果读取未完成；已加载项目仅供查看，请重新扫描"
@@ -1055,14 +834,9 @@ class ScanWorkbenchActivity : ComponentActivity() {
             resultText = saved.optString("resultText"), policyTitle = cleanupPolicy.title,
             policyKey = cleanupPolicy.key, highRiskMode = cleanupPolicy.highRiskMode)
     }
-
     private fun stableId(value: String): String = MessageDigest.getInstance("SHA-256")
-        .digest(value.toByteArray(Charsets.UTF_8))
-        .joinToString("") { "%02x".format(it) }
-        .take(24)
-
+        .digest(value.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it) }.take(24)
     private fun formatBytes(bytes: Long): String = Formatter.formatFileSize(this, bytes.coerceAtLeast(0L))
-
     companion object {
         private const val CACHE_PAGE_SIZE = 100
         private const val PROFILE_PAGE_SIZE = 60
@@ -1071,17 +845,8 @@ class ScanWorkbenchActivity : ComponentActivity() {
     }
 }
 
-private data class CleanAggregate(
-    val bytes: Long,
-    val files: Long,
-    val failures: Int,
-    val candidates: Int,
-    val messages: List<String>,
-    val outcomes: Map<String, String>,
-    val cancelled: Boolean,
-    val incomplete: Boolean
-)
-
+private data class CleanAggregate(val bytes: Long, val files: Long, val failures: Int, val candidates: Int,
+    val messages: List<String>, val outcomes: Map<String, String>, val cancelled: Boolean, val incomplete: Boolean)
 private fun categoryLabel(category: String): String = when (category) {
     "empty_file" -> "空文件"
     "empty_dir" -> "空目录"
@@ -1090,7 +855,6 @@ private fun categoryLabel(category: String): String = when (category) {
     "rule_trash" -> "规则垃圾"
     else -> "安全项目"
 }
-
 private fun riskReason(risk: String, label: String, policy: CleanupPolicy): String = when (risk) {
     "low" -> "$label · 可安全自动处理"
     "medium" -> "$label · 清理前再次校验白名单与大小限制"
@@ -1101,6 +865,5 @@ private fun riskReason(risk: String, label: String, policy: CleanupPolicy): Stri
     }
     else -> "$label · 关键风险项目，只展示不自动清理"
 }
-
 private fun itWasNotCleaned(id: String, outcomes: Map<String, String>): Boolean =
     outcomes[id] !in setOf("已清理", "已按所选缓存执行清理")

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchScreen.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/ScanWorkbenchScreen.kt
@@ -37,6 +37,7 @@ import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
 import io.github.xgl34222220.baize.ui.components.*
 import io.github.xgl34222220.baize.ui.miuix.GlassActionButton
 import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -95,7 +96,9 @@ internal data class WorkbenchActions(
     val onSelectAll: () -> Unit,
     val onClear: () -> Unit,
     val onProtect: (WorkbenchItem) -> Unit,
-    val onQuarantine: (WorkbenchItem) -> Unit
+    val onQuarantine: (WorkbenchItem) -> Unit,
+    val onSelectMedium: () -> Unit = {},
+    val onManageWhitelist: () -> Unit = {}
 )
 
 private data class WorkbenchGroup(
@@ -110,11 +113,9 @@ private data class WorkbenchGroup(
 
 private sealed interface WorkbenchRow {
     val key: String
-
     data class Group(val group: WorkbenchGroup) : WorkbenchRow {
         override val key: String = "group:${group.key}"
     }
-
     data class Candidate(val item: WorkbenchItem) : WorkbenchRow {
         override val key: String = "item:${item.id}"
     }
@@ -136,6 +137,10 @@ private fun workbenchPresentation(
 ): WorkbenchPresentation {
     val filtered = items.filter { item ->
         when (filter) {
+            "medium" -> item.risk == "medium"
+            "high" -> item.risk == "high"
+            "unfinished" -> item.outcome.isNotBlank() && item.outcome != "未勾选，保留" &&
+                item.outcome !in setOf("已清理", "已按所选缓存执行清理")
             "unselected" -> item.id !in selectedIds && !item.outcome.startsWith("已清理") && !item.outcome.startsWith("已按所选")
             "blocked" -> !item.selectable
             "deep" -> item.profile == "deep"
@@ -167,6 +172,7 @@ private fun workbenchPresentation(
 }
 
 /** Task outcome, selection and the list have separate roles; connection is never success. */
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun ScanWorkbenchScreen(
     appearance: AppearanceSettings,
@@ -182,14 +188,26 @@ internal fun ScanWorkbenchScreen(
     var showReport by rememberSaveable { mutableStateOf(false) }
     var inspected by remember { mutableStateOf<WorkbenchItem?>(null) }
     var confirmedSelection by remember { mutableStateOf<Pair<Long, Set<String>>?>(null) }
-    val editable = state.connected && state.scanReady && !state.running && !state.loadingResults
+    val now by produceState(SystemClock.elapsedRealtime(), state.scanReady, state.expiresAtRealtime) {
+        value = SystemClock.elapsedRealtime()
+        while (state.scanReady && value < state.expiresAtRealtime) {
+            delay(1_000L)
+            value = SystemClock.elapsedRealtime()
+        }
+    }
+    val liveSnapshot = state.scanReady && now < state.expiresAtRealtime
+    val lockedReason = reviewSelectionBlockReason(state, now)
+    val editable = lockedReason == null
+    val visibleState = if (state.scanReady && !liveSnapshot && !state.running) state.copy(
+        scanReady = false, notice = WorkbenchNotice.WARNING, phase = "扫描结果已过期，请重新扫描") else state
     val presentation by produceState(WorkbenchPresentation(), state.items, state.selectedIds,
         filter, expandedGroups, state.loadingResults) {
         value = withContext(Dispatchers.Default) {
             workbenchPresentation(state.items, state.selectedIds, filter, expandedGroups, state.loadingResults)
         }
     }
-    val filters = listOf("all" to "全部", "unselected" to "待处理", "blocked" to "不可选",
+    val filters = listOf("all" to "全部", "medium" to "中风险", "high" to "高风险",
+        "unselected" to "待处理", "unfinished" to "未完成", "blocked" to "不可选",
         "deep" to "深度规则", "cache" to "应用缓存", "empty" to "空项目",
         "rules" to "规则垃圾", "fragments" to "残留碎片")
     val selected = remember(state.items, state.selectedIds) { state.items.filter { it.selectable && it.id in state.selectedIds } }
@@ -205,14 +223,17 @@ internal fun ScanWorkbenchScreen(
         LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = bottomBarHeight + 12.dp)) {
             item {
                 DetailPageHeader("扫描结果", "", actions.onBack) {
+                    IconButton(onClick = actions.onManageWhitelist, enabled = !state.running && !state.loadingResults) {
+                        Icon(Icons.Rounded.Shield, "管理白名单", Modifier.size(22.dp))
+                    }
                     IconButton(onClick = { showGuide = true }) { Icon(Icons.Rounded.Info, "扫描说明", Modifier.size(22.dp)) }
                 }
             }
             if (state.items.isEmpty()) {
-                item { WorkbenchEmptyCard(state, onDetails = { showReport = true }) }
+                item { WorkbenchEmptyCard(visibleState, onDetails = { showReport = true }) }
             } else {
                 item {
-                    WorkbenchSummaryCard(state, presentation, selected.size, selectedHigh.size,
+                    WorkbenchSummaryCard(visibleState, presentation, selected.size, selectedHigh.size,
                         selected.any { it.bytes < 0L }, onDetails = { showReport = true })
                 }
                 item {
@@ -227,14 +248,23 @@ internal fun ScanWorkbenchScreen(
                                 Icon(Icons.Rounded.Tune, "筛选结果", Modifier.size(17.dp))
                             }
                         }
-                        if (editable) Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                            TextButton(actions.onSelectAll, contentPadding = PaddingValues(end = 12.dp)) {
-                                Text("选中低、中风险", fontSize = 12.sp)
+                        FlowRow(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            TextButton(actions.onSelectAll, enabled = editable, contentPadding = PaddingValues(horizontal = 8.dp)) {
+                                Text("全选低、中风险", fontSize = 13.sp)
                             }
-                            TextButton(actions.onClear, enabled = selected.isNotEmpty(),
+                            TextButton(actions.onSelectMedium, enabled = editable, contentPadding = PaddingValues(horizontal = 8.dp)) {
+                                Text("仅选中风险", fontSize = 13.sp)
+                            }
+                            TextButton(actions.onClear, enabled = editable && selected.isNotEmpty(),
                                 contentPadding = PaddingValues(horizontal = 8.dp)) {
-                                Text("清空选择", fontSize = 12.sp)
+                                Text("清空选择", fontSize = 13.sp)
                             }
+                        }
+                        Text(lockedReason ?: "批量选择作用于全部扫描结果；高风险请展开后逐项选择。",
+                            style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        if (state.items.any { it.outcome.isNotBlank() && it.outcome != "未勾选，保留" &&
+                                it.outcome !in setOf("已清理", "已按所选缓存执行清理") }) {
+                            TextButton(onClick = { filter = "unfinished" }) { Text("查看未完成项目") }
                         }
                     }
                 }
@@ -250,14 +280,13 @@ internal fun ScanWorkbenchScreen(
                             } }, onSelect = { actions.onToggleGroup(row.group.key) }
                         )
                         is WorkbenchRow.Candidate -> WorkbenchCandidateRow(
-                            row.item, row.item.id in state.selectedIds, editable,
+                            row.item, row.item.id in state.selectedIds, editable, lockedReason,
                             onToggle = { actions.onToggleItem(row.item.id) }, onDetails = { inspected = row.item }
                         )
                     }
                 }
             }
         }
-        // A compact floating dock keeps the only primary action reachable above system navigation.
         Box(Modifier.align(Alignment.BottomCenter).fillMaxWidth()
             .onSizeChanged { bottomBarHeight = with(density) { it.height.toDp() } }
             .padding(horizontal = 20.dp).padding(top = 12.dp, bottom = inset + 12.dp)) {
@@ -265,19 +294,19 @@ internal fun ScanWorkbenchScreen(
                 tonalElevation = 0.dp, shadowElevation = 8.dp, shape = RoundedCornerShape(24.dp)) {
                 Row(Modifier.fillMaxWidth().padding(8.dp), verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    if (state.scanReady && !state.running) IconButton(onClick = actions.onScan,
+                    if (liveSnapshot && !state.running) IconButton(onClick = actions.onScan,
                         modifier = Modifier.size(48.dp).clip(RoundedCornerShape(16.dp))
                             .background(BaiZeTokens.colors.surfaceOverlay)) {
                         Icon(Icons.Rounded.Refresh, "重扫", Modifier.size(22.dp), tint = MaterialTheme.colorScheme.onSurface)
                     }
                     GlassActionButton(
-                        label = when { state.running -> "停止当前任务"; state.scanReady -> "清理已选 ${selected.size} 项";
+                        label = when { state.running -> "停止当前任务"; liveSnapshot -> "清理已选 ${selected.size} 项";
                             !state.connected -> "重新连接并扫描"; state.items.isNotEmpty() || state.notice == WorkbenchNotice.ERROR -> "重新扫描"; else -> "开始扫描" },
-                        onClick = when { state.running -> actions.onStop; state.scanReady -> clean; else -> actions.onScan },
+                        onClick = when { state.running -> actions.onStop; liveSnapshot -> clean; else -> actions.onScan },
                         modifier = Modifier.weight(1f),
-                        enabled = if (state.scanReady && !state.running) canClean else true,
+                        enabled = if (liveSnapshot && !state.running) canClean else true,
                         secondary = state.running,
-                        icon = if (state.running) Icons.Rounded.Stop else if (state.scanReady) Icons.Rounded.CleaningServices else Icons.Rounded.Search
+                        icon = if (state.running) Icons.Rounded.Stop else if (liveSnapshot) Icons.Rounded.CleaningServices else Icons.Rounded.Search
                     )
                 }
             }
@@ -293,11 +322,14 @@ internal fun ScanWorkbenchScreen(
         } }, confirmButton = { TextButton({ showFilters = false }) { Text("取消") } })
     if (showGuide) WorkbenchInfoDialog("扫描与选择", buildString {
         append("按应用展开后，可以逐项选择文件。低、中风险支持批量选择，高风险需单独勾选并确认。\n\n")
-        append("白名单、关键系统数据和已变化的文件会继续保留。\n\n")
+        append("应用行复选框只批量选择低、中风险；全部是高风险的分组请点“逐项选择”。\n\n")
+        append("白名单、关键系统数据和已变化的文件会继续保留，具体原因在每项下方显示。\n\n")
+        append("应用及路径白名单都可在右上角盾牌入口管理。取消保护不等于立即删除，之后需重新扫描。\n\n")
         append("扫描结果保留 30 分钟；过期或执行结果未确认时，需要重新扫描。大小未完成统计的项目仍可显示。\n\n")
         append("当前策略：${state.policyTitle}")
     }) { showGuide = false }
-    if (showReport) WorkbenchInfoDialog("任务详情", listOf(state.phase, state.resultText, state.currentPath)
+    if (showReport) WorkbenchInfoDialog(if (liveSnapshot || state.running) "任务详情" else "上次任务详情",
+        listOf(visibleState.phase, if (!liveSnapshot && state.items.isNotEmpty()) REVIEW_HISTORY_HINT else "", state.resultText, state.currentPath)
         .filter { it.isNotBlank() }.distinct().joinToString("\n\n")) { showReport = false }
     inspected?.let { item ->
         AlertDialog(onDismissRequest = { inspected = null }, title = { Text(item.title, fontSize = 18.sp) },
@@ -305,7 +337,12 @@ internal fun ScanWorkbenchScreen(
                 RiskBadge(item.risk)
                 SelectionContainer { Text(listOf(item.groupTitle, item.outcome.ifBlank { item.reason }, item.path)
                     .filter { it.isNotBlank() }.joinToString("\n\n"), fontSize = 13.sp, lineHeight = 20.sp) }
-                if (!item.selectable) Text("此项目不可选：${item.reason}", fontSize = 12.sp, color = MaterialTheme.colorScheme.error)
+                reviewItemRestriction(item, lockedReason)?.let { reason ->
+                    Text(reason, fontSize = 13.sp, color = MaterialTheme.colorScheme.error)
+                }
+                if (!state.running && !state.loadingResults) TextButton({ inspected = null; actions.onManageWhitelist() }) {
+                    Text("管理应用 / 路径白名单")
+                }
                 if (editable && item.selectable && item.risk == "high" && state.highRiskMode != "audit") {
                     TextButton({ inspected = null; actions.onQuarantine(item) }) {
                         Icon(Icons.Rounded.Inventory2, null, Modifier.size(18.dp)); Spacer(Modifier.width(6.dp)); Text("移入隔离区")
@@ -336,7 +373,6 @@ internal fun ScanWorkbenchScreen(
 
 private fun workbenchErrorSummary(state: WorkbenchUiState): String {
     val details = "${state.phase}\n${state.resultText}"
-    // Binder failure does not establish whether the service died or its buffer was exhausted.
     if (listOf("transaction failed", "deadobjectexception", "binder buffer", "failed binder transaction")
             .any { details.contains(it, ignoreCase = true) }) {
         return "清理服务通信失败，结果未确认"
@@ -361,7 +397,8 @@ private fun workbenchStatusColor(state: WorkbenchUiState) = when {
 private fun workbenchStatusTitle(state: WorkbenchUiState) = when {
     state.running -> if (state.loadingResults) "正在读取扫描结果" else "正在处理"
     state.notice == WorkbenchNotice.ERROR -> workbenchErrorSummary(state)
-    state.notice == WorkbenchNotice.WARNING -> "有项目需要核对"
+    !state.scanReady && state.items.isNotEmpty() -> reviewRecordTitle(state)
+    state.notice == WorkbenchNotice.WARNING -> state.phase.ifBlank { "扫描未完成，请查看原因" }
     state.scanReady -> "扫描完成"
     state.notice == WorkbenchNotice.SUCCESS -> "任务已完成"
     !state.connected -> "等待清理服务连接"
@@ -393,7 +430,7 @@ private fun WorkbenchSummaryCard(
                 Icon(Icons.Rounded.ChevronRight, null, Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             Spacer(Modifier.height(20.dp))
-            Text(if (state.scanReady) "已选项目 · 预计释放" else "保留的扫描记录",
+            Text(if (state.scanReady) "已选项目 · 预计释放" else "上次扫描记录 · 非剩余垃圾量",
                 style = BaiZeTokens.type.caption, color = MaterialTheme.colorScheme.onSurfaceVariant)
             Text(if (state.scanReady) Formatter.formatFileSize(LocalContext.current, presentation.selectedBytes)
                 else "${state.items.size} 项", Modifier.padding(top = 3.dp),
@@ -401,7 +438,7 @@ private fun WorkbenchSummaryCard(
             Row(Modifier.fillMaxWidth().padding(top = 18.dp).clip(RoundedCornerShape(16.dp))
                 .background(BaiZeTokens.colors.surfaceBase).padding(vertical = 12.dp)) {
                 WorkbenchStat("${presentation.appCount}", "应用", Modifier.weight(1f))
-                WorkbenchStat("$selectedCount", "已选项目", Modifier.weight(1f))
+                WorkbenchStat("$selectedCount", if (state.scanReady) "已选项目" else "原选择", Modifier.weight(1f))
                 WorkbenchStat("${presentation.protectedCount}", "不可选", Modifier.weight(1f))
             }
             when {
@@ -409,7 +446,7 @@ private fun WorkbenchSummaryCard(
                     fontSize = 12.sp, lineHeight = 18.sp, color = BaiZeTokens.colors.warning)
                 state.scanReady && hasUnknownSize -> Text("部分大小待统计，释放量以清理结果为准", Modifier.padding(top = 12.dp),
                     fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                !state.scanReady && !state.running -> Text("记录可继续查看，重新扫描后可选择清理", Modifier.padding(top = 12.dp),
+                !state.scanReady && !state.running -> Text(REVIEW_HISTORY_HINT, Modifier.padding(top = 12.dp),
                     fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             if (state.running) WorkbenchProgress(state)
@@ -508,10 +545,14 @@ private fun WorkbenchGroupRow(group: WorkbenchGroup, expanded: Boolean, enabled:
                 if (group.selectedCount > 0) Text("已选 ${group.selectedCount} 项", fontSize = 11.sp, lineHeight = 15.sp,
                     color = MaterialTheme.colorScheme.primary)
             }
-            TriStateCheckbox(state = when { group.bulkSelectedCount == 0 -> ToggleableState.Off;
-                group.bulkSelectedCount == group.selectableCount -> ToggleableState.On; else -> ToggleableState.Indeterminate },
-                onClick = onSelect, enabled = enabled && group.selectableCount > 0,
-                modifier = Modifier.semantics { contentDescription = "选择${group.title}的低中风险项目" })
+            if (group.selectableCount > 0) {
+                TriStateCheckbox(state = when { group.bulkSelectedCount == 0 -> ToggleableState.Off;
+                    group.bulkSelectedCount == group.selectableCount -> ToggleableState.On; else -> ToggleableState.Indeterminate },
+                    onClick = onSelect, enabled = enabled,
+                    modifier = Modifier.semantics { contentDescription = "选择${group.title}的低中风险项目" })
+            } else TextButton(onClick = onExpand, contentPadding = PaddingValues(horizontal = 6.dp)) {
+                Text(if (group.items.any { it.selectable && it.risk == "high" }) "逐项选择" else "查看原因", fontSize = 12.sp)
+            }
             Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, null,
                 Modifier.size(18.dp), tint = MaterialTheme.colorScheme.onSurfaceVariant)
         }
@@ -519,11 +560,11 @@ private fun WorkbenchGroupRow(group: WorkbenchGroup, expanded: Boolean, enabled:
 }
 
 @Composable
-private fun WorkbenchCandidateRow(item: WorkbenchItem, selected: Boolean, enabled: Boolean, onToggle: () -> Unit, onDetails: () -> Unit) {
+private fun WorkbenchCandidateRow(item: WorkbenchItem, selected: Boolean, enabled: Boolean, lockedReason: String?, onToggle: () -> Unit, onDetails: () -> Unit) {
     Row(Modifier.fillMaxWidth().padding(horizontal = 28.dp).padding(bottom = 4.dp)
         .clip(RoundedCornerShape(16.dp)).background(BaiZeTokens.colors.surfaceRaised.copy(alpha = .72f))
         .padding(start = 2.dp, end = 3.dp, top = 8.dp, bottom = 8.dp), verticalAlignment = Alignment.Top) {
-        Checkbox(selected, onCheckedChange = { onToggle() }, enabled = enabled && item.selectable,
+        Checkbox(selected, onCheckedChange = { onToggle() }, enabled = enabled && item.selectable && item.risk != "critical",
             modifier = Modifier.semantics { contentDescription = "选择${item.title}" })
         Column(Modifier.weight(1f).clickable(onClickLabel = "查看文件明细", onClick = onDetails).padding(top = 7.dp, bottom = 5.dp),
             verticalArrangement = Arrangement.spacedBy(7.dp)) {
@@ -533,7 +574,12 @@ private fun WorkbenchCandidateRow(item: WorkbenchItem, selected: Boolean, enable
                 Text(if (item.bytes < 0L) "大小待统计" else Formatter.formatFileSize(LocalContext.current, item.bytes),
                     fontSize = 11.sp, lineHeight = 16.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
-            Text(item.outcome.ifBlank { if (!item.selectable) item.reason else item.path }, fontSize = 11.sp, lineHeight = 17.sp,
+            reviewItemRestriction(item, lockedReason)?.let { reason ->
+                Text(reason, fontSize = 12.sp, lineHeight = 18.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            if (item.risk == "high" && item.selectable && enabled) Text("可单独勾选，删除前须确认路径", fontSize = 12.sp,
+                color = BaiZeTokens.colors.warning)
+            Text(item.outcome.ifBlank { item.path }, fontSize = 11.sp, lineHeight = 17.sp,
                 maxLines = 2, overflow = TextOverflow.Ellipsis, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
         IconButton(onDetails, Modifier.size(40.dp)) { Icon(Icons.Rounded.MoreHoriz, "${item.title}详情", Modifier.size(19.dp)) }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/WhitelistActivity.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/WhitelistActivity.kt
@@ -1,457 +1,210 @@
 package io.github.xgl34222220.baize
 
-import io.github.xgl34222220.baize.root.RootServiceClients
 import android.content.ComponentName
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
-import android.text.Editable
-import android.text.TextWatcher
-import android.util.LruCache
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
-import androidx.core.graphics.ColorUtils
-import androidx.core.view.ViewCompat
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.*
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
-import androidx.core.view.updatePadding
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.color.MaterialColors
 import com.topjohnwu.superuser.ipc.RootService
-import io.github.xgl34222220.baize.databinding.ActivityWhitelistBinding
-import io.github.xgl34222220.baize.databinding.ItemWhitelistAppBinding
 import io.github.xgl34222220.baize.root.BaiZeProfileRootService
 import io.github.xgl34222220.baize.root.IProfileRootService
+import io.github.xgl34222220.baize.root.RootServiceClients
+import io.github.xgl34222220.baize.root.WhitelistFileClient
+import io.github.xgl34222220.baize.ui.appearance.*
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import org.json.JSONObject
 
-class WhitelistActivity : AppCompatActivity() {
-    private lateinit var binding: ActivityWhitelistBinding
-    private val allApps = mutableListOf<AppEntry>()
-    private val iconCache = LruCache<String, Drawable>(48)
-    private var service: IProfileRootService? = null
-    private var serviceBound = false
-    private var currentFilter = Filter.ALL
-    private var loading = true
-    private var localFallbackStarted = false
+@androidx.annotation.Keep
+internal class WhitelistViewModel : ViewModel() {
+    var state by mutableStateOf(WhitelistUiState())
+}
 
-    private val adapter = AppAdapter(
-        iconLoader = ::loadIcon,
-        onToggle = { entry, checked ->
-            allApps.firstOrNull { it.packageName == entry.packageName }?.selected = checked
-            applyFilter()
-        }
-    )
+/** Application and explicit-path protection share a discoverable, reversible management page. */
+class WhitelistActivity : ComponentActivity() {
+    private val appearance: AppearanceViewModel by viewModels()
+    private val model: WhitelistViewModel by viewModels()
+    private var state: WhitelistUiState
+        get() = model.state
+        set(value) { model.state = value }
+    private var service: IProfileRootService? = null
+    private var bindingRequested = false
+    private var loadGeneration = 0
 
     private val connection = object : ServiceConnection {
         override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
             service = RootServiceClients.profile(binder, applicationContext.cacheDir)
-            serviceBound = true
-            binding.saveButton.isEnabled = true
-            loadCatalogAndWhitelist()
+            state = state.copy(connected = true)
+            load()
         }
-
         override fun onServiceDisconnected(name: ComponentName?) {
+            loadGeneration++
             service = null
-            serviceBound = false
-            binding.saveButton.isEnabled = false
-            binding.statusText.text = "Root 服务已断开，当前选择尚未写入清理引擎"
+            bindingRequested = false
+            state = state.copy(connected = false, loading = false, saving = false,
+                message = "Root 服务已断开；未保存的选择已保留，请重新连接。")
+        }
+        override fun onNullBinding(name: ComponentName?) {
+            runCatching { RootService.unbind(this) }
+            onServiceDisconnected(name)
         }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        state = state.copy(connected = false, loading = false, saving = false)
         WindowCompat.setDecorFitsSystemWindows(window, false)
-        binding = ActivityWhitelistBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-        applySystemBarInsets()
-
-        binding.backButton.setOnClickListener { finish() }
-        binding.appList.layoutManager = LinearLayoutManager(this)
-        binding.appList.adapter = adapter
-        binding.appList.setHasFixedSize(true)
-        binding.appList.clipToOutline = true
-        binding.saveButton.isEnabled = false
-        binding.selectVisibleButton.isEnabled = false
-        binding.clearButton.isEnabled = false
-
-        binding.clearButton.setOnClickListener {
-            allApps.forEach { it.selected = false }
-            applyFilter()
-        }
-        binding.selectVisibleButton.setOnClickListener {
-            val visible = filteredApps()
-            val shouldSelect = visible.any { !it.selected }
-            visible.forEach { it.selected = shouldSelect }
-            applyFilter()
-        }
-        binding.saveButton.setOnClickListener { saveWhitelist() }
-
-        binding.filterGroup.setOnCheckedStateChangeListener { _, checkedIds ->
-            currentFilter = when (checkedIds.firstOrNull()) {
-                R.id.filterUser -> Filter.USER
-                R.id.filterSystem -> Filter.SYSTEM
-                R.id.filterProtected -> Filter.PROTECTED
-                else -> Filter.ALL
+        setContent {
+            val settings = appearance.settings.collectAsStateWithLifecycle().value
+            val systemDark = isSystemInDarkTheme()
+            val dark = settings.themeMode == ThemeMode.DARK || settings.themeMode == ThemeMode.SYSTEM && systemDark
+            SideEffect {
+                WindowCompat.getInsetsController(window, window.decorView).apply {
+                    isAppearanceLightStatusBars = !dark
+                    isAppearanceLightNavigationBars = !dark
+                }
             }
-            applyFilter()
-        }
-        binding.filterAll.isChecked = true
-
-        binding.queryInput.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = applyFilter()
-            override fun afterTextChanged(s: Editable?) = Unit
-        })
-
-        showLoading("正在通过 Root 服务读取全部已安装应用…")
-        connectService()
-        binding.root.postDelayed({
-            if (service == null && loading && !isFinishing) {
-                lifecycleScope.launch { loadLocalFallback("Root 服务连接较慢，先显示系统可见应用…") }
+            BaiZeTheme(settings) {
+                CompositionLocalProvider(LocalAppearanceSettings provides settings) {
+                    WhitelistManagerScreen(state,
+                        onBack = ::finish, onRefresh = { if (service == null) connect() else load() },
+                        onToggle = { pkg -> if (canEditApps()) state = state.copy(draft = state.draft.toggle(pkg)) },
+                        onClearApps = { if (canEditApps()) state = state.copy(draft = state.draft.copy(selected = emptySet())) },
+                        onSaveApps = ::saveApps, onRemovePath = ::removePath)
+                }
             }
-        }, ROOT_FALLBACK_DELAY_MS)
+        }
+        connect()
     }
 
-    private fun applySystemBarInsets() {
-        val headerTop = binding.headerContainer.paddingTop
-        val rootBottom = binding.whitelistRoot.paddingBottom
-        ViewCompat.setOnApplyWindowInsetsListener(binding.whitelistRoot) { _, insets ->
-            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
-            val searching = insets.isVisible(WindowInsetsCompat.Type.ime())
-            binding.headerContainer.updatePadding(top = headerTop + bars.top)
-            binding.whitelistRoot.updatePadding(bottom = rootBottom + maxOf(bars.bottom, ime.bottom))
-            binding.pageTitle.visibility = if (searching) View.GONE else View.VISIBLE
-            binding.pageSubtitle.visibility = if (searching) View.GONE else View.VISIBLE
-            binding.bottomActionCard.visibility = if (searching) View.GONE else View.VISIBLE
-            insets
-        }
-        WindowInsetsControllerCompat(window, binding.root).apply {
-            isAppearanceLightStatusBars = !ThemeManager.isDark(this@WhitelistActivity)
-            isAppearanceLightNavigationBars = !ThemeManager.isDark(this@WhitelistActivity)
-        }
-        ViewCompat.requestApplyInsets(binding.whitelistRoot)
-    }
+    private fun canEditApps() = state.connected && state.packagesLoaded && !state.loading && !state.saving
 
-    private fun connectService() {
+    private fun connect() {
+        if (bindingRequested) return
+        bindingRequested = true
+        state = state.copy(message = "正在连接 Root 服务…")
         runCatching {
-            RootService.bind(
-                Intent(this, BaiZeProfileRootService::class.java)
-                    .addCategory(RootService.CATEGORY_DAEMON_MODE),
-                connection
-            )
+            RootService.bind(Intent(this, BaiZeProfileRootService::class.java)
+                .addCategory(RootService.CATEGORY_DAEMON_MODE), connection)
         }.onFailure {
-            serviceBound = false
-            binding.statusText.text = "Root 服务连接失败：${it.message ?: it.javaClass.simpleName}"
-            lifecycleScope.launch { loadLocalFallback("Root 不可用，正在读取系统可见应用…") }
+            bindingRequested = false
+            state = state.copy(connected = false, message = "Root 连接失败：${it.message}。请确认模块已安装并授权。")
         }
     }
 
-    private fun loadCatalogAndWhitelist() {
-        val rootService = service ?: return
-        showLoading("正在读取应用目录与白名单…")
+    private fun load() {
+        val remote = service ?: return
+        if (state.saving) return
+        val generation = ++loadGeneration
+        state = state.copy(loading = true, message = "正在读取应用与路径白名单…")
         lifecycleScope.launch {
-            val result = withContext(Dispatchers.IO) {
-                val catalogRaw = runCatching { rootService.getInstalledPackageCatalog() }.getOrNull()
-                val whitelistRaw = runCatching { rootService.getWhitelistPackages() }.getOrNull()
-                val selected = parseWhitelist(whitelistRaw)
-                val rootCatalog = parseRootCatalog(catalogRaw)
-                val catalog = if (rootCatalog.isNotEmpty()) rootCatalog else loadLocalCatalog()
-                val apps = buildEntries(catalog, selected)
-                CatalogResult(
-                    apps = apps,
-                    selectedCount = selected.size,
-                    source = if (rootCatalog.isNotEmpty()) "Root 完整目录" else "系统兼容目录"
-                )
-            }
-            renderCatalog(result)
-        }
-    }
-
-    private suspend fun loadLocalFallback(message: String) {
-        if (localFallbackStarted || service != null) return
-        localFallbackStarted = true
-        showLoading(message)
-        val result = withContext(Dispatchers.IO) {
-            val catalog = loadLocalCatalog()
-            CatalogResult(buildEntries(catalog, emptySet()), 0, "系统兼容目录")
-        }
-        if (service == null) renderCatalog(result)
-    }
-
-    private fun renderCatalog(result: CatalogResult) {
-        allApps.clear()
-        allApps += result.apps
-        loading = false
-        binding.loadingIndicator.visibility = View.GONE
-        binding.clearButton.isEnabled = allApps.isNotEmpty()
-        binding.statusText.text = if (allApps.isEmpty()) {
-            "仍未读取到应用。请确认模块已刷入并授予 Root，然后返回重试。"
-        } else {
-            "已从${result.source}读取 ${allApps.size} 个应用；已保存保护 ${result.selectedCount} 个。"
-        }
-        applyFilter()
-    }
-
-    private fun showLoading(message: String) {
-        loading = true
-        binding.loadingIndicator.visibility = View.VISIBLE
-        binding.emptyText.visibility = View.GONE
-        binding.statusText.text = message
-        binding.selectionText.text = "正在准备应用列表…"
-    }
-
-    private fun parseRootCatalog(raw: String?): List<CatalogEntry> {
-        if (raw.isNullOrBlank()) return emptyList()
-        return runCatching {
-            val root = JSONObject(raw)
-            val array = root.optJSONArray("packages") ?: JSONArray()
-            buildList {
-                for (index in 0 until array.length()) {
-                    val item = array.optJSONObject(index) ?: continue
-                    val packageName = item.optString("packageName").trim()
-                    if (PACKAGE_NAME.matches(packageName) && packageName != this@WhitelistActivity.packageName) {
-                        add(CatalogEntry(packageName, item.optBoolean("system")))
+            val result = runCatching { withContext(Dispatchers.IO) {
+                // A failed read is not an empty whitelist and can never authorize a save.
+                val packages = stringSet(remote.getWhitelistPackages())
+                val paths = stringSet(remote.getWhitelistPaths()).sorted()
+                val catalog = runCatching { JSONObject(remote.getInstalledPackageCatalog()).getJSONArray("packages") }.getOrNull()
+                val entries = linkedMapOf<String, Boolean>()
+                if (catalog != null) for (i in 0 until catalog.length()) {
+                    val row = catalog.getJSONObject(i)
+                    entries[row.getString("packageName")] = row.optBoolean("system")
+                }
+                if (entries.isEmpty()) {
+                    @Suppress("DEPRECATION")
+                    packageManager.getInstalledApplications(0).forEach { info ->
+                        entries[info.packageName] = info.flags and ApplicationInfo.FLAG_SYSTEM != 0
                     }
                 }
-            }
-        }.getOrDefault(emptyList())
-    }
-
-    private fun parseWhitelist(raw: String?): Set<String> {
-        if (raw.isNullOrBlank()) return emptySet()
-        return runCatching {
-            val array = JSONArray(raw)
-            buildSet {
-                for (index in 0 until array.length()) {
-                    val packageName = array.optString(index).trim()
-                    if (PACKAGE_NAME.matches(packageName)) add(packageName)
-                }
-            }
-        }.getOrDefault(emptySet())
-    }
-
-    private fun loadLocalCatalog(): List<CatalogEntry> {
-        val installed = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            packageManager.getInstalledApplications(PackageManager.ApplicationInfoFlags.of(0))
-        } else {
-            @Suppress("DEPRECATION")
-            packageManager.getInstalledApplications(0)
-        }
-        return installed.asSequence()
-            .filter { it.packageName != packageName }
-            .map { info ->
-                CatalogEntry(
-                    packageName = info.packageName,
-                    system = info.flags and ApplicationInfo.FLAG_SYSTEM != 0
-                )
-            }
-            .distinctBy { it.packageName }
-            .toList()
-    }
-
-    private fun buildEntries(catalog: List<CatalogEntry>, selected: Set<String>): List<AppEntry> {
-        val manager = packageManager
-        return catalog.asSequence()
-            .distinctBy { it.packageName }
-            .map { entry ->
-                val info = runCatching {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                        manager.getApplicationInfo(entry.packageName, PackageManager.ApplicationInfoFlags.of(0))
-                    } else {
-                        @Suppress("DEPRECATION")
-                        manager.getApplicationInfo(entry.packageName, 0)
-                    }
-                }.getOrNull()
-                val label = info?.let { runCatching { manager.getApplicationLabel(it).toString() }.getOrNull() }
-                    ?.takeIf { it.isNotBlank() }
-                    ?: entry.packageName.substringAfterLast('.').replaceFirstChar { it.uppercase() }
-                AppEntry(
-                    packageName = entry.packageName,
-                    label = label,
-                    system = entry.system || (info?.flags?.and(ApplicationInfo.FLAG_SYSTEM) != 0),
-                    selected = entry.packageName in selected
-                )
-            }
-            .sortedWith(
-                compareByDescending<AppEntry> { it.selected }
-                    .thenBy { it.system }
-                    .thenBy { it.label.lowercase() }
-                    .thenBy { it.packageName }
-            )
-            .toList()
-    }
-
-    private fun filteredApps(): List<AppEntry> {
-        val query = binding.queryInput.text?.toString().orEmpty().trim().lowercase()
-        return allApps.filter { app ->
-            val filterMatch = when (currentFilter) {
-                Filter.ALL -> true
-                Filter.USER -> !app.system
-                Filter.SYSTEM -> app.system
-                Filter.PROTECTED -> app.selected
-            }
-            filterMatch && (
-                query.isBlank() ||
-                    app.label.lowercase().contains(query) ||
-                    app.packageName.lowercase().contains(query)
-                )
-        }
-    }
-
-    private fun applyFilter() {
-        if (loading) return
-        val visible = filteredApps()
-        adapter.submit(visible)
-        val selected = allApps.count { it.selected }
-        val userCount = allApps.count { !it.system }
-        val systemCount = allApps.size - userCount
-        binding.selectionText.text = "已保护 $selected 个"
-        binding.filterUser.text = "用户应用 $userCount"
-        binding.filterSystem.text = "系统应用 $systemCount"
-        binding.emptyText.visibility = if (visible.isEmpty()) View.VISIBLE else View.GONE
-        binding.appList.visibility = if (visible.isEmpty()) View.GONE else View.VISIBLE
-        binding.selectVisibleButton.isEnabled = visible.isNotEmpty()
-        binding.selectVisibleButton.text = if (visible.isNotEmpty() && visible.all { it.selected }) {
-            "取消当前"
-        } else {
-            "全选当前"
-        }
-        binding.selectVisibleButton.contentDescription = "${binding.selectVisibleButton.text} ${visible.size} 个应用"
-        binding.clearButton.isEnabled = selected > 0
-    }
-
-    private fun saveWhitelist() {
-        val rootService = service ?: return
-        val packages = allApps.asSequence()
-            .filter { it.selected }
-            .map { it.packageName }
-            .sorted()
-            .toList()
-        val payload = JSONArray(packages).toString()
-        binding.saveButton.isEnabled = false
-        binding.statusText.text = "正在写入清理引擎白名单…"
-        lifecycleScope.launch {
-            val result = runCatching {
-                withContext(Dispatchers.IO) { rootService.saveWhitelistPackages(payload) }
-            }
-            result.onSuccess { raw ->
-                val json = runCatching { JSONObject(raw) }.getOrDefault(JSONObject())
-                binding.statusText.text = if (json.optBoolean("success")) {
-                    "已保护 ${json.optInt("count", packages.size)} 个应用，下一次扫描立即生效。"
-                } else {
-                    "保存失败：${json.optString("message", json.optString("error", "未知错误"))}"
-                }
+                // Include protected packages even when uninstalled or not visible in the catalog.
+                packages.forEach { entries.putIfAbsent(it, false) }
+                val apps = entries.map { (pkg, system) ->
+                    val label = runCatching {
+                        val info = if (Build.VERSION.SDK_INT >= 33)
+                            packageManager.getApplicationInfo(pkg, PackageManager.ApplicationInfoFlags.of(0))
+                        else { @Suppress("DEPRECATION") packageManager.getApplicationInfo(pkg, 0) }
+                        packageManager.getApplicationLabel(info).toString()
+                    }.getOrDefault(pkg)
+                    WhitelistApp(pkg, label, system)
+                }.sortedWith(compareBy<WhitelistApp> { it.system }.thenBy { it.label.lowercase() }.thenBy { it.packageName })
+                Triple(packages, paths, apps)
+            } }
+            if (generation != loadGeneration || service !== remote) return@launch
+            result.onSuccess { (packages, paths, apps) ->
+                val draft = if (state.draft.dirty) state.draft.rebase(packages) else WhitelistDraft(packages, packages)
+                state = state.copy(loading = false, packagesLoaded = true, pathsLoaded = true,
+                    apps = apps, paths = paths, draft = draft,
+                    message = "已保存 ${packages.size} 个应用、${paths.size} 条手动路径保护。修改后需重新扫描。")
             }.onFailure {
-                binding.statusText.text = "保存失败：${it.message ?: it.javaClass.simpleName}"
+                if (it is CancellationException) throw it
+                state = state.copy(loading = false, packagesLoaded = false, pathsLoaded = false,
+                    message = "白名单读取失败，已禁止写入，原保护不变：${it.message}")
             }
-            binding.saveButton.isEnabled = service != null
         }
     }
 
-    private fun loadIcon(packageName: String): Drawable {
-        iconCache.get(packageName)?.let { return it }
-        val icon = runCatching { packageManager.getApplicationIcon(packageName) }
-            .getOrElse { ContextCompat.getDrawable(this, R.drawable.ic_baize) ?: packageManager.defaultActivityIcon }
-        iconCache.put(packageName, icon)
-        return icon
+    private fun saveApps() {
+        val remote = service ?: return
+        if (!canEditApps() || !state.draft.dirty) return
+        val draft = state.draft
+        state = state.copy(saving = true, message = "正在保存应用白名单…")
+        lifecycleScope.launch {
+            val result = runCatching { withContext(Dispatchers.IO) {
+                requireSuccess(WhitelistFileClient.updatePackages(remote, applicationContext.cacheDir, draft.added, draft.removed))
+                stringSet(remote.getWhitelistPackages())
+            } }
+            if (service !== remote) return@launch
+            result.onSuccess { latest ->
+                state = state.copy(saving = false, draft = WhitelistDraft(latest, latest),
+                    message = "应用白名单已保存。取消勾选的应用不再受这条保护；重新扫描后生效。")
+            }.onFailure {
+                if (it is CancellationException) throw it
+                state = state.copy(saving = false, message = operationFailure(it))
+            }
+        }
     }
+
+    private fun removePath(path: String) {
+        val remote = service ?: return
+        if (!state.pathsLoaded || state.loading || state.saving || path !in state.paths) return
+        state = state.copy(saving = true, message = "正在取消此路径保护…")
+        lifecycleScope.launch {
+            val result = runCatching { withContext(Dispatchers.IO) {
+                val response = requireSuccess(WhitelistFileClient.removePath(remote, applicationContext.cacheDir, path))
+                stringSet(remote.getWhitelistPaths()).sorted() to response.optString("message")
+            } }
+            if (service !== remote) return@launch
+            result.onSuccess { (paths, message) -> state = state.copy(saving = false, paths = paths, message = message) }
+                .onFailure { if (it is CancellationException) throw it; state = state.copy(saving = false, message = operationFailure(it)) }
+        }
+    }
+
+    private fun requireSuccess(raw: String): JSONObject = JSONObject(raw).also {
+        check(it.optBoolean("success")) { it.optString("message", it.optString("error", "请求未确认")) }
+    }
+    private fun stringSet(raw: String): Set<String> = JSONArray(raw).let { array ->
+        (0 until array.length()).map { array.getString(it) }.toSet()
+    }
+    private fun operationFailure(error: Throwable): String =
+        "操作未确认，请刷新核对；不会自动重试。${error.message.orEmpty()}。若提示不支持的请求，请刷入本版模块并重启。"
 
     override fun onDestroy() {
-        if (serviceBound) runCatching { RootService.unbind(connection) }
+        loadGeneration++
+        if (bindingRequested) runCatching { RootService.unbind(connection) }
         super.onDestroy()
-    }
-
-    private enum class Filter { ALL, USER, SYSTEM, PROTECTED }
-
-    private data class CatalogEntry(val packageName: String, val system: Boolean)
-
-    private data class CatalogResult(
-        val apps: List<AppEntry>,
-        val selectedCount: Int,
-        val source: String
-    )
-
-    private data class AppEntry(
-        val packageName: String,
-        val label: String,
-        val system: Boolean,
-        var selected: Boolean
-    )
-
-    private class AppAdapter(
-        private val iconLoader: (String) -> Drawable,
-        private val onToggle: (AppEntry, Boolean) -> Unit
-    ) : RecyclerView.Adapter<AppAdapter.Holder>() {
-        private var items: List<AppEntry> = emptyList()
-
-        fun submit(next: List<AppEntry>) {
-            val previous = items
-            // Immutable row snapshots let a checkbox update only the changed row.
-            val snapshot = next.map { it.copy() }
-            val changes = DiffUtil.calculateDiff(object : DiffUtil.Callback() {
-                override fun getOldListSize() = previous.size
-                override fun getNewListSize() = snapshot.size
-                override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                    previous[oldItemPosition].packageName == snapshot[newItemPosition].packageName
-                override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int) =
-                    previous[oldItemPosition] == snapshot[newItemPosition]
-            })
-            items = snapshot
-            changes.dispatchUpdatesTo(this)
-        }
-
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
-            val binding = ItemWhitelistAppBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-            return Holder(binding)
-        }
-
-        override fun onBindViewHolder(holder: Holder, position: Int) {
-            holder.bind(items[position])
-        }
-
-        override fun getItemCount(): Int = items.size
-
-        inner class Holder(private val binding: ItemWhitelistAppBinding) : RecyclerView.ViewHolder(binding.root) {
-            fun bind(item: AppEntry) {
-                binding.appName.text = item.label
-                binding.packageName.text = item.packageName
-                binding.appIcon.setImageDrawable(iconLoader(item.packageName))
-                binding.typeText.text = if (item.system) "系统" else "用户"
-                binding.selectedCheck.setOnCheckedChangeListener(null)
-                binding.selectedCheck.isChecked = item.selected
-
-                val primaryContainer = MaterialColors.getColor(binding.root, com.google.android.material.R.attr.colorPrimaryContainer)
-                val surface = MaterialColors.getColor(binding.root, com.google.android.material.R.attr.colorSurface)
-                binding.root.setCardBackgroundColor(if (item.selected) ColorUtils.blendARGB(surface, primaryContainer, .35f) else surface)
-                binding.root.strokeWidth = 0
-                binding.selectedCheck.contentDescription = "保护${item.label}"
-
-                binding.selectedCheck.setOnCheckedChangeListener { _, checked -> onToggle(item, checked) }
-                binding.root.setOnClickListener { onToggle(item, !item.selected) }
-            }
-
-        }
-    }
-
-    companion object {
-        private const val ROOT_FALLBACK_DELAY_MS = 3_500L
-        private val PACKAGE_NAME = Regex("^[A-Za-z0-9_]+(?:\\.[A-Za-z0-9_]+)+$")
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/WhitelistManagerScreen.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/WhitelistManagerScreen.kt
@@ -1,0 +1,130 @@
+package io.github.xgl34222220.baize
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import io.github.xgl34222220.baize.ui.components.DetailPageHeader
+import io.github.xgl34222220.baize.ui.miuix.LuoShuGroup
+import io.github.xgl34222220.baize.ui.miuix.VideoTabs
+import io.github.xgl34222220.baize.ui.theme.BaiZeTokens
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun WhitelistManagerScreen(
+    state: WhitelistUiState, onBack: () -> Unit, onRefresh: () -> Unit,
+    onToggle: (String) -> Unit, onClearApps: () -> Unit, onSaveApps: () -> Unit,
+    onRemovePath: (String) -> Unit
+) {
+    var tab by rememberSaveable { mutableIntStateOf(0) }
+    var query by rememberSaveable { mutableStateOf("") }
+    var protectedOnly by rememberSaveable { mutableStateOf(false) }
+    var showClear by rememberSaveable { mutableStateOf(false) }
+    var showLeave by rememberSaveable { mutableStateOf(false) }
+    var removal by rememberSaveable { mutableStateOf<String?>(null) }
+    val edit = state.connected && state.packagesLoaded && !state.loading && !state.saving
+    val pathEdit = state.connected && state.pathsLoaded && !state.loading && !state.saving
+    val leave: () -> Unit = { if (state.draft.dirty) showLeave = true else onBack() }
+    BackHandler(state.draft.dirty, onBack = { showLeave = true })
+    val visible = remember(state.apps, state.draft.selected, query, protectedOnly) {
+        state.apps.filter { (!protectedOnly || it.packageName in state.draft.selected) &&
+            (it.label.contains(query, true) || it.packageName.contains(query, true)) }
+    }
+    val visiblePaths = remember(state.paths, query) { state.paths.filter { it.contains(query, true) } }
+    val inset = Modifier.padding(horizontal = 20.dp)
+
+    Surface(Modifier.fillMaxSize(), color = BaiZeTokens.colors.surfaceBase) {
+        Column {
+            DetailPageHeader("白名单", "", leave) {
+                IconButton(onRefresh, enabled = !state.loading && !state.saving) { Icon(Icons.Rounded.Refresh, "刷新白名单") }
+            }
+            VideoTabs(listOf("应用保护", "路径保护"), tab, { tab = it; query = "" })
+            Spacer(Modifier.height(12.dp))
+            OutlinedTextField(query, { query = it }, modifier = inset.fillMaxWidth(), singleLine = true,
+                shape = RoundedCornerShape(18.dp), leadingIcon = { Icon(Icons.Rounded.Search, null) },
+                placeholder = { Text(if (tab == 0) "搜索应用名称或包名" else "搜索保护路径") })
+            Text(state.message, inset.padding(vertical = 12.dp), style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            if (state.loading || state.saving) LinearProgressIndicator(Modifier.fillMaxWidth())
+            if (tab == 0) {
+                FlowRow(inset.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(selected = !protectedOnly, onClick = { protectedOnly = false }, label = { Text("全部应用") })
+                    FilterChip(selected = protectedOnly, onClick = { protectedOnly = true }, label = { Text("已保护 ${state.draft.selected.size}") })
+                    TextButton({ showClear = true }, enabled = edit && state.draft.selected.isNotEmpty()) { Text("取消全部应用保护") }
+                }
+                LazyColumn(Modifier.weight(1f), contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    if (visible.isEmpty() && !state.loading) item { Text("没有匹配的应用", style = MaterialTheme.typography.bodyMedium) }
+                    items(visible, key = { it.packageName }) { app ->
+                        LuoShuGroup {
+                            Row(Modifier.fillMaxWidth().clickable(enabled = edit, role = Role.Checkbox) { onToggle(app.packageName) }
+                                .padding(start = 14.dp, end = 6.dp, top = 12.dp, bottom = 12.dp), verticalAlignment = Alignment.CenterVertically) {
+                                ApplicationIcon(app.packageName, app.label, Modifier.size(42.dp))
+                                Column(Modifier.weight(1f).padding(horizontal = 12.dp)) {
+                                    Text(app.label, style = MaterialTheme.typography.titleSmall)
+                                    Text(app.packageName, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                                }
+                                Checkbox(app.packageName in state.draft.selected, { onToggle(app.packageName) }, enabled = edit,
+                                    modifier = Modifier.semantics { contentDescription = "保护${app.label}" })
+                            }
+                        }
+                    }
+                }
+                Column(inset.navigationBarsPadding().imePadding().padding(bottom = 12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(if (state.draft.dirty) "有未保存修改：新增 ${state.draft.added.size}，取消 ${state.draft.removed.size}。"
+                        else "取消勾选后点保存；不会删除应用或文件。", style = MaterialTheme.typography.bodySmall)
+                    Button(onSaveApps, enabled = edit && state.draft.dirty,
+                        modifier = Modifier.fillMaxWidth().heightIn(min = 50.dp), shape = RoundedCornerShape(18.dp)) {
+                        Text(if (state.saving) "正在保存…" else "保存应用白名单")
+                    }
+                }
+            } else {
+                Text("这里只列手动添加的路径。移除仅取消此条保护，不删除文件，也不解除其它白名单或关键数据限制。",
+                    inset.padding(bottom = 10.dp), style = MaterialTheme.typography.bodySmall)
+                LazyColumn(Modifier.weight(1f).navigationBarsPadding(),
+                    contentPadding = PaddingValues(start = 20.dp, end = 20.dp, bottom = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    if (visiblePaths.isEmpty() && !state.loading) item { LuoShuGroup {
+                        Text(if (state.pathsLoaded) "没有匹配的手动保护路径" else "路径名单尚未读取，原保护不变",
+                            Modifier.padding(20.dp), style = MaterialTheme.typography.bodyMedium)
+                    } }
+                    items(visiblePaths, key = { it }) { path -> LuoShuGroup {
+                        Column(Modifier.padding(16.dp)) {
+                            SelectionContainer { Text(path, style = MaterialTheme.typography.bodyMedium) }
+                            TextButton({ removal = path }, enabled = pathEdit) { Text("移除此路径保护") }
+                        }
+                    } }
+                }
+            }
+        }
+    }
+    if (showClear) AlertDialog(onDismissRequest = { showClear = false }, title = { Text("取消全部应用保护？") },
+        text = { Text("将取消当前选择的 ${state.draft.selected.size} 个应用保护，需要再点保存才生效。手动路径保护不变，不会删除任何文件。") },
+        confirmButton = { TextButton({ showClear = false; onClearApps() }, enabled = edit) { Text("取消这些保护") } },
+        dismissButton = { TextButton({ showClear = false }) { Text("返回") } })
+    removal?.let { path -> AlertDialog(onDismissRequest = { removal = null }, title = { Text("移除路径白名单？") },
+        text = { Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            SelectionContainer { Text(path) }
+            Text("仅移除这条记录。其父目录、子目录及应用保护不会一并取消；文件不变。完成后请重新扫描。")
+        } },
+        confirmButton = { TextButton({ removal = null; onRemovePath(path) }, enabled = pathEdit && path in state.paths) { Text("确认移除") } },
+        dismissButton = { TextButton({ removal = null }) { Text("保留") } }) }
+    if (showLeave) AlertDialog(onDismissRequest = { showLeave = false }, title = { Text("应用白名单尚未保存") },
+        text = { Text("离开不会把未保存的修改写入清理引擎。") },
+        confirmButton = { TextButton({ showLeave = false; onBack() }) { Text("不保存并离开") } },
+        dismissButton = { TextButton({ showLeave = false }) { Text("继续编辑") } })
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/WhitelistModels.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/WhitelistModels.kt
@@ -1,0 +1,24 @@
+package io.github.xgl34222220.baize
+
+/** Keep uninstalled/hidden protected apps too; filtering never changes the saved set. */
+internal data class WhitelistDraft(val original: Set<String> = emptySet(), val selected: Set<String> = emptySet()) {
+    val added: Set<String> get() = selected - original
+    val removed: Set<String> get() = original - selected
+    val dirty: Boolean get() = original != selected
+    fun toggle(packageName: String): WhitelistDraft = copy(selected =
+        if (packageName in selected) selected - packageName else selected + packageName)
+    fun rebase(latest: Set<String>): WhitelistDraft = WhitelistDraft(latest, (latest - removed) + added)
+}
+
+internal data class WhitelistApp(val packageName: String, val label: String, val system: Boolean = false)
+internal data class WhitelistUiState(
+    val connected: Boolean = false,
+    val loading: Boolean = false,
+    val saving: Boolean = false,
+    val packagesLoaded: Boolean = false,
+    val pathsLoaded: Boolean = false,
+    val apps: List<WhitelistApp> = emptyList(),
+    val paths: List<String> = emptyList(),
+    val draft: WhitelistDraft = WhitelistDraft(),
+    val message: String = "正在连接 Root 服务…"
+)

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/WorkbenchReviewPolicy.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/WorkbenchReviewPolicy.kt
@@ -1,0 +1,33 @@
+package io.github.xgl34222220.baize
+
+internal const val REVIEW_HISTORY_HINT = "列表和大小来自上次扫描，不代表清理后的剩余垃圾；重新扫描后才能继续选择。"
+
+/** One selection gate shared by callbacks and the visible controls. */
+internal fun reviewSelectionBlockReason(state: WorkbenchUiState, now: Long): String? = when {
+    state.loadingResults -> "正在读取结果，读取完成后可选择"
+    state.running -> "任务正在执行，请等待完成或停止"
+    !state.connected -> "清理服务未连接，请重新连接后扫描"
+    !state.scanReady -> "当前为历史记录，请重新扫描后选择"
+    now >= state.expiresAtRealtime -> "扫描结果已过期，请重新扫描"
+    else -> null
+}
+
+internal fun reviewRiskSelection(items: List<WorkbenchItem>, risks: Set<String>): Set<String> =
+    items.asSequence().filter { it.selectable && it.risk in risks && it.risk in setOf("low", "medium") }
+        .mapTo(linkedSetOf()) { it.id }
+
+internal fun reviewItemRestriction(item: WorkbenchItem, global: String?): String? = when {
+    item.risk == "critical" -> "关键数据不可清理；取消白名单也不会解除此限制。" + item.reason
+    !item.selectable -> "不可选：" + item.reason.ifBlank { "扫描引擎已保护该项目" }
+    global != null -> global
+    else -> null
+}
+
+internal fun reviewRecordTitle(state: WorkbenchUiState): String = when {
+    state.phase.contains("过期") -> "扫描结果已过期 · 需重新扫描"
+    state.phase.contains("未完成") && state.items.all { it.outcome.isBlank() } -> "结果读取未完成 · 需重新扫描"
+    state.notice == WorkbenchNotice.SUCCESS -> "清理已完成 · 记录已保留"
+    state.items.any { it.outcome.isNotBlank() && it.outcome != "未勾选，保留" &&
+        it.outcome !in setOf("已清理", "已按所选缓存执行清理") } -> "部分项目未完成 · 需重新扫描"
+    else -> "历史记录 · 需重新扫描"
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/BaiZeProfileRootService.kt
@@ -9,12 +9,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 
-/**
- * Thin Binder facade for BaiZe's persistent Root process.
- *
- * Task locking/state lives in [TaskCoordinator]. Scheduler/configuration, history, diagnostics,
- * package catalog, whitelist and organizer logic are isolated so Binder routing stays stable.
- */
+/** Binder facade; repositories own validation and task coordination. */
 class BaiZeProfileRootService : RootService() {
     private val coordinator = TaskCoordinator()
     private val schedulerRepository = SchedulerRepository()
@@ -26,7 +21,6 @@ class BaiZeProfileRootService : RootService() {
     private val cacheSelectionRepository = CacheSelectionRepository()
     private val quarantineRepository = QuarantineRepository()
     private val moduleTasks = ModuleTaskController(coordinator, schedulerRepository, diagnostics)
-
     private val profileEngine by lazy { NativeProfileEngine(this, coordinator.cancelled, quarantineRepository) }
     private val instantCacheEngine by lazy {
         InstantCacheEngine(coordinator.cancelled) { coordinator.publishExternal(it) }
@@ -40,261 +34,165 @@ class BaiZeProfileRootService : RootService() {
     }
 
     private val binder = object : IProfileRootService.Stub() {
-
         override fun exchangeJson(operation: String?, request: ParcelFileDescriptor?): ParcelFileDescriptor =
             JsonFileTransport.serve(File(RootPaths.STATE_DIR, "ipc"), request) { dispatchJson(operation, it) }
-
         override fun exchangeJsonInto(operation: String?, request: ParcelFileDescriptor?, response: ParcelFileDescriptor?): Int =
             JsonFileTransport.serveInto(request, response) { dispatchJson(operation, it) }
 
-        private fun dispatchJson(operation: String?, arguments: JSONArray): String {
-            return when (operation) {
-                "scanProfile" -> {
-                    require(arguments.length() == 2)
-                    scanProfile(arguments.getString(0), arguments.getString(1))
-                }
-                "getProfilePage" -> {
-                    require(arguments.length() == 3)
-                    getProfilePage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
-                }
-                "cleanProfileSelected" -> {
-                    require(arguments.length() == 3)
-                    cleanProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
-                }
-                "quarantineProfileSelected" -> {
-                    require(arguments.length() == 3)
-                    quarantineProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
-                }
-                "prepareCacheSelection" -> {
-                    require(arguments.length() == 2)
-                    prepareCacheSelection(arguments.getString(0), arguments.getString(1))
-                }
-                "getQuarantinePage" -> {
-                    require(arguments.length() == 2)
-                    getQuarantinePage(arguments.getInt(0), arguments.getInt(1))
-                }
-                "getModuleState" -> {
-                    require(arguments.length() == 0)
-                    getModuleState()
-                }
-                "getTaskHistory" -> {
-                    require(arguments.length() == 1)
-                    getTaskHistory(arguments.getInt(0))
-                }
-                "getTaskHistoryPage" -> {
-                    require(arguments.length() == 2)
-                    getTaskHistoryPage(arguments.getInt(0), arguments.getInt(1))
-                }
-                "getAuditTimelinePage" -> {
-                    require(arguments.length() == 2)
-                    getAuditTimelinePage(arguments.getInt(0), arguments.getInt(1))
-                }
-                "getScanCoverage" -> {
-                    require(arguments.length() == 0)
-                    getScanCoverage()
-                }
-                "clearPackageCaches" -> {
-                    require(arguments.length() == 1)
-                    clearPackageCaches(arguments.getString(0))
-                }
-                "scanFileOrganizer" -> {
-                    require(arguments.length() == 0)
-                    scanFileOrganizer()
-                }
-                "applyFileOrganizer" -> {
-                    require(arguments.length() == 2)
-                    applyFileOrganizer(arguments.getString(0), arguments.getString(1))
-                }
-                "undoFileOrganizer" -> {
-                    require(arguments.length() == 0)
-                    undoFileOrganizer()
-                }
-                "getInstalledPackageCatalog" -> {
-                    require(arguments.length() == 0)
-                    getInstalledPackageCatalog()
-                }
-                "getWhitelistPackages" -> {
-                    require(arguments.length() == 0)
-                    getWhitelistPackages()
-                }
-                "saveWhitelistPackages" -> {
-                    require(arguments.length() == 1)
-                    saveWhitelistPackages(arguments.getString(0))
-                }
-                "getWhitelistPaths" -> {
-                    require(arguments.length() == 0)
-                    getWhitelistPaths()
-                }
-                else -> throw IllegalArgumentException("不支持的服务请求")
+        private fun dispatchJson(operation: String?, arguments: JSONArray): String = when (operation) {
+            "scanProfile" -> {
+                require(arguments.length() == 2)
+                scanProfile(arguments.getString(0), arguments.getString(1))
             }
+            "getProfilePage" -> {
+                require(arguments.length() == 3)
+                getProfilePage(arguments.getString(0), arguments.getInt(1), arguments.getInt(2))
+            }
+            "cleanProfileSelected" -> {
+                require(arguments.length() == 3)
+                cleanProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
+            }
+            "quarantineProfileSelected" -> {
+                require(arguments.length() == 3)
+                quarantineProfileSelected(arguments.getString(0), arguments.getString(1), arguments.getString(2))
+            }
+            "prepareCacheSelection" -> {
+                require(arguments.length() == 2)
+                prepareCacheSelection(arguments.getString(0), arguments.getString(1))
+            }
+            "getQuarantinePage" -> {
+                require(arguments.length() == 2)
+                getQuarantinePage(arguments.getInt(0), arguments.getInt(1))
+            }
+            "getModuleState" -> { require(arguments.length() == 0); getModuleState() }
+            "getTaskHistory" -> { require(arguments.length() == 1); getTaskHistory(arguments.getInt(0)) }
+            "getTaskHistoryPage" -> {
+                require(arguments.length() == 2)
+                getTaskHistoryPage(arguments.getInt(0), arguments.getInt(1))
+            }
+            "getAuditTimelinePage" -> {
+                require(arguments.length() == 2)
+                getAuditTimelinePage(arguments.getInt(0), arguments.getInt(1))
+            }
+            "getScanCoverage" -> { require(arguments.length() == 0); getScanCoverage() }
+            "clearPackageCaches" -> { require(arguments.length() == 1); clearPackageCaches(arguments.getString(0)) }
+            "scanFileOrganizer" -> { require(arguments.length() == 0); scanFileOrganizer() }
+            "applyFileOrganizer" -> {
+                require(arguments.length() == 2)
+                applyFileOrganizer(arguments.getString(0), arguments.getString(1))
+            }
+            "undoFileOrganizer" -> { require(arguments.length() == 0); undoFileOrganizer() }
+            "getInstalledPackageCatalog" -> { require(arguments.length() == 0); getInstalledPackageCatalog() }
+            "getWhitelistPackages" -> { require(arguments.length() == 0); getWhitelistPackages() }
+            "saveWhitelistPackages" -> { require(arguments.length() == 1); saveWhitelistPackages(arguments.getString(0)) }
+            "getWhitelistPaths" -> { require(arguments.length() == 0); getWhitelistPaths() }
+            // Only edit whitelist configuration records, never the target files.
+            // Reuse the App-owned FD channel; preserve existing AIDL transaction IDs.
+            "removeWhitelistPath" -> {
+                require(arguments.length() == 1)
+                if (coordinator.isBusy()) coordinator.busy("whitelist-path-remove") else
+                    coordinator.runExclusive("whitelist-path-remove", "正在取消路径保护", "whitelist_write_failed") {
+                        whitelistRepository.removePath(arguments.getString(0))
+                    }
+            }
+            "updateWhitelistPackages" -> {
+                require(arguments.length() == 2)
+                if (coordinator.isBusy()) coordinator.busy("whitelist-package-update") else
+                    coordinator.runExclusive("whitelist-package-update", "正在保存应用白名单", "whitelist_write_failed") {
+                        whitelistRepository.updatePackages(arguments.getString(0), arguments.getString(1))
+                    }
+            }
+            else -> throw IllegalArgumentException("不支持的服务请求")
         }
 
         override fun ping(): String = JSONObject()
-            .put("uid", Process.myUid())
-            .put("root", Process.myUid() == 0)
+            .put("uid", Process.myUid()).put("root", Process.myUid() == 0)
             .put("module", File(RootPaths.MODULE_DIR, "module.prop").isFile)
             .put("cleaner", File(RootPaths.MODULE_DIR, "cleaner.sh").isFile)
             .put("deepRules", File(RootPaths.MODULE_DIR, "config/deep.rules").isFile)
             .put("scheduler", File(RootPaths.MODULE_DIR, "scheduler.sh").isFile)
             .put("engine", "unified-root-task-coordinator-v2-audit")
-            .also { RootVersionInfo.putInto(it) }
-            .toString()
-
+            .also { RootVersionInfo.putInto(it) }.toString()
         override fun getProfileCatalog(): String = profileEngine.catalog()
 
         override fun scanProfile(profile: String?, optionsJson: String?): String = audited("profile-scan") {
-            coordinator.runExclusive(
-                operation = "profile-scan",
-                phase = "正在扫描保护项",
-                failureCode = "profile_scan_failed"
-            ) { started ->
+            coordinator.runExclusive(operation = "profile-scan", phase = "正在扫描保护项", failureCode = "profile_scan_failed") { started ->
                 profileEngine.scan(profile.orEmpty(), optionsJson.orEmpty()) { progress ->
-                    coordinator.update(
-                        operation = "profile-scan",
-                        phase = progress.phase,
-                        current = progress.current,
-                        total = progress.total,
-                        currentPath = progress.path,
-                        startedRealtime = started,
-                        deletedBytes = progress.bytes,
-                        deletedFiles = progress.files,
-                        failures = progress.failures
-                    )
+                    coordinator.update(operation = "profile-scan", phase = progress.phase, current = progress.current,
+                        total = progress.total, currentPath = progress.path, startedRealtime = started,
+                        deletedBytes = progress.bytes, deletedFiles = progress.files, failures = progress.failures)
                 }
             }
         }
-
         override fun getProfilePage(snapshotId: String?, offset: Int, limit: Int): String {
             if (coordinator.isBusy()) return coordinator.busy("profile-page")
             coordinator.cancelled.set(false)
             return profileEngine.page(snapshotId.orEmpty(), offset, limit)
         }
-
-        override fun cleanProfileSelected(
-            snapshotId: String?,
-            selectionJson: String?,
-            optionsJson: String?
-        ): String = audited("profile-clean") {
-            coordinator.runExclusive(
-                operation = "profile-clean",
-                phase = "正在清理已选择项目",
-                failureCode = "profile_clean_failed"
-            ) { started ->
+        override fun cleanProfileSelected(snapshotId: String?, selectionJson: String?, optionsJson: String?): String = audited("profile-clean") {
+            coordinator.runExclusive(operation = "profile-clean", phase = "正在清理已选择项目", failureCode = "profile_clean_failed") { started ->
                 profileEngine.clean(snapshotId.orEmpty(), selectionJson.orEmpty(), optionsJson.orEmpty()) { progress ->
-                    coordinator.update(
-                        operation = "profile-clean",
-                        phase = progress.phase,
-                        current = progress.current,
-                        total = progress.total,
-                        currentPath = progress.path,
-                        startedRealtime = started,
-                        deletedBytes = progress.bytes,
-                        deletedFiles = progress.files,
-                        failures = progress.failures
-                    )
+                    coordinator.update(operation = "profile-clean", phase = progress.phase, current = progress.current,
+                        total = progress.total, currentPath = progress.path, startedRealtime = started,
+                        deletedBytes = progress.bytes, deletedFiles = progress.files, failures = progress.failures)
                 }
             }
         }
-
-        override fun quarantineProfileSelected(
-            snapshotId: String?,
-            selectionJson: String?,
-            optionsJson: String?
-        ): String = audited("profile-quarantine") {
-            coordinator.runExclusive(
-                operation = "profile-quarantine",
-                phase = "正在隔离高风险项目",
-                failureCode = "profile_quarantine_failed"
-            ) { started ->
+        override fun quarantineProfileSelected(snapshotId: String?, selectionJson: String?, optionsJson: String?): String = audited("profile-quarantine") {
+            coordinator.runExclusive(operation = "profile-quarantine", phase = "正在隔离高风险项目", failureCode = "profile_quarantine_failed") { started ->
                 profileEngine.quarantine(snapshotId.orEmpty(), selectionJson.orEmpty(), optionsJson.orEmpty()) { progress ->
-                    coordinator.update(
-                        operation = "profile-quarantine",
-                        phase = progress.phase,
-                        current = progress.current,
-                        total = progress.total,
-                        currentPath = progress.path,
-                        startedRealtime = started,
-                        deletedBytes = progress.bytes,
-                        deletedFiles = progress.files,
-                        failures = progress.failures
-                    )
+                    coordinator.update(operation = "profile-quarantine", phase = progress.phase, current = progress.current,
+                        total = progress.total, currentPath = progress.path, startedRealtime = started,
+                        deletedBytes = progress.bytes, deletedFiles = progress.files, failures = progress.failures)
                 }
             }
         }
-
         override fun prepareCacheSelection(snapshotId: String?, selectionJson: String?): String =
             cacheSelectionRepository.prepare(snapshotId, selectionJson)
-
         override fun getQuarantinePage(offset: Int, limit: Int): String {
             if (coordinator.isBusy()) return coordinator.busy("quarantine-page")
             return quarantineRepository.page(offset, limit)
         }
-
         override fun restoreQuarantineItem(id: String?): String = audited("quarantine-restore") {
-            coordinator.runExclusive(
-                operation = "quarantine-restore",
-                phase = "正在恢复隔离内容",
-                failureCode = "quarantine_restore_failed"
-            ) { quarantineRepository.restore(id) }
+            coordinator.runExclusive(operation = "quarantine-restore", phase = "正在恢复隔离内容", failureCode = "quarantine_restore_failed") {
+                quarantineRepository.restore(id)
+            }
         }
-
         override fun purgeQuarantineItem(id: String?): String = audited("quarantine-purge") {
-            coordinator.runExclusive(
-                operation = "quarantine-purge",
-                phase = "正在永久删除隔离内容",
-                failureCode = "quarantine_purge_failed"
-            ) { quarantineRepository.purge(id) }
+            coordinator.runExclusive(operation = "quarantine-purge", phase = "正在永久删除隔离内容", failureCode = "quarantine_purge_failed") {
+                quarantineRepository.purge(id)
+            }
         }
-
         override fun purgeExpiredQuarantine(): String = audited("quarantine-expire") {
-            coordinator.runExclusive(
-                operation = "quarantine-expire",
-                phase = "正在清理过期隔离项",
-                failureCode = "quarantine_expire_failed"
-            ) { quarantineRepository.purgeExpired() }
+            coordinator.runExclusive(operation = "quarantine-expire", phase = "正在清理过期隔离项", failureCode = "quarantine_expire_failed") {
+                quarantineRepository.purgeExpired()
+            }
         }
-
-        override fun runMaintenanceTool(tool: String?, optionsJson: String?): String =
-            diagnostics.runMaintenanceTool(tool, optionsJson)
-
+        override fun runMaintenanceTool(tool: String?, optionsJson: String?): String = diagnostics.runMaintenanceTool(tool, optionsJson)
         override fun runModuleTask(mode: String?): String {
             val normalized = mode.orEmpty().trim().lowercase()
-            if (normalized.startsWith("scheduler-")) {
-                return schedulerRepository.control(normalized)
-            }
-            if (normalized !in MODULE_TASKS) {
-                return JSONObject().put("error", "unsupported_mode").put("mode", normalized).toString()
-            }
+            if (normalized.startsWith("scheduler-")) return schedulerRepository.control(normalized)
+            if (normalized !in MODULE_TASKS) return JSONObject().put("error", "unsupported_mode").put("mode", normalized).toString()
             val phase = when (normalized) {
                 "scan" -> "正在执行安全扫描"
                 "organize" -> "正在启动文件归类"
                 else -> "正在执行 Root 任务"
             }
             return audited(normalized) {
-                coordinator.runExclusive(
-                    operation = "module-$normalized",
-                    phase = phase,
-                    failureCode = "module_task_failed"
-                ) { started ->
-                    if (normalized in DETACHED_TASKS) {
-                        moduleTasks.startDetachedModuleTask(normalized, started)
-                    } else {
-                        moduleTasks.executeModuleTask(normalized, started)
-                    }
+                coordinator.runExclusive(operation = "module-$normalized", phase = phase, failureCode = "module_task_failed") { started ->
+                    if (normalized in DETACHED_TASKS) moduleTasks.startDetachedModuleTask(normalized, started)
+                    else moduleTasks.executeModuleTask(normalized, started)
                 }
             }
         }
-
         override fun getModuleState(): String {
             val state = moduleTasks.moduleState()
             RootMediaScanQueue.flush(this@BaiZeProfileRootService)
             return state
         }
         override fun getTaskHistory(limit: Int): String = historyRepository.taskHistoryJson(limit)
-        override fun getTaskHistoryPage(offset: Int, limit: Int): String =
-            historyRepository.taskHistoryPageJson(offset, limit)
-        override fun getAuditTimelinePage(offset: Int, limit: Int): String =
-            auditRepository.timelinePageJson(offset, limit)
+        override fun getTaskHistoryPage(offset: Int, limit: Int): String = historyRepository.taskHistoryPageJson(offset, limit)
+        override fun getAuditTimelinePage(offset: Int, limit: Int): String = auditRepository.timelinePageJson(offset, limit)
         override fun clearAuditTimeline(): String = auditRepository.clearTimelineJson()
         override fun updateRuleQualityReview(ruleKey: String?, action: String?, note: String?): String =
             auditRepository.updateRuleQualityReviewJson(ruleKey, action, note)
@@ -309,110 +207,61 @@ class BaiZeProfileRootService : RootService() {
             return result
         }
         override fun getSchedulerConfig(): String = schedulerRepository.configJson()
-        override fun saveSchedulerConfig(configJson: String?): String =
-            schedulerRepository.saveConfig(configJson.orEmpty())
+        override fun saveSchedulerConfig(configJson: String?): String = schedulerRepository.saveConfig(configJson.orEmpty())
         override fun resetScanWorkerProfile(): String = diagnostics.resetScanWorkerProfileJson()
-
         override fun clearPackageCaches(requestJson: String?): String = audited("instant-cache") {
-            coordinator.runExclusive(
-                operation = "instant-cache",
-                phase = "正在清理应用缓存",
-                failureCode = "instant_cache_failed"
-            ) { started ->
+            coordinator.runExclusive(operation = "instant-cache", phase = "正在清理应用缓存", failureCode = "instant_cache_failed") { started ->
                 instantCacheEngine.run(requestJson.orEmpty(), started)
             }
         }
-
         override fun scanFileOrganizer(): String = audited("file-organizer-scan") {
-            coordinator.runExclusive(
-                operation = "file-organizer-scan",
-                phase = "正在扫描可归类文件",
-                failureCode = "file_organizer_scan_failed"
-            ) { started ->
+            coordinator.runExclusive(operation = "file-organizer-scan", phase = "正在扫描可归类文件", failureCode = "file_organizer_scan_failed") { started ->
                 organizerController.scan { progress ->
-                    coordinator.update(
-                        operation = "file-organizer-scan",
-                        phase = progress.phase,
-                        current = progress.current,
-                        total = progress.total,
-                        currentPath = progress.path,
-                        startedRealtime = started
-                    )
+                    coordinator.update(operation = "file-organizer-scan", phase = progress.phase, current = progress.current,
+                        total = progress.total, currentPath = progress.path, startedRealtime = started)
                 }
             }
         }
-
-        override fun applyFileOrganizer(snapshotId: String?, selectionJson: String?): String =
-            audited("file-organizer-apply") {
-                coordinator.runExclusive(
-                    operation = "file-organizer-apply",
-                    phase = "正在归类文件",
-                    failureCode = "file_organizer_apply_failed"
-                ) { started ->
-                    val result = organizerController.apply(snapshotId.orEmpty(), selectionJson.orEmpty()) { progress ->
-                        coordinator.update(
-                            operation = "file-organizer-apply",
-                            phase = progress.phase,
-                            current = progress.current,
-                            total = progress.total,
-                            currentPath = progress.path,
-                            startedRealtime = started
-                        )
-                    }
-                    RootMediaScanQueue.flush(this@BaiZeProfileRootService)
-                    result
-                }
-            }
-
-        override fun undoFileOrganizer(): String = audited("file-organizer-undo") {
-            coordinator.runExclusive(
-                operation = "file-organizer-undo",
-                phase = "正在撤销上次归类",
-                failureCode = "file_organizer_undo_failed"
-            ) { started ->
-                val result = organizerController.undo { progress ->
-                    coordinator.update(
-                        operation = "file-organizer-undo",
-                        phase = progress.phase,
-                        current = progress.current,
-                        total = progress.total,
-                        currentPath = progress.path,
-                        startedRealtime = started
-                    )
+        override fun applyFileOrganizer(snapshotId: String?, selectionJson: String?): String = audited("file-organizer-apply") {
+            coordinator.runExclusive(operation = "file-organizer-apply", phase = "正在归类文件", failureCode = "file_organizer_apply_failed") { started ->
+                val result = organizerController.apply(snapshotId.orEmpty(), selectionJson.orEmpty()) { progress ->
+                    coordinator.update(operation = "file-organizer-apply", phase = progress.phase, current = progress.current,
+                        total = progress.total, currentPath = progress.path, startedRealtime = started)
                 }
                 RootMediaScanQueue.flush(this@BaiZeProfileRootService)
                 result
             }
         }
-
+        override fun undoFileOrganizer(): String = audited("file-organizer-undo") {
+            coordinator.runExclusive(operation = "file-organizer-undo", phase = "正在撤销上次归类", failureCode = "file_organizer_undo_failed") { started ->
+                val result = organizerController.undo { progress ->
+                    coordinator.update(operation = "file-organizer-undo", phase = progress.phase, current = progress.current,
+                        total = progress.total, currentPath = progress.path, startedRealtime = started)
+                }
+                RootMediaScanQueue.flush(this@BaiZeProfileRootService)
+                result
+            }
+        }
         override fun getInstalledPackageCatalog(): String = packageCatalog.installedPackagesJson()
         override fun getWhitelistPackages(): String = whitelistRepository.packagesJson()
-        override fun saveWhitelistPackages(packagesJson: String?): String =
-            whitelistRepository.savePackages(packagesJson.orEmpty())
+        override fun saveWhitelistPackages(packagesJson: String?): String = whitelistRepository.savePackages(packagesJson.orEmpty())
         override fun getWhitelistPaths(): String = whitelistRepository.pathsJson()
         override fun addWhitelistPath(path: String?): String = whitelistRepository.addPath(path)
-
         override fun getTaskState(): String = coordinator.currentState()
         override fun registerTaskProgressCallback(callback: ITaskProgressCallback?) = coordinator.register(callback)
         override fun unregisterTaskProgressCallback(callback: ITaskProgressCallback?) = coordinator.unregister(callback)
         override fun cancelCurrentTask() = coordinator.cancelCurrentTask()
     }
-
     private fun audited(operation: String, source: String = "app", block: () -> String): String {
         val started = System.currentTimeMillis()
         val result = block()
         runCatching { auditRepository.recordResult(operation, source, result, started) }
         return result
     }
-
     override fun onBind(intent: Intent): IBinder = binder
-
     companion object {
-        private val MODULE_TASKS = setOf(
-            "scan", "clean", "cache-clean", "empty-clean", "rules-clean", "fragment-scan",
-            "fragment-clean", "deep-scan", "deep-clean", "corpse-scan", "corpse-clean",
-            "apk-scan", "apk-clean", "organize"
-        )
+        private val MODULE_TASKS = setOf("scan", "clean", "cache-clean", "empty-clean", "rules-clean", "fragment-scan",
+            "fragment-clean", "deep-scan", "deep-clean", "corpse-scan", "corpse-clean", "apk-scan", "apk-clean", "organize")
         private val DETACHED_TASKS = setOf("clean", "organize")
     }
 }

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/WhitelistFileClient.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/WhitelistFileClient.kt
@@ -1,0 +1,18 @@
+package io.github.xgl34222220.baize.root
+
+import org.json.JSONArray
+import java.io.File
+
+/** New operations use the existing caller-owned FD protocol; AIDL transaction IDs stay unchanged. */
+internal object WhitelistFileClient {
+    fun removePath(service: IProfileRootService, directory: File, path: String): String =
+        JsonFileTransport.callInto(directory, JSONArray().put(path)) { request, response ->
+            service.exchangeJsonInto("removeWhitelistPath", request, response)
+        }
+
+    fun updatePackages(service: IProfileRootService, directory: File, added: Set<String>, removed: Set<String>): String =
+        JsonFileTransport.callInto(directory, JSONArray().put(JSONArray(added.sorted()).toString())
+            .put(JSONArray(removed.sorted()).toString())) { request, response ->
+            service.exchangeJsonInto("updateWhitelistPackages", request, response)
+        }
+}

--- a/v2/app/src/main/java/io/github/xgl34222220/baize/root/WhitelistRepository.kt
+++ b/v2/app/src/main/java/io/github/xgl34222220/baize/root/WhitelistRepository.kt
@@ -4,48 +4,52 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 
-internal class WhitelistRepository {
-    fun packagesJson(): String = JSONArray(readPackages().sorted()).toString()
+internal class WhitelistRepository(
+    private val whitelistFile: File = File(RootPaths.WHITELIST_FILE),
+    private val packageFile: File = File(RootPaths.WHITELIST_PACKAGES_FILE),
+    private val userRoots: List<File> = listOf("/data/user", "/data/user_de", "/data/media").map(::File)
+) {
+    fun packagesJson(): String = synchronized(LOCK) { JSONArray(readPackages().sorted()).toString() }
 
-    fun pathsJson(): String = JSONArray(readManualPaths().sorted()).toString()
+    fun pathsJson(): String = synchronized(LOCK) { JSONArray(readManualPaths().sorted()).toString() }
 
-    fun savePackages(raw: String): String {
+    fun savePackages(raw: String): String = synchronized(LOCK) {
         val array = runCatching { JSONArray(raw) }.getOrElse {
-            return JSONObject().put("error", "invalid_json").put("message", "白名单格式无效").toString()
+            return@synchronized JSONObject().put("error", "invalid_json").put("message", "白名单格式无效").toString()
         }
         val packages = linkedSetOf<String>()
         for (index in 0 until array.length()) {
             val packageName = array.optString(index).trim()
             if (!RootValidation.packageName.matches(packageName)) {
-                return JSONObject().put("error", "invalid_package").put("package", packageName).toString()
+                return@synchronized JSONObject().put("error", "invalid_package").put("package", packageName).toString()
             }
             packages += packageName
             if (packages.size > 500) {
-                return JSONObject().put("error", "too_many_packages").put("limit", 500).toString()
+                return@synchronized JSONObject().put("error", "too_many_packages").put("limit", 500).toString()
             }
         }
 
-        File(RootPaths.STATE_DIR).mkdirs()
+        val manualPaths = readManualPaths()
         val sidecar = packages.sorted().joinToString("\n", postfix = if (packages.isEmpty()) "" else "\n")
-        RootFileStore.writeAtomic(File(RootPaths.WHITELIST_PACKAGES_FILE), sidecar, worldReadable = true)
-        writeWhitelistFile(packages, readManualPaths())
-        return JSONObject()
+        RootFileStore.writeAtomic(packageFile, sidecar, worldReadable = true)
+        writeWhitelistFile(packages, manualPaths)
+        return@synchronized JSONObject()
             .put("success", true)
             .put("count", packages.size)
             .put("message", "应用白名单已写入清理引擎")
             .toString()
     }
 
-    fun addPath(raw: String?): String {
+    fun addPath(raw: String?): String = synchronized(LOCK) {
         val path = normalizeManualPath(raw.orEmpty())
-            ?: return JSONObject().put("error", "invalid_path").put("message", "只能保护规范的绝对路径").toString()
+            ?: return@synchronized JSONObject().put("error", "invalid_path").put("message", "只能保护规范的绝对路径").toString()
         val manual = readManualPaths().toMutableSet()
         val added = manual.add(path)
         if (manual.size > MAX_MANUAL_PATHS) {
-            return JSONObject().put("error", "too_many_paths").put("limit", MAX_MANUAL_PATHS).toString()
+            return@synchronized JSONObject().put("error", "too_many_paths").put("limit", MAX_MANUAL_PATHS).toString()
         }
         writeWhitelistFile(readPackages(), manual)
-        return JSONObject()
+        return@synchronized JSONObject()
             .put("success", true)
             .put("added", added)
             .put("path", path)
@@ -54,8 +58,40 @@ internal class WhitelistRepository {
             .toString()
     }
 
+    /** Apply only the user's additions/removals under the same lock as all other writers. */
+    fun updatePackages(addedRaw: String, removedRaw: String): String = synchronized(LOCK) {
+        val added = parsePackageDelta(addedRaw) ?: return@synchronized failure("invalid_packages", "新增应用名单无效")
+        val removed = parsePackageDelta(removedRaw) ?: return@synchronized failure("invalid_packages", "取消保护名单无效")
+        if (added.intersect(removed).isNotEmpty()) return@synchronized failure("conflicting_delta", "同一应用不能同时添加和移除")
+        val packages = (readPackages() - removed) + added
+        savePackages(JSONArray(packages.sorted()).toString())
+    }
+
+    /** Remove this exact whitelist record, never a file, parent path, or another rule. */
+    fun removePath(raw: String?): String = synchronized(LOCK) {
+        val path = normalizeManualPath(raw.orEmpty()) ?: return@synchronized failure("invalid_path", "路径格式无效")
+        val manual = readManualPaths().toMutableSet()
+        val removed = manual.remove(path)
+        if (removed) writeWhitelistFile(readPackages(), manual)
+        JSONObject().put("success", true).put("removed", removed).put("path", path)
+            .put("count", manual.size).put("message", if (removed)
+                "已取消此路径保护；其它白名单仍生效，重新扫描后可核对。" else "此路径已不在手动白名单中")
+            .toString()
+    }
+
+    private fun parsePackageDelta(raw: String): Set<String>? = runCatching {
+        val array = JSONArray(raw)
+        require(array.length() <= 500)
+        (0 until array.length()).map { index -> array.getString(index).trim().also {
+            require(RootValidation.packageName.matches(it))
+        } }.toSet()
+    }.getOrNull()
+
+    private fun failure(code: String, message: String): String = JSONObject()
+        .put("success", false).put("error", code).put("message", message).toString()
+
     private fun readPackages(): Set<String> {
-        val sidecar = File(RootPaths.WHITELIST_PACKAGES_FILE)
+        val sidecar = packageFile
         if (sidecar.isFile) {
             return sidecar.readLines()
                 .asSequence()
@@ -65,8 +101,13 @@ internal class WhitelistRepository {
         }
 
         val inferred = linkedSetOf<String>()
-        File(RootPaths.WHITELIST_FILE).takeIf { it.isFile }?.forEachLine { raw ->
+        val managed = whitelistFile.isFile && whitelistFile.useLines { lines -> lines.any { it.trim() == APP_WHITELIST_BEGIN } }
+        var generated = false
+        whitelistFile.takeIf { it.isFile }?.forEachLine { raw ->
             val line = raw.trim()
+            if (line == APP_WHITELIST_BEGIN) { generated = true; return@forEachLine }
+            if (line == APP_WHITELIST_END) { generated = false; return@forEachLine }
+            if (managed && !generated) return@forEachLine
             for (pattern in GENERATED_PATH_PATTERNS) {
                 val packageName = pattern.matchEntire(line)?.groupValues?.getOrNull(1)
                 if (!packageName.isNullOrBlank()) inferred += packageName
@@ -78,12 +119,15 @@ internal class WhitelistRepository {
     private fun readManualPaths(): Set<String> {
         val result = linkedSetOf<String>()
         var generatedSection = false
-        File(RootPaths.WHITELIST_FILE).takeIf { it.isFile }?.forEachLine { raw ->
+        // In a managed file, everything outside the generated block is a manual
+        // entry, even if it happens to equal an application's root directory.
+        val managed = whitelistFile.isFile && whitelistFile.useLines { lines -> lines.any { it.trim() == APP_WHITELIST_BEGIN } }
+        whitelistFile.takeIf { it.isFile }?.forEachLine { raw ->
             val line = raw.trim()
             when (line) {
                 APP_WHITELIST_BEGIN -> generatedSection = true
                 APP_WHITELIST_END -> generatedSection = false
-                else -> if (!generatedSection && line.startsWith("/") && !isGeneratedAppPath(line)) {
+                else -> if (!generatedSection && line.startsWith("/") && (managed || !isGeneratedAppPath(line))) {
                     normalizeManualPath(line)?.let(result::add)
                 }
             }
@@ -93,8 +137,8 @@ internal class WhitelistRepository {
 
     private fun writeWhitelistFile(packages: Set<String>, manualPaths: Set<String>) {
         val users = linkedSetOf("0")
-        listOf("/data/user", "/data/user_de", "/data/media").forEach { root ->
-            File(root).listFiles()
+        userRoots.forEach { root ->
+            root.listFiles()
                 ?.asSequence()
                 ?.filter { it.isDirectory && it.name.all(Char::isDigit) }
                 ?.mapTo(users) { it.name }
@@ -115,10 +159,11 @@ internal class WhitelistRepository {
             }
             append(APP_WHITELIST_END).append('\n')
         }
-        RootFileStore.writeAtomic(File(RootPaths.WHITELIST_FILE), output, worldReadable = true)
+        RootFileStore.writeAtomic(whitelistFile, output, worldReadable = true)
     }
 
     private fun normalizeManualPath(raw: String): String? {
+        if (raw.any { it == '\u0000' || it == '\n' || it == '\r' }) return null
         val value = raw.trim().replace(Regex("/+"), "/")
         if (!value.startsWith('/') || value.length > 4_096 || value.contains('\u0000') || value.contains('\n') || value.contains('\r')) return null
         val components = value.split('/').filter { it.isNotEmpty() }
@@ -130,6 +175,7 @@ internal class WhitelistRepository {
         GENERATED_PATH_PATTERNS.any { it.matches(path.trimEnd('/')) }
 
     companion object {
+        private val LOCK = Any()
         private const val APP_WHITELIST_BEGIN = "# BEGIN BAIZE APP WHITELIST"
         private const val APP_WHITELIST_END = "# END BAIZE APP WHITELIST"
         private const val MAX_MANUAL_PATHS = 500

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/ReviewControlsTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/ReviewControlsTest.kt
@@ -1,0 +1,42 @@
+package io.github.xgl34222220.baize
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ReviewControlsTest {
+    private fun item(id: String, risk: String, selectable: Boolean = true) = WorkbenchItem(
+        id, "profile", "rules", "test.app", "测试", "log", "app:test", "测试", id, risk,
+        "/storage/emulated/0/test/$id", 100, 1, 0, if (selectable) "日志" else "白名单保护", selectable)
+    private fun ready() = WorkbenchUiState(profileConnected = true, cacheConnected = true,
+        scanReady = true, expiresAtRealtime = 1_000L)
+    @Test fun mediumOnlyAndBulkNeverSelectBlockedHighOrCritical() {
+        val items = listOf(item("low", "low"), item("medium", "medium"), item("high", "high"),
+            item("critical", "critical"), item("protected", "medium", false))
+        assertEquals(setOf("medium"), reviewRiskSelection(items, setOf("medium")))
+        assertEquals(setOf("low", "medium"), reviewRiskSelection(items, setOf("low", "medium", "high", "critical")))
+    }
+    @Test fun historyExpiryLoadingAndDisconnectHaveDifferentExplanations() {
+        assertNull(reviewSelectionBlockReason(ready(), 100))
+        assertTrue(reviewSelectionBlockReason(ready().copy(scanReady = false), 100)!!.contains("历史记录"))
+        assertTrue(reviewSelectionBlockReason(ready(), 1_000)!!.contains("过期"))
+        assertTrue(reviewSelectionBlockReason(ready().copy(loadingResults = true), 100)!!.contains("读取"))
+        assertTrue(reviewSelectionBlockReason(ready().copy(profileConnected = false), 100)!!.contains("未连接"))
+    }
+    @Test fun highRiskIsManualNotAnUnexplainedDisabledGroup() {
+        assertNull(reviewItemRestriction(item("offline", "high"), null))
+        assertTrue(reviewItemRestriction(item("offline", "high"), "请重新扫描")!!.contains("重新扫描"))
+        assertTrue(reviewItemRestriction(item("locked", "high", false), null)!!.contains("白名单保护"))
+        assertTrue(reviewItemRestriction(item("account", "critical"), null)!!.contains("取消白名单也不会"))
+    }
+    @Test fun restoredRecordIsNotPresentedAsUnexplainedRiskWarning() {
+        val state = ready().copy(scanReady = false, notice = WorkbenchNotice.WARNING, items = listOf(item("old", "medium")))
+        assertEquals("历史记录 · 需重新扫描", reviewRecordTitle(state))
+        assertEquals("清理已完成 · 记录已保留", reviewRecordTitle(state.copy(notice = WorkbenchNotice.SUCCESS)))
+        assertEquals("部分项目未完成 · 需重新扫描", reviewRecordTitle(state.copy(items = listOf(item("old", "medium").copy(outcome = "未清理：已变化")))))
+    }
+    @Test fun whitelistDraftMergesOnlyUserChanges() {
+        val draft = WhitelistDraft(setOf("keep.app", "remove.app"), setOf("keep.app", "add.app"))
+        assertEquals(setOf("remove.app"), draft.removed)
+        assertEquals(setOf("keep.app", "add.app", "new.remote"), draft.rebase(setOf("keep.app", "remove.app", "new.remote")).selected)
+    }
+}

--- a/v2/app/src/test/java/io/github/xgl34222220/baize/root/WhitelistRemovalTest.kt
+++ b/v2/app/src/test/java/io/github/xgl34222220/baize/root/WhitelistRemovalTest.kt
@@ -1,0 +1,67 @@
+package io.github.xgl34222220.baize.root
+
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class WhitelistRemovalTest {
+    @get:Rule val folder = TemporaryFolder()
+    private fun repository() = WhitelistRepository(File(folder.root, "whitelist.conf"), File(folder.root, "whitelist.packages"), emptyList())
+    private fun paths(repo: WhitelistRepository): Set<String> = JSONArray(repo.pathsJson()).let { a -> (0 until a.length()).map { a.getString(it) }.toSet() }
+    private fun packages(repo: WhitelistRepository): Set<String> = JSONArray(repo.packagesJson()).let { a -> (0 until a.length()).map { a.getString(it) }.toSet() }
+    @Test fun removingOnePathDoesNotDeleteFilesOrOtherRules() {
+        val repo = repository()
+        val parent = folder.newFolder("user-files")
+        val target = File(parent, "keep.txt").apply { writeText("valuable user content") }
+        repo.savePackages("[\"keep.app\"]")
+        repo.addPath(parent.path)
+        repo.addPath(target.path)
+        assertTrue(JSONObject(repo.removePath(target.path)).getBoolean("removed"))
+        assertEquals(setOf(parent.path), paths(repo))
+        assertEquals(setOf("keep.app"), packages(repo))
+        assertEquals("valuable user content", target.readText())
+        assertFalse(JSONObject(repo.removePath(target.path)).getBoolean("removed"))
+    }
+    @Test fun appRootLookingManualPathRemainsVisibleAndRemovable() {
+        val repo = repository()
+        repo.addPath("/data/user/0/example.app")
+        assertEquals(setOf("/data/user/0/example.app"), paths(repo))
+        assertTrue(packages(repo).isEmpty())
+        repo.savePackages("[\"other.app\"]")
+        assertTrue(JSONObject(repo.removePath("/data/user/0/example.app/")).getBoolean("success"))
+        assertTrue(paths(repo).isEmpty())
+        assertEquals(setOf("other.app"), packages(repo))
+    }
+    @Test fun savingApplicationsPreservesManualPathsAndOtherConcurrentAdditions() {
+        val repo = repository()
+        repo.addPath("/storage/emulated/0/Archive")
+        repo.savePackages("[\"one.app\",\"two.app\",\"new.remote\"]")
+        assertTrue(JSONObject(repo.updatePackages("[\"add.app\"]", "[\"two.app\"]")).getBoolean("success"))
+        assertEquals(setOf("one.app", "new.remote", "add.app"), packages(repo))
+        assertEquals(setOf("/storage/emulated/0/Archive"), paths(repo))
+        val reloaded = repository()
+        assertEquals(packages(repo), packages(reloaded))
+        assertEquals(paths(repo), paths(reloaded))
+    }
+    @Test fun badInputCannotClearAWhitelist() {
+        val repo = repository()
+        repo.addPath("/storage/emulated/0/Keep")
+        repo.savePackages("[\"keep.app\"]")
+        for (path in listOf("relative", "/a/../Keep", "/storage/emulated/0/Keep\n")) {
+            assertFalse(JSONObject(repo.removePath(path)).optBoolean("success"))
+        }
+        assertFalse(JSONObject(repo.updatePackages("bad json", "[]")).optBoolean("success"))
+        assertEquals(setOf("keep.app"), packages(repo))
+        assertEquals(setOf("/storage/emulated/0/Keep"), paths(repo))
+    }
+    @Test fun parentAndChildProtectionAreNotImplicitlyRemoved() {
+        val repo = repository()
+        listOf("/sdcard/Download", "/sdcard/Download/keep", "/sdcard/Downloads").forEach { repo.addPath(it) }
+        repo.removePath("/sdcard/Download/keep")
+        assertEquals(setOf("/sdcard/Download", "/sdcard/Downloads"), paths(repo))
+    }
+}

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WhitelistManagerUiTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WhitelistManagerUiTest.kt
@@ -1,0 +1,80 @@
+package io.github.xgl34222220.baize
+
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
+import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], application = Application::class, qualifiers = "zh-rCN-w393dp-h852dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WhitelistManagerUiTest {
+    @get:Rule val compose = createAndroidComposeRule<ComponentActivity>()
+    private var state by mutableStateOf(WhitelistUiState())
+    private var saves = 0
+    private val removals = mutableListOf<String>()
+    private fun render(connected: Boolean = true) {
+        state = WhitelistUiState(connected = connected, packagesLoaded = true, pathsLoaded = true,
+            apps = listOf(WhitelistApp("one.app", "测试应用")),
+            paths = listOf("/storage/emulated/0/Documents/Important"),
+            draft = WhitelistDraft(setOf("one.app"), setOf("one.app")))
+        val appearance = AppearanceSettings(monetEnabled = false, blurEnabled = false)
+        compose.setContent {
+            BaiZeTheme(appearance) { CompositionLocalProvider(LocalAppearanceSettings provides appearance) {
+                WhitelistManagerScreen(state, {}, {},
+                    { state = state.copy(draft = state.draft.toggle(it)) },
+                    { state = state.copy(draft = state.draft.copy(selected = emptySet())) },
+                    { saves++ }, { removals += it })
+            } }
+        }
+        compose.waitForIdle()
+    }
+    @Test fun removingAPathRequiresExactConfirmation() {
+        render()
+        compose.onNodeWithText("路径保护").performClick()
+        compose.onNodeWithText("移除此路径保护").performClick()
+        assertTrue(removals.isEmpty())
+        compose.onNodeWithText("确认移除").performClick()
+        assertEquals(listOf("/storage/emulated/0/Documents/Important"), removals)
+        screenshot("whitelist-paths")
+    }
+    @Test fun cancelingPathDialogKeepsProtection() {
+        render()
+        compose.onNodeWithText("路径保护").performClick()
+        compose.onNodeWithText("移除此路径保护").performClick()
+        compose.onNodeWithText("保留").performClick()
+        assertTrue(removals.isEmpty())
+    }
+    @Test fun uncheckingAnAppDoesNotSaveUntilRequested() {
+        render()
+        compose.onNodeWithText("保存应用白名单").assertIsNotEnabled()
+        compose.onNodeWithContentDescription("保护测试应用").performClick()
+        assertEquals(0, saves)
+        compose.onNodeWithText("保存应用白名单").assertIsEnabled().performClick()
+        assertEquals(1, saves)
+        screenshot("whitelist-apps")
+    }
+    @Test fun disconnectedWhitelistCannotWrite() {
+        render(connected = false)
+        compose.onNodeWithContentDescription("保护测试应用").assertIsNotEnabled()
+        compose.onNodeWithText("路径保护").performClick()
+        compose.onNodeWithText("移除此路径保护").assertIsNotEnabled()
+    }
+    private fun screenshot(name: String) {
+        val bitmap = compose.runOnIdle { captureActivityContent(compose.activity) }
+        val target = File("build/reports/ui-screenshots/$name.png").apply { parentFile.mkdirs() }
+        target.outputStream().use { bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, it) }
+    }
+}

--- a/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchRefactorUiTest.kt
+++ b/v2/app/src/testDebug/java/io/github/xgl34222220/baize/WorkbenchRefactorUiTest.kt
@@ -1,0 +1,75 @@
+package io.github.xgl34222220.baize
+
+import android.app.Application
+import android.os.SystemClock
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.*
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import io.github.xgl34222220.baize.ui.appearance.AppearanceSettings
+import io.github.xgl34222220.baize.ui.appearance.LocalAppearanceSettings
+import io.github.xgl34222220.baize.ui.theme.BaiZeTheme
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], application = Application::class, qualifiers = "zh-rCN-w393dp-h852dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class WorkbenchRefactorUiTest {
+    @get:Rule val compose = createAndroidComposeRule<ComponentActivity>()
+    private var state by mutableStateOf(WorkbenchUiState())
+    private var scans = 0
+    private var whitelistRequests = 0
+    private fun item(id: String, risk: String, selectable: Boolean = true) = WorkbenchItem(id,
+        "profile", "rules", "test.app", "测试应用", "日志", "app:test.app", "测试应用", id, risk,
+        "/storage/emulated/0/test/$id", 100, 1, 0, "白名单保护", selectable)
+    private fun render(history: Boolean = false, highOnly: Boolean = false) {
+        state = WorkbenchUiState(profileConnected = true, cacheConnected = true, scanReady = !history,
+            notice = if (history) WorkbenchNotice.WARNING else WorkbenchNotice.SUCCESS,
+            phase = if (history) "已恢复上次结果，重新扫描后可清理" else "扫描完成",
+            items = if (highOnly) listOf(item("offline", "high")) else listOf(item("low", "low"), item("medium", "medium"), item("high", "high"), item("blocked", "medium", false)),
+            expiresAtRealtime = SystemClock.elapsedRealtime() + 1_800_000L)
+        val appearance = AppearanceSettings(monetEnabled = false, blurEnabled = false)
+        compose.setContent {
+            BaiZeTheme(appearance) { CompositionLocalProvider(LocalAppearanceSettings provides appearance) {
+                ScanWorkbenchScreen(appearance, state, WorkbenchActions({}, { scans++ }, {}, {},
+                    { id -> state = state.copy(selectedIds = state.selectedIds.toMutableSet().apply { if (!add(id)) remove(id) }) },
+                    {}, { state = state.copy(selectedIds = reviewRiskSelection(state.items, setOf("low", "medium"))) },
+                    { state = state.copy(selectedIds = emptySet()) }, {}, {},
+                    { state = state.copy(selectedIds = reviewRiskSelection(state.items, setOf("medium"))) }, { whitelistRequests++ }))
+            } }
+        }
+        compose.waitForIdle()
+    }
+    @Test fun historyExplainsWhyBatchSelectionIsDisabled() {
+        render(history = true)
+        compose.onNodeWithText("历史记录 · 需重新扫描").assertIsDisplayed()
+        compose.onNodeWithText("有项目需要核对").assertDoesNotExist()
+        compose.onNodeWithText("全选低、中风险").performScrollTo().assertIsNotEnabled()
+        compose.onNodeWithText("仅选中风险").assertIsNotEnabled()
+        compose.onNodeWithText("重新扫描").performClick()
+        assertEquals(1, scans)
+    }
+    @Test fun mediumSelectionExcludesBlockedAndHigh() {
+        render()
+        compose.onNodeWithText("仅选中风险").performScrollTo().performClick()
+        assertEquals(setOf("medium"), state.selectedIds)
+        compose.onNodeWithText("全选低、中风险").performClick()
+        assertEquals(setOf("low", "medium"), state.selectedIds)
+    }
+    @Test fun highOnlyGroupShowsAManualSelectionEntry() {
+        render(highOnly = true)
+        compose.waitUntil(5_000) { compose.onAllNodesWithText("这个分类下没有项目").fetchSemanticsNodes().isEmpty() }
+        compose.onNode(hasScrollAction()).performScrollToNode(hasText("逐项选择"))
+        compose.onNodeWithText("逐项选择").assertIsEnabled().performClick()
+        compose.waitUntil(5_000) { runCatching {
+            compose.onNode(hasScrollAction()).performScrollToNode(hasContentDescription("选择offline"))
+        }.isSuccess }
+        compose.onNodeWithContentDescription("选择offline").assertIsEnabled()
+    }
+}


### PR DESCRIPTION
按所有者要求修复扫描历史/过期提示、仅选中风险、普通高风险逐项选择，以及应用和手动路径白名单撤销入口。此前未完成写入的入口现已接通，进入白名单使旧扫描快照失效。

重要边界：不自动选择高风险、不放开关键数据限制、不删除白名单路径对应文件、不改变清理引擎和规则。保留 30002 WorkManager 启动修复、正式签名和应用/模块标识。

本 PR 先验证功能改动；准备显示版本 1.0.0、内部构建号 30003。后续正式版本顺序 1.0.0 → 1.1.1 → 2.0.0 → 2.2.2 → 3.0.0 → 3.3.3，使用 refactor-v 前缀避免覆盖旧标签。

新增回归覆盖历史按钮禁用原因、仅中风险筛选、全高风险分组手动入口、移除精确路径不改文件/其它保护、应用增量保存、断线禁止写入、对话框取消。CI 尚未完成；在最终签名 APK 启动/升级与发布校验完成前不推进 OTA。